### PR TITLE
[Port dspace-7_x] requestItemService.findbyBitstream for more efficient bitstream deletion

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemServiceImpl.java
@@ -11,7 +11,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemServiceImpl.java
@@ -11,6 +11,8 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.TimeZone;
+import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -94,6 +96,11 @@ public class RequestItemServiceImpl implements RequestItemService {
     @Override
     public Iterator<RequestItem> findByItem(Context context, Item item) throws SQLException {
         return requestItemDAO.findByItem(context, item);
+    }
+
+    @Override
+    public Iterator<RequestItem> findByBitstreamId(Context context, UUID bitstreamId) throws SQLException {
+        return requestItemDAO.findByBitstreamId(context, bitstreamId);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/dao/RequestItemDAO.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/dao/RequestItemDAO.java
@@ -9,6 +9,7 @@ package org.dspace.app.requestitem.dao;
 
 import java.sql.SQLException;
 import java.util.Iterator;
+import java.util.UUID;
 
 import org.dspace.app.requestitem.RequestItem;
 import org.dspace.content.Item;
@@ -26,7 +27,7 @@ import org.dspace.core.GenericDAO;
  */
 public interface RequestItemDAO extends GenericDAO<RequestItem> {
     /**
-     * Fetch a request named by its unique token (passed in emails).
+     * Fetch a request named by its unique approval token (passed in emails).
      *
      * @param context the current DSpace context.
      * @param token uniquely identifies the request.
@@ -36,4 +37,17 @@ public interface RequestItemDAO extends GenericDAO<RequestItem> {
     public RequestItem findByToken(Context context, String token) throws SQLException;
 
     public Iterator<RequestItem> findByItem(Context context, Item item) throws SQLException;
+
+    /**
+     * Retrieve all requests (as iterator) for a given bitstream UUID
+     * A UUID parameter is used here rather than Bitstream object, to make it usable
+     * in situations even when a bitstream object no longer exists, but orphaned
+     * entries need to be found by their (previous) bitstream UUID.
+     *
+     * @param context current DSpace context
+     * @param bitstreamId the bitstream UUID to search for
+     * @return the matching requests (or empty iterator)
+     */
+    public Iterator<RequestItem> findByBitstreamId(Context context, UUID bitstreamId) throws SQLException;
+
 }

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/dao/impl/RequestItemDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/dao/impl/RequestItemDAOImpl.java
@@ -9,6 +9,7 @@ package org.dspace.app.requestitem.dao.impl;
 
 import java.sql.SQLException;
 import java.util.Iterator;
+import java.util.UUID;
 import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -42,10 +43,22 @@ public class RequestItemDAOImpl extends AbstractHibernateDAO<RequestItem> implem
         criteriaQuery.where(criteriaBuilder.equal(requestItemRoot.get(RequestItem_.token), token));
         return uniqueResult(context, criteriaQuery, false, RequestItem.class);
     }
+
     @Override
     public Iterator<RequestItem> findByItem(Context context, Item item) throws SQLException {
-        Query query = createQuery(context, "FROM RequestItem WHERE item_id= :uuid");
-        query.setParameter("uuid", item.getID());
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, RequestItem.class);
+        Root<RequestItem> requestItemRoot = criteriaQuery.from(RequestItem.class);
+        criteriaQuery.select(requestItemRoot);
+        criteriaQuery.where(criteriaBuilder.equal(requestItemRoot.get(RequestItem_.item), item));
+        Query query = createQuery(context, criteriaQuery);
+        return iterate(query);
+    }
+
+    @Override
+    public Iterator<RequestItem> findByBitstreamId(Context context, UUID bitstreamId) throws SQLException {
+        Query query = createQuery(context, "FROM RequestItem WHERE bitstream.id = :bitstreamId");
+        query.setParameter("bitstreamId", bitstreamId);
         return iterate(query);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/requestitem/service/RequestItemService.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/service/RequestItemService.java
@@ -10,6 +10,7 @@ package org.dspace.app.requestitem.service;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.dspace.app.requestitem.RequestItem;
 import org.dspace.content.Bitstream;
@@ -40,7 +41,7 @@ public interface RequestItemService {
      * @return the token of the request item
      * @throws SQLException if database error
      */
-    public String createRequest(Context context, Bitstream bitstream, Item item,
+    String createRequest(Context context, Bitstream bitstream, Item item,
             boolean allFiles, String reqEmail, String reqName, String reqMessage)
         throws SQLException;
 
@@ -49,35 +50,51 @@ public interface RequestItemService {
      *
      * @param context current DSpace session.
      * @return all item requests.
-     * @throws java.sql.SQLException passed through.
+     * @throws SQLException passed through.
      */
-    public List<RequestItem> findAll(Context context)
+    List<RequestItem> findAll(Context context)
             throws SQLException;
 
     /**
-     * Retrieve a request by its token.
+     * Retrieve a request by its approver token.
      *
      * @param context current DSpace session.
-     * @param token the token identifying the request.
+     * @param token the token identifying the request to be approved.
      * @return the matching request, or null if not found.
      */
-    public RequestItem findByToken(Context context, String token);
+    RequestItem findByToken(Context context, String token);
 
     /**
-     * Retrieve a request based on the item.
+     * Retrieve all requests (as iterator) for a given item
      * @param context current DSpace session.
      * @param item the item to find requests for.
-     * @return the matching requests, or null if not found.
+     * @return the matching requests (or empty iterator)
      */
-    public Iterator<RequestItem> findByItem(Context context, Item item) throws SQLException;
+    Iterator<RequestItem> findByItem(Context context, Item item) throws SQLException;
+
 
     /**
-     * Save updates to the record. Only accept_request, and decision_date are set-able.
+     * Retrieve all requests (as iterator) for a given bitstream UUID
+     * A UUID parameter is used here rather than Bitstream object, to make it usable
+     * in situations even when a bitstream object no longer exists, but orphaned
+     * entries need to be found by their (previous) bitstream UUID.
+     *
+     * @param context current DSpace context
+     * @param bitstreamId the bitstream UUID to search for
+     * @return the matching requests (or empty iterator)
+     */
+    Iterator<RequestItem> findByBitstreamId(Context context, UUID bitstreamId) throws SQLException;
+
+    /**
+     * Save updates to the record. Only accept_request, decision_date, access_period are settable.
+     *
+     * Note: the "is settable" rules mentioned here are enforced in RequestItemRest with annotations meaning that
+     * these JSON properties are considered READ-ONLY by the core DSpaceRestRepository methods
      *
      * @param context     The relevant DSpace Context.
      * @param requestItem requested item
      */
-    public void update(Context context, RequestItem requestItem);
+    void update(Context context, RequestItem requestItem);
 
     /**
      * Remove the record from the database.
@@ -85,7 +102,7 @@ public interface RequestItemService {
      * @param context current DSpace context.
      * @param request record to be removed.
      */
-    public void delete(Context context, RequestItem request);
+    void delete(Context context, RequestItem request);
 
     /**
      * Is there at least one valid READ resource policy for this object?
@@ -94,6 +111,6 @@ public interface RequestItemService {
      * @return true if a READ policy applies.
      * @throws SQLException passed through.
      */
-    public boolean isRestricted(Context context, DSpaceObject o)
+    boolean isRestricted(Context context, DSpaceObject o)
             throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamServiceImpl.java
@@ -293,11 +293,9 @@ public class BitstreamServiceImpl extends DSpaceObjectServiceImpl<Bitstream> imp
 
         // Remove any RequestItem entities associated with this bitstream ensuring there are no requests referencing
         // a deleted bitstream
-        List<RequestItem> requestItems = requestItemService.findAll(context);
-        for (RequestItem requestItem : requestItems) {
-            if (bitstream.equals(requestItem.getBitstream())) {
-                requestItemService.delete(context, requestItem);
-            }
+        Iterator<RequestItem> requestItems = requestItemService.findByBitstreamId(context, bitstream.getID());
+        while (requestItems.hasNext()) {
+            requestItemService.delete(context, requestItems.next());
         }
 
         // Remove policies only after the bitstream has been updated (otherwise the current user has not WRITE rights)

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RequestItemRepositoryIT.java
@@ -684,11 +684,56 @@ public class RequestItemRepositoryIT
             // verify the body is empty
             .andExpect(jsonPath("$").doesNotExist());
 
+        // Verify the request item exists via findByBitstreamId before deletion
+        Iterator<RequestItem> bitstreamRequests = requestItemService.findByBitstreamId(context, bitstream.getID());
+        assertTrue("Request item should exist before bitstream deletion", bitstreamRequests.hasNext());
+
         // Delete associated Bitstream
         ContentServiceFactory.getInstance().getBitstreamService().delete(context, bitstream);
 
         // Verify that all RequestItems related to this bitstream have been removed
         Iterator<RequestItem> itemRequests = requestItemService.findByItem(context, item);
         assertFalse(itemRequests.hasNext());
+
+        // Also verify via findByBitstreamId
+        Iterator<RequestItem> remaining = requestItemService.findByBitstreamId(context, bitstream.getID());
+        assertFalse("Request items should be removed after bitstream deletion", remaining.hasNext());
+    }
+
+    /**
+     * Test that findByBitstreamId returns matching request items and does not return items for other bitstreams.
+     */
+    @Test
+    public void testFindByBitstreamId() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        // Create a request item for the existing bitstream
+        RequestItemBuilder.createRequestItem(context, item, bitstream)
+            .build();
+
+        // Create a second bitstream with no request items
+        InputStream is2 = new ByteArrayInputStream("other content".getBytes());
+        Bitstream bitstream2 = BitstreamBuilder
+            .createBitstream(context, item, is2)
+            .withName("Other Bitstream")
+            .build();
+
+        context.restoreAuthSystemState();
+
+        // findByBitstreamId should return the request for the first bitstream
+        Iterator<RequestItem> results = requestItemService.findByBitstreamId(context, bitstream.getID());
+        assertTrue("Should find request item for bitstream", results.hasNext());
+        RequestItem found = results.next();
+        assertEquals("Request item should reference correct bitstream",
+            bitstream.getID(), found.getBitstream().getID());
+        assertFalse("Should only find one request item", results.hasNext());
+
+        // findByBitstreamId should return nothing for the second bitstream
+        Iterator<RequestItem> noResults = requestItemService.findByBitstreamId(context, bitstream2.getID());
+        assertFalse("Should find no request items for bitstream without requests", noResults.hasNext());
+
+        // findByBitstreamId should return nothing for a random UUID
+        Iterator<RequestItem> randomResults = requestItemService.findByBitstreamId(context, UUID.randomUUID());
+        assertFalse("Should find no request items for nonexistent bitstream", randomResults.hasNext());
     }
 }


### PR DESCRIPTION
Backport of https://github.com/DSpace/DSpace/pull/12158 for 7.x

Conflicts resolved: Date vs Instant handling, stripping out the Requestitem access token feature (not released in 7.x), kept in some small improvements like javadoc typos, DAO query improvement, stripping scope from service interface