### PR TITLE
Add support for concurrent indexing and running plugin-only index updates using atomic udpates

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -9,11 +9,15 @@ package org.dspace.discovery;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
@@ -51,6 +55,20 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         if (indexClientOptions == IndexClientOptions.HELP) {
             printHelp();
             return;
+        }
+
+        // Resolve optional plugin list (-p)
+        List<SolrServiceIndexPlugin> plugins = new ArrayList<>();
+        if (commandLine.hasOption('p')) {
+            if (indexClientOptions == IndexClientOptions.BUILD ||
+                    indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
+                throw new IllegalArgumentException(
+                        "-p (plugin) cannot be combined with -b (build): a full rebuild always applies all plugins. ");
+            }
+            plugins = resolvePlugins(commandLine.getOptionValues('p'));
+            handler.logInfo("Running plugin(s): " + StringUtils.join(plugins.stream()
+                                                                            .map(p -> p.getClass().getName())
+                                                                            .collect(Collectors.toList()), ", "));
         }
 
         /** Acquire from dspace-services in future */
@@ -128,20 +146,34 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         } else if (indexClientOptions == IndexClientOptions.INDEX) {
             handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
             final long startTimeMillis = System.currentTimeMillis();
-            final long count = indexAll(indexer, context, indexableObject.get(), numThreads);
+            final long count;
+            if (!plugins.isEmpty()) {
+                indexer.indexContent(context, indexableObject.get(), true, true, plugins);
+                count = 1;
+            } else {
+                count = indexAll(indexer, context, indexableObject.get(), numThreads);
+            }
             final long seconds = (System.currentTimeMillis() - startTimeMillis) / 1000;
             handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") + " in " + seconds + " seconds");
         } else if (indexClientOptions == IndexClientOptions.UPDATE ||
             indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
             handler.logInfo("Updating Index");
-            indexer.updateIndex(context, false);
+            if (!plugins.isEmpty()) {
+                indexer.updateIndex(context, false, plugins);
+            } else {
+                indexer.updateIndex(context, false);
+            }
             if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
             }
         } else if (indexClientOptions == IndexClientOptions.FORCEUPDATE ||
             indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
             handler.logInfo("Updating Index");
-            indexer.updateIndex(context, true);
+            if (!plugins.isEmpty()) {
+                indexer.updateIndex(context, true, plugins);
+            } else {
+                indexer.updateIndex(context, true);
+            }
             if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
             }
@@ -166,6 +198,45 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         indexClientOptions = IndexClientOptions.getIndexClientOption(commandLine);
         numThreads = configurationService.getIntProperty("discovery.index.threads", 1);
     }
+
+    /**
+     * Resolves the given class names to registered {@link SolrServiceIndexPlugin} beans.
+     *
+     * If a class name cannot be found on the classpath the method fails and lists all available plugin
+     *       class names
+     * If the class exists but is not registered as a {@link SolrServiceIndexPlugin} Spring bean the
+     *       method fails and lists all supported plugin class names
+     *
+     * @param classNames fully-qualified class names of the plugins to run
+     * @return resolved plugin instances, in the same order as {@code classNames}
+     */
+    private List<SolrServiceIndexPlugin> resolvePlugins(String[] classNames) {
+        List<SolrServiceIndexPlugin> available = DSpaceServicesFactory.getInstance()
+                .getServiceManager().getServicesByType(SolrServiceIndexPlugin.class);
+        List<String> availableNames = available.stream()
+                .map(p -> p.getClass().getName())
+                .collect(Collectors.toList());
+
+        List<SolrServiceIndexPlugin> result = new ArrayList<>();
+        for (String className : classNames) {
+            try {
+                Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException(
+                        "Plugin class not found: " + className + ". Available plugins: \n - " +
+                                String.join("\n - ", availableNames));
+            }
+            SolrServiceIndexPlugin plugin = available.stream()
+                    .filter(p -> p.getClass().getName().equals(className))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "Plugin " + className + " is not a registered SolrServiceIndexPlugin bean. "
+                                    + "Supported plugins: \n - " + String.join("\n - ", availableNames)));
+            result.add(plugin);
+        }
+        return result;
+    }
+
 
     /**
      * Indexes the given object and all children, if applicable.

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -9,7 +9,6 @@ package org.dspace.discovery;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,7 +19,6 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
-import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.discovery.indexobject.IndexableCollection;
 import org.dspace.discovery.indexobject.IndexableCommunity;
@@ -29,6 +27,7 @@ import org.dspace.discovery.indexobject.factory.IndexFactory;
 import org.dspace.discovery.indexobject.factory.IndexObjectFactoryFactory;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
 
@@ -41,6 +40,9 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
     private IndexingService indexer = DSpaceServicesFactory.getInstance().getServiceManager()
                                                .getServiceByName(IndexingService.class.getName(),
                                                                  IndexingService.class);
+    private final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+    private int numThreads;
 
     private IndexClientOptions indexClientOptions;
 
@@ -126,8 +128,7 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         } else if (indexClientOptions == IndexClientOptions.INDEX) {
             handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
             final long startTimeMillis = System.currentTimeMillis();
-            final long count = indexAll(indexer, ContentServiceFactory.getInstance().
-                    getItemService(), context, indexableObject.get());
+            final long count = indexAll(indexer, context, indexableObject.get(), numThreads);
             final long seconds = (System.currentTimeMillis() - startTimeMillis) / 1000;
             handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") + " in " + seconds + " seconds");
         } else if (indexClientOptions == IndexClientOptions.UPDATE ||
@@ -163,22 +164,24 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             throw new ParseException("Unable to create a new DSpace Context: " + e.getMessage());
         }
         indexClientOptions = IndexClientOptions.getIndexClientOption(commandLine);
+        numThreads = configurationService.getIntProperty("discovery.index.threads", 1);
     }
+
     /**
      * Indexes the given object and all children, if applicable.
      *
      * @param indexingService
-     * @param itemService
      * @param context         The relevant DSpace Context.
      * @param dso             DSpace object to index recursively
+     * @param numThreads      number of parallel indexing threads; 1 means sequential
      * @throws IOException            A general class of exceptions produced by failed or interrupted I/O operations.
      * @throws SearchServiceException in case of a solr exception
      * @throws SQLException           An exception that provides information on a database access error or other errors.
      */
     private static long indexAll(final IndexingService indexingService,
-                                 final ItemService itemService,
                                  final Context context,
-                                 final IndexableObject dso)
+                                 final IndexableObject dso,
+                                 final int numThreads)
         throws IOException, SearchServiceException, SQLException {
         long count = 0;
 
@@ -188,7 +191,7 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             final Community community = (Community) dso.getIndexedObject();
             final String communityHandle = community.getHandle();
             for (final Community subcommunity : community.getSubcommunities()) {
-                count += indexAll(indexingService, itemService, context, new IndexableCommunity(subcommunity));
+                count += indexAll(indexingService, context, new IndexableCommunity(subcommunity), numThreads);
                 //To prevent memory issues, discard an object from the cache after processing
                 context.uncacheEntity(subcommunity);
             }
@@ -198,44 +201,13 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
             for (final Collection collection : reloadedCommunity.getCollections()) {
                 count++;
                 indexingService.indexContent(context, new IndexableCollection(collection), true, true);
-                count += indexItems(indexingService, itemService, context, collection);
+                count += indexingService.indexItems(context, collection, true, numThreads);
                 //To prevent memory issues, discard an object from the cache after processing
                 context.uncacheEntity(collection);
             }
         } else if (dso instanceof IndexableCollection) {
-            count += indexItems(indexingService, itemService, context, (Collection) dso.getIndexedObject());
+            count += indexingService.indexItems(context, (Collection) dso.getIndexedObject(), true, numThreads);
         }
-
-        return count;
-    }
-
-    /**
-     * Indexes all items in the given collection.
-     *
-     * @param indexingService
-     * @param itemService
-     * @param context         The relevant DSpace Context.
-     * @param collection      collection to index
-     * @throws IOException            A general class of exceptions produced by failed or interrupted I/O operations.
-     * @throws SearchServiceException in case of a solr exception
-     * @throws SQLException           An exception that provides information on a database access error or other errors.
-     */
-    private static long indexItems(final IndexingService indexingService,
-                                   final ItemService itemService,
-                                   final Context context,
-                                   final Collection collection)
-        throws IOException, SearchServiceException, SQLException {
-        long count = 0;
-
-        final Iterator<Item> itemIterator = itemService.findByCollection(context, collection);
-        while (itemIterator.hasNext()) {
-            Item item = itemIterator.next();
-            indexingService.indexContent(context, new IndexableItem(item), true, false);
-            count++;
-            //To prevent memory issues, discard an object from the cache after processing
-            context.uncacheEntity(item);
-        }
-        indexingService.commit();
 
         return count;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClientOptions.java
@@ -9,6 +9,7 @@
 package org.dspace.discovery;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 /**
@@ -84,6 +85,10 @@ public enum IndexClientOptions {
         options.addOption("s", "spellchecker", false, "Rebuild the spellchecker, can be combined with -b and -f.");
         options.addOption("f", "force", false,
                           "if updating existing index, force each handle to be reindexed even if uptodate");
+        options.addOption(Option.builder("p").longOpt("plugin").hasArgs()
+                .desc("run one or more indexing plugins (by class name) on all indexed objects without a full "
+                        + "reindex; can be combined with -i to restrict scope to a single object")
+                .build());
         options.addOption("h", "help", false, "print this help message");
         return options;
     }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -9,6 +9,7 @@ package org.dspace.discovery;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrServerException;
@@ -44,6 +45,20 @@ public interface IndexingService {
     void indexContent(Context context, IndexableObject dso,
                       boolean force, boolean commit, boolean preDb) throws SQLException, SearchServiceException;
 
+    /**
+     * Apply the provided plugins as atomic Solr updates for the given object, leaving all other index
+     * fields intact.
+     *
+     * @param context  The DSpace Context
+     * @param dso      The object to update
+     * @param force    unused; kept for symmetry with the other indexContent overloads
+     * @param commit   if true, commit after applying the plugins
+     * @param plugins  the plugins to apply
+     */
+    void indexContent(Context context, IndexableObject dso,
+                      boolean force, boolean commit, List<SolrServiceIndexPlugin> plugins)
+            throws SQLException, SearchServiceException;
+
     void unIndexContent(Context context, IndexableObject dso)
         throws SQLException, IOException;
 
@@ -66,6 +81,16 @@ public interface IndexingService {
     void updateIndex(Context context, boolean force);
 
     void updateIndex(Context context, boolean force, String type);
+
+    /**
+     * Iterate over all indexed objects and apply the provided plugins as atomic updates,
+     * leaving all other index fields intact.
+     *
+     * @param context  The DSpace Context
+     * @param force    unused; kept for symmetry with the other updateIndex overloads
+     * @param plugins  the plugins to apply
+     */
+    void updateIndex(Context context, boolean force, List<SolrServiceIndexPlugin> plugins);
 
     void cleanIndex() throws IOException, SQLException, SearchServiceException;
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrServerException;
+import org.dspace.content.Collection;
 import org.dspace.core.Context;
 
 /**
@@ -86,4 +87,22 @@ public interface IndexingService {
      */
     void atomicUpdate(Context context, String uniqueIndexId, String field, Map<String,Object> fieldModifier)
             throws SolrServerException, IOException;
+
+    /**
+     * Index all items in the given collection.
+     * When {@code numThreads} is greater than 1, items are indexed in parallel using a fixed
+     * thread pool. The caller's {@code context} is used only to pre-collect item IDs; each
+     * worker thread opens its own read-only {@link Context}.
+     *
+     * @param context    calling context
+     * @param collection collection whose items should be indexed
+     * @param force      when {@code true} every item is re-indexed regardless of modification date
+     * @param numThreads number of parallel worker threads; 1 means sequential
+     * @return number of items indexed
+     * @throws SQLException           on database error
+     * @throws IOException            on I/O error
+     * @throws SearchServiceException on Solr error
+     */
+    long indexItems(Context context, Collection collection, boolean force, int numThreads)
+        throws SQLException, IOException, SearchServiceException;
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrSearchCore.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrSearchCore.java
@@ -54,7 +54,7 @@ public class SolrSearchCore {
      * Get access to current SolrClient. If no current SolrClient exists, a new one is initialized, see initSolr().
      * @return SolrClient Solr client
      */
-    public SolrClient getSolr() {
+    public synchronized SolrClient getSolr() {
         if (solr == null) {
             initSolr();
         }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -50,6 +50,7 @@ import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.SolrInputField;
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.HighlightParams;
 import org.apache.solr.common.params.MoreLikeThisParams;
@@ -344,7 +345,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
      */
     @Override
     public void updateIndex(Context context, boolean force) {
-        updateIndex(context, force, null);
+        updateIndex(context, force, (String) null);
     }
 
     @Override
@@ -395,6 +396,25 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         log.info("Solr commit complete for type {}", indexableObjectService.getType());
                     }
                 }
+            }
+        } catch (IOException | SQLException | SolrServerException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void updateIndex(Context context, boolean force, List<SolrServiceIndexPlugin> plugins) {
+        try {
+            for (IndexFactory indexableObjectService : indexObjectServiceFactory.getIndexFactories()) {
+                final Iterator<IndexableObject> indexableObjects = indexableObjectService.findAll(context);
+                while (indexableObjects.hasNext()) {
+                    final IndexableObject indexableObject = indexableObjects.next();
+                    applyPluginsAtomic(context, indexableObject, plugins);
+                    context.uncacheEntity(indexableObject.getIndexedObject());
+                }
+            }
+            if (solrSearchCore.getSolr() != null) {
+                solrSearchCore.getSolr().commit();
             }
         } catch (IOException | SQLException | SolrServerException e) {
             log.error(e.getMessage(), e);
@@ -1744,6 +1764,43 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         if (commit) {
             commit();
         }
+    }
+
+    @Override
+    public void indexContent(Context context, IndexableObject dso, boolean force, boolean commit,
+                             List<SolrServiceIndexPlugin> plugins) throws SearchServiceException, SQLException {
+        try {
+            applyPluginsAtomic(context, dso, plugins);
+        } catch (IOException | SolrServerException e) {
+            throw new SearchServiceException(e.getMessage(), e);
+        }
+        if (commit) {
+            commit();
+        }
+    }
+
+    /**
+     * Collect contributions from the given plugins into a single atomic-update Solr document and submit it.
+     * Only fields actually written by the plugins are touched; all other index fields are left intact.
+     */
+    private void applyPluginsAtomic(Context context, IndexableObject indexableObject,
+                                    List<SolrServiceIndexPlugin> plugins) throws IOException, SolrServerException {
+        SolrInputDocument pluginDoc = new SolrInputDocument();
+        for (SolrServiceIndexPlugin plugin : plugins) {
+            plugin.additionalIndex(context, indexableObject, pluginDoc);
+        }
+        if (pluginDoc.isEmpty() || solrSearchCore.getSolr() == null) {
+            return;
+        }
+        SolrInputDocument atomicDoc = new SolrInputDocument();
+        atomicDoc.setField(SearchUtils.RESOURCE_UNIQUE_ID, indexableObject.getUniqueIndexID());
+        for (SolrInputField field : pluginDoc) {
+            List<Object> values = new ArrayList<>(field.getValues());
+            Map<String, Object> atomicOp = new HashMap<>();
+            atomicOp.put("set", values.size() == 1 ? values.get(0) : values);
+            atomicDoc.setField(field.getName(), atomicOp);
+        }
+        solrSearchCore.getSolr().add(atomicDoc);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -30,6 +30,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.mail.MessagingException;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -57,6 +62,7 @@ import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
 import org.dspace.core.Email;
@@ -109,6 +115,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     // facet by indexing "each word to end of value' partial value
     public static final String SOLR_FIELD_SUFFIX_FACET_PREFIXES = "_prefix";
 
+    // Recycle worker Contexts, log progress, and commit Solr every this many objects.
+    private static final int INDEX_BATCH_SIZE = 1000;
+
     @Autowired
     protected ContentServiceFactory contentServiceFactory;
     @Autowired
@@ -119,6 +128,8 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     protected SolrSearchCore solrSearchCore;
     @Autowired
     protected ConfigurationService configurationService;
+    @Autowired
+    protected ItemService itemService;
 
     protected SolrServiceImpl() {
 
@@ -338,26 +349,217 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
     @Override
     public void updateIndex(Context context, boolean force, String type) {
+        final int numThreads = configurationService.getIntProperty("discovery.index.threads", 1);
         try {
-            final List<IndexFactory> indexableObjectServices = indexObjectServiceFactory.
-                getIndexFactories();
+            final List<IndexFactory> indexableObjectServices = indexObjectServiceFactory.getIndexFactories();
             for (IndexFactory indexableObjectService : indexableObjectServices) {
                 if (type == null || StringUtils.equals(indexableObjectService.getType(), type)) {
                     final Iterator<IndexableObject> indexableObjects = indexableObjectService.findAll(context);
-                    while (indexableObjects.hasNext()) {
-                        final IndexableObject indexableObject = indexableObjects.next();
-                        indexContent(context, indexableObject, force);
-                        context.uncacheEntity(indexableObject.getIndexedObject());
+                    // Only parallelize when force=true: every object needs actual work.
+                    // When force=false, requiresIndexing() is a cheap Solr check per object that filters down
+                    // to a small percentage of the total, so parallelizing the  would add more overhead than it's worth
+                    if (numThreads > 1 && force) {
+                        log.info("Collecting IDs for type {} ...", indexableObjectService.getType());
+                        final List<String> ids = new ArrayList<>();
+                        while (indexableObjects.hasNext()) {
+                            final IndexableObject obj = indexableObjects.next();
+                            ids.add(obj.getID().toString());
+                            context.uncacheEntity(obj.getIndexedObject());
+                        }
+                        log.info("Collected {} objects of type {}, starting parallel indexing with {} threads",
+                                 ids.size(), indexableObjectService.getType(), numThreads);
+                        indexContentParallel(indexableObjectService, ids, force, numThreads);
+                    } else {
+                        long processed = 0;
+                        while (indexableObjects.hasNext()) {
+                            final IndexableObject indexableObject = indexableObjects.next();
+                            indexContent(context, indexableObject, force);
+                            context.uncacheEntity(indexableObject.getIndexedObject());
+                            processed++;
+                            if (processed % INDEX_BATCH_SIZE == 0) {
+                                log.info("Processed {} objects of type {} ...",
+                                         processed, indexableObjectService.getType());
+                                // Only commit mid-batch when forcing a full reindex; committing
+                                // when nothing has changed triggers needless Solr segment merges.
+                                if (force && solrSearchCore.getSolr() != null) {
+                                    solrSearchCore.getSolr().commit();
+                                }
+                            }
+                        }
+                    }
+                    if (force) {
+                        log.info("Committing Solr for type {} ...", indexableObjectService.getType());
+                        if (solrSearchCore.getSolr() != null) {
+                            solrSearchCore.getSolr().commit();
+                        }
+                        log.info("Solr commit complete for type {}", indexableObjectService.getType());
                     }
                 }
             }
-            if (solrSearchCore.getSolr() != null) {
-                solrSearchCore.getSolr().commit();
-            }
-
         } catch (IOException | SQLException | SolrServerException e) {
             log.error(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public long indexItems(Context context, Collection collection, boolean force, int numThreads)
+        throws SQLException, IOException, SearchServiceException {
+        log.info("Collecting items for collection {} ...", collection.getHandle());
+        final List<String> ids = new ArrayList<>();
+        final Iterator<Item> it = itemService.findByCollection(context, collection);
+        while (it.hasNext()) {
+            final Item item = it.next();
+            ids.add(item.getID().toString());
+            context.uncacheEntity(item);
+        }
+        log.info("Collected {} items for collection {}", ids.size(), collection.getHandle());
+
+        final String label = "items in collection " + collection.getHandle();
+        final long count;
+        if (numThreads > 1) {
+            count = runParallelWorkers(ids, numThreads,
+                (ctx, id) -> {
+                    final Item item = itemService.find(ctx, UUID.fromString(id));
+                    return item != null ? Optional.of(new IndexableItem(item)) : Optional.empty();
+                },
+                force, label);
+        } else {
+            long c = 0;
+            for (final String id : ids) {
+                final Item item = itemService.find(context, UUID.fromString(id));
+                if (item != null) {
+                    indexContent(context, new IndexableItem(item), force, false);
+                    c++;
+                    context.uncacheEntity(item);
+                    if (c % INDEX_BATCH_SIZE == 0) {
+                        log.info("Indexed {}/{} {}", c, ids.size(), label);
+                    }
+                }
+            }
+            count = c;
+        }
+        log.info("Committing Solr for {} ({} items) ...", label, count);
+        commit();
+        return count;
+    }
+
+    /**
+     * Functional interface for loading an {@link IndexableObject} from the database
+     * inside a worker thread, given the object's string ID.
+     */
+    @FunctionalInterface
+    private interface ObjectLoader {
+        Optional<? extends IndexableObject> load(Context ctx, String id) throws Exception;
+    }
+
+    /**
+     * Run a fixed pool of worker threads that each poll from {@code ids} and index objects
+     * using a per-thread read-only {@link Context}.
+     * <p>
+     * Each worker calls {@link Context#uncacheEntity} after each item to evict Item, Bundle and
+     * Bitstream from the Hibernate first-level cache, and recycles its Context entirely every
+     * {@link #INDEX_BATCH_SIZE} items to clear entities that {@code uncacheEntity()} does not
+     * evict, in particular the MetadataValue, MetadataField, EPerson and Version objects that
+     * {@code buildDocument()} loads. Individual item failures are logged and skipped, the
+     * returned count reflects only successfully indexed objects.
+     *
+     * @param ids           string IDs of all objects to index
+     * @param numThreads    size of the worker thread pool
+     * @param loader        loads an {@link IndexableObject} by its string ID
+     * @param force         when {@code true} every object is re-indexed regardless of modification date
+     * @param progressLabel human-readable label used in log messages
+     * @return total number of objects successfully indexed
+     */
+    private long runParallelWorkers(final List<String> ids,
+                                    final int numThreads,
+                                    final ObjectLoader loader,
+                                    final boolean force,
+                                    final String progressLabel) {
+        final ConcurrentLinkedQueue<String> queue = new ConcurrentLinkedQueue<>(ids);
+        final AtomicLong count = new AtomicLong(0);
+        final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+        try {
+            for (int t = 0; t < numThreads; t++) {
+                executor.submit(() -> {
+                    Context workerContext = null;
+                    try {
+                        workerContext = new Context(Context.Mode.READ_ONLY);
+                        workerContext.turnOffAuthorisationSystem();
+                        String id;
+                        long workerCount = 0;
+                        while ((id = queue.poll()) != null) {
+                            try {
+                                final Optional<? extends IndexableObject> obj = loader.load(workerContext, id);
+                                if (obj.isPresent()) {
+                                    indexContent(workerContext, obj.get(), force);
+                                    // Evict Item, Bundle and Bitstream immediately. The periodic Context
+                                    // recycle below clears everything else (MetadataValue, EPerson, etc.)
+                                    // that buildDocument() loads but uncacheEntity() does not cover.
+                                    workerContext.uncacheEntity(obj.get().getIndexedObject());
+                                    final long total = count.incrementAndGet();
+                                    if (total % INDEX_BATCH_SIZE == 0) {
+                                        log.info("Indexed {}/{} {} ...", total, ids.size(), progressLabel);
+                                    }
+                                }
+                            } catch (Exception e) {
+                                log.error("Failed to index {} from {}", id, progressLabel, e);
+                            }
+                            workerCount++;
+                            if (workerCount % INDEX_BATCH_SIZE == 0) {
+                                // Recycle the Context to flush everything the Hibernate session has
+                                // accumulated over the last batch (MetadataValue, MetadataField,
+                                // EPerson, Version, etc.) that uncacheEntity() does not evict.
+                                workerContext.abort();
+                                workerContext = new Context(Context.Mode.READ_ONLY);
+                                workerContext.turnOffAuthorisationSystem();
+                            }
+                        }
+                    } catch (Exception e) {
+                        log.error("Parallel indexing worker for {} failed to initialize", progressLabel, e);
+                    } finally {
+                        if (workerContext != null) {
+                            workerContext.abort();
+                        }
+                    }
+                });
+            }
+        } finally {
+            // Guarantee shutdown
+            executor.shutdown();
+        }
+        try {
+            // Poll with a finite timeout so we can log progress and avoid hanging silently
+            // if a worker stalls.
+            while (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                log.info("Still indexing {}, {} items remaining in queue ...", progressLabel, queue.size());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Parallel indexing of {} was interrupted", progressLabel);
+            executor.shutdownNow();
+        }
+        return count.get();
+    }
+
+    /**
+     * Index a list of objects in parallel using a fixed thread pool.
+     * Delegates to {@link #runParallelWorkers} for the actual parallel execution.
+     *
+     * @param indexableObjectService factory used to reload each object by its ID
+     * @param ids                    string IDs of all objects to index
+     * @param force                  when {@code true} every object is re-indexed regardless of modification date
+     * @param numThreads             size of the worker thread pool
+     */
+    private void indexContentParallel(final IndexFactory indexableObjectService,
+                                      final List<String> ids,
+                                      final boolean force,
+                                      final int numThreads) {
+        final String label = indexableObjectService.getType() + " objects";
+        log.info("Starting parallel indexing of {} {} using {} threads", ids.size(), label, numThreads);
+        runParallelWorkers(ids, numThreads,
+            (ctx, id) -> indexableObjectService.findIndexableObject(ctx, id),
+            force, label);
+        log.info("All parallel workers finished for type {}", indexableObjectService.getType());
     }
 
     /**

--- a/dspace/config/modules/discovery.cfg
+++ b/dspace/config/modules/discovery.cfg
@@ -45,6 +45,12 @@ discovery.facet.namedtype.workflow.item = 002workflow\n|||\nWorkflow###workflow
 discovery.facet.namedtype.workflow.claimed = 003workflow\n|||\nValidation###validation
 discovery.facet.namedtype.workflow.pooled = 004workflow\n|||\nWaiting for Controller###waitingforcontroller
 
+# Number of threads to use when (re)indexing content into Solr.
+# Each thread opens its own database connection, so this value must not exceed
+# the available DB connection pool size (see db.maxconnections in dspace.cfg).
+# Default is 1 (sequential). A value of 4-8 is a reasonable starting point.
+#discovery.index.threads = 1
+
 # Set the number of retry of a query when stale objects are found.
 # Set to -1 if stale objects should be ignored. Set to 0 if you want to avoid extra query but take the chance to cleanup 
 # the index each time that stale objects are found. Default 3


### PR DESCRIPTION
## References
* Fixes #12477

## Description
This PR adds configurable parallel indexing and selective plugin-based indexing to the discovery system. Introduces `discovery.index.threads` configuration property for multi-threaded indexing and a new `-p` / `--plugin` command-line option for running plugins without a full rebuild.

## Key Changes
* Multi-threaded indexing with configurable thread pool via `discovery.index.threads` config
* New `-p` / `--plugin` option to apply indexing plugins selectively without full reindex
* Refactored `indexAll()` and added new `indexItems()` method with parallel execution support
* Thread-safe Solr client access (synchronized `getSolr()`)
* Proper context recycling and batch processing to prevent OOM

## Performance Improvements
Local testing on a realistic production database `dspace index-discovery -b` (full rebuild):

| Configuration | Time |
|---------------|------|
| Before (single-threaded) | 2h 37m |
| After, threads=1 (default) | 2h 43m |
| After, threads=4 | 44m |
| After, threads=14 (max on macbook M4 Pro) | 12m |

## Testing
1. Sequential indexing (default behavior): `dspace index-discovery -b`
2. Parallel indexing: Set `discovery.index.threads = 4` in `dspace/config/modules/discovery.cfg`, then run rebuild
3. Plugin-based indexing: `dspace index-discovery -p org.example.CustomPlugin1`

---

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (< 1,000 lines, not including comments & integration tests).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

