### PR TITLE
Set CORS max-age header to a default of 86400s and make it configurable

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/WebApplication.java
@@ -56,6 +56,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebApplication {
 
+    private static final String[] CORS_ALLOWED_HEADERS = {
+        "Accept", "Authorization", "Content-Type", "Origin", "X-On-Behalf-Of",
+        "X-Requested-With", "X-XSRF-TOKEN", "X-CORRELATION-ID", "X-REFERRER",
+        "x-captcha-payload"
+    };
+
+    private static final String[] CORS_EXPOSED_HEADERS = {
+        "Authorization", "DSPACE-XSRF-TOKEN", "Location", "WWW-Authenticate"
+    };
+
     @Autowired
     private ApplicationConfig configuration;
 
@@ -174,6 +184,7 @@ public class WebApplication {
                 boolean corsAllowCredentials = configuration.getCorsAllowCredentials();
                 boolean iiifAllowCredentials = configuration.getIiifAllowCredentials();
                 boolean signpostingAllowCredentials = configuration.getSignpostingAllowCredentials();
+                int corsMaxAge = configuration.getCorsMaxAge();
                 if (corsAllowedOrigins != null) {
                     registry.addMapping("/api/**").allowedMethods(CorsConfiguration.ALL)
                             // Set Access-Control-Allow-Credentials to "true" and specify which origins are valid
@@ -181,11 +192,10 @@ public class WebApplication {
                             // for our Access-Control-Allow-Origin header
                             .allowCredentials(corsAllowCredentials).allowedOrigins(corsAllowedOrigins)
                             // Allow list of request preflight headers allowed to be sent to us from the client
-                            .allowedHeaders("Accept", "Authorization", "Content-Type", "Origin", "X-On-Behalf-Of",
-                                "X-Requested-With", "X-XSRF-TOKEN", "X-CORRELATION-ID", "X-REFERRER",
-                                "x-captcha-payload")
+                            .allowedHeaders(CORS_ALLOWED_HEADERS)
                             // Allow list of response headers allowed to be sent by us (the server) to the client
-                            .exposedHeaders("Authorization", "DSPACE-XSRF-TOKEN", "Location", "WWW-Authenticate");
+                            .exposedHeaders(CORS_EXPOSED_HEADERS)
+                            .maxAge(corsMaxAge);
                 }
                 if (iiifAllowedOrigins != null) {
                     registry.addMapping("/iiif/**").allowedMethods(CorsConfiguration.ALL)
@@ -193,11 +203,10 @@ public class WebApplication {
                             // for our Access-Control-Allow-Origin header
                             .allowCredentials(iiifAllowCredentials).allowedOrigins(iiifAllowedOrigins)
                             // Allow list of request preflight headers allowed to be sent to us from the client
-                            .allowedHeaders("Accept", "Authorization", "Content-Type", "Origin", "X-On-Behalf-Of",
-                                "X-Requested-With", "X-XSRF-TOKEN", "X-CORRELATION-ID", "X-REFERRER",
-                                "x-captcha-payload")
+                            .allowedHeaders(CORS_ALLOWED_HEADERS)
                             // Allow list of response headers allowed to be sent by us (the server) to the client
-                            .exposedHeaders("Authorization", "DSPACE-XSRF-TOKEN", "Location", "WWW-Authenticate");
+                            .exposedHeaders(CORS_EXPOSED_HEADERS)
+                            .maxAge(corsMaxAge);
                 }
                 if (signpostingAllowedOrigins != null) {
                     registry.addMapping("/signposting/**").allowedMethods(CorsConfiguration.ALL)
@@ -205,11 +214,10 @@ public class WebApplication {
                             // for our Access-Control-Allow-Origin header
                             .allowCredentials(signpostingAllowCredentials).allowedOrigins(signpostingAllowedOrigins)
                             // Allow list of request preflight headers allowed to be sent to us from the client
-                            .allowedHeaders("Accept", "Authorization", "Content-Type", "Origin", "X-On-Behalf-Of",
-                                    "X-Requested-With", "X-XSRF-TOKEN", "X-CORRELATION-ID", "X-REFERRER",
-                                    "x-captcha-payload", "access-control-allow-headers")
+                            .allowedHeaders(CORS_ALLOWED_HEADERS)
                             // Allow list of response headers allowed to be sent by us (the server) to the client
-                            .exposedHeaders("Authorization", "DSPACE-XSRF-TOKEN", "Location", "WWW-Authenticate");
+                            .exposedHeaders(CORS_EXPOSED_HEADERS)
+                            .maxAge(corsMaxAge);
                 }
             }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/ApplicationConfig.java
@@ -71,6 +71,9 @@ public class ApplicationConfig {
     @Value("${signposting.cors.allow-credentials:true}")
     private boolean signpostingCorsAllowCredentials;
 
+    @Value("${rest.cors.max-age:86400}")
+    private int corsMaxAge;
+
     // Configured User Interface URL (default: http://localhost:4000)
     @Value("${dspace.ui.url:http://localhost:4000}")
     private String uiURL;
@@ -161,5 +164,14 @@ public class ApplicationConfig {
      */
     public boolean getSignpostingAllowCredentials() {
         return signpostingCorsAllowCredentials;
+    }
+
+    /**
+     * Return the CORS max age value, defined in the DSpace configuration. This is used to set the
+     * CORS "Access-Control-Max-Age" header in Application class. Defaults to 86400 seconds.
+     * @return cors max age
+     */
+    public int getCorsMaxAge() {
+        return corsMaxAge;
     }
 }

--- a/dspace/config/local.cfg.EXAMPLE
+++ b/dspace/config/local.cfg.EXAMPLE
@@ -218,7 +218,10 @@ db.password = dspace
 # When an external authentication system is involved like Shibboleth some browsers (i.e. Safari) include
 # in the request the Origin header with the url of the IdP. In such case you need to allow also the IdP to
 # avoid trouble for such browsers (i.e.  rest.cors.allowed-origins = ${dspace.ui.url}, https://samltest.id )
+# You can also set the Access-Control-Max-Age header value here. It currently defaults to
+# 86400 seconds (24hours), but is configurable via rest.cors.max-age.
 #rest.cors.allowed-origins = ${dspace.ui.url}
+#rest.cors.max-age = 86400
 
 #################################################
 # SPRING BOOT SETTINGS (Used by Server Webapp)  #


### PR DESCRIPTION
## References
* Fixes #12087
* [Background info on Access-Control-Max-Age header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Max-Age)

## Description
With this PR, the Access-Control-Max-Age header becomes configurable. The header defines how long the result of the preflight requests are going to be cached. On the main branch the header is currently not explicitly set, but it is filled by the [embedded tomcat](https://tomcat.apache.org/tomcat-9.0-doc/config/filter.html) with a default value of 1800s (30mins).

Initially I assumed that there are a lot of unnecessary preflight requests, like it was stated in the issue #12087. It became clear that these requests appear in the browser dev tools only because the feature "Disable Cache" is usually activated on the network tab. When you disable that feature, you don't see that high number of preflight requests.

Nevertheless this PR could help by making the setting of the header value explicit and also it reduces the preflight requests made in a day by setting it to 24hours. Not all browsers support 24hours, but some do.

## Instructions for Reviewers
1. Set `rest.cors.max-age` to a value of your choice
2. Observe that the header `Access-Control-Max-Age` is set to this value in the browser dev tools

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
