### PR TITLE
Add OrderedAccessStatusHelper plugin

### DIFF
--- a/dspace-api/src/main/java/org/dspace/access/status/OrderedAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/OrderedAccessStatusHelper.java
@@ -1,0 +1,132 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.access.status;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+import org.dspace.content.AccessStatus;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * Implementation of the access status helper that uses an ordered list of access statuses to enforce an order
+ * of precedence when there are multiple bitstreams in the original bundle that have difference policies.
+ * <p>
+ * The ordered list is read from the {@code access.status.order} configuration property via
+ * {@link ConfigurationService}. The status with the highest precedence comes first. When the property is not
+ * configured, the order defaults to {@link #DEFAULT_ORDERED_BITSTREAM_STATUSES}.
+ * 
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
+public class OrderedAccessStatusHelper extends DefaultAccessStatusHelper {
+
+    /**
+     * Configuration key for the ordered list of access statuses.
+     */
+    public static final String ACCESS_STATUS_ORDER_PROPERTY = "access.status.order";
+
+    /**
+     * Default ordered list of access statuses, used when {@link #ACCESS_STATUS_ORDER_PROPERTY} is not configured.
+     */
+    static final String[] DEFAULT_ORDERED_BITSTREAM_STATUSES =
+        new String[] { EMBARGO, RESTRICTED, UNKNOWN, OPEN_ACCESS };
+
+    /**
+     * Iterate over all the bitstreams in the item's original bundle, calculate the access status for each bitstream,
+     * and select the access status with the most precedence based on the configured ordered list of statuses. The
+     * access status with the highest precedence is at index 0 in the list.
+     * <p>
+     * If the item Original bundle is empty, "metadata.only" is returned.
+     * <p>
+     * If the item is null, simply returns the "unknown" value.
+     *
+     * @param context     the DSpace context
+     * @param item        the item to check for embargoes
+     * @param threshold   the embargo threshold date
+     * @param type        the type of calculation
+     * @return the access status
+     */
+    @Override
+    public AccessStatus getAccessStatusFromItem(Context context, Item item, LocalDate threshold, String type) {
+        if (item == null) {
+            return new AccessStatus(UNKNOWN, null);
+        }
+
+        final List<Bundle> bundles = item.getBundles(Constants.DEFAULT_BUNDLE_NAME);
+
+        boolean noBitstreamsInBundles = bundles.stream()
+            .allMatch(bundle -> bundle.getBitstreams().isEmpty());
+
+        if (noBitstreamsInBundles) {
+            return new AccessStatus(METADATA_ONLY, null);
+        }
+
+        return getAccessStatusForItemBitstreams(context, bundles, threshold, type);
+    }
+
+    private AccessStatus getAccessStatusForItemBitstreams(Context context, List<Bundle> bundles, LocalDate threshold,
+                                                          String type) {
+        final String[] orderedStatuses = getOrderedBitstreamStatuses();
+        return bundles.stream()
+            .map(Bundle::getBitstreams)
+            .flatMap(List::stream)
+            .map(bitstream -> getAccessStatusForBitstreamSafe(context, bitstream, threshold, type))
+            .min(Comparator.comparingInt(
+                accessStatus -> {
+                    int index = indexOf(orderedStatuses, accessStatus.getStatus());
+                    if (index == -1) {
+                        throw new RuntimeException("Access status " + accessStatus.getStatus() +
+                            " not found in ordered list");
+                    }
+                    return index;
+                }
+            ))
+            .orElseGet(() -> new AccessStatus(UNKNOWN, null));
+    }
+
+    /**
+     * Read the ordered list of access statuses from configuration, falling back to
+     * {@link #DEFAULT_ORDERED_BITSTREAM_STATUSES} when the property is not set.
+     *
+     * @return the ordered list of access statuses; never empty
+     */
+    protected String[] getOrderedBitstreamStatuses() {
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        String[] configured = configurationService.getArrayProperty(ACCESS_STATUS_ORDER_PROPERTY);
+        if (configured == null || configured.length == 0) {
+            return DEFAULT_ORDERED_BITSTREAM_STATUSES;
+        }
+        return configured;
+    }
+
+    private static int indexOf(String[] values, String target) {
+        for (int i = 0; i < values.length; i++) {
+            if (values[i].equals(target)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private AccessStatus getAccessStatusForBitstreamSafe(Context context, Bitstream bitstream, LocalDate threshold,
+                                                         String type) {
+        try {
+            return getAccessStatusFromBitstream(context, bitstream, threshold, type);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/access/status/AbstractAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/AbstractAccessStatusHelperTest.java
@@ -1,0 +1,593 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.access.status;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.ResourcePolicy;
+import org.dspace.authorize.factory.AuthorizeServiceFactory;
+import org.dspace.authorize.service.ResourcePolicyService;
+import org.dspace.content.AccessStatus;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.content.service.BundleService;
+import org.dspace.content.service.CollectionService;
+import org.dspace.content.service.CommunityService;
+import org.dspace.content.service.InstallItemService;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.WorkspaceItemService;
+import org.dspace.core.Constants;
+import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
+import org.dspace.eperson.factory.EPersonServiceFactory;
+import org.dspace.eperson.service.EPersonService;
+import org.dspace.eperson.service.GroupService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractAccessStatusHelperTest extends AbstractUnitTest {
+
+    private static final Logger log = LogManager.getLogger(AbstractAccessStatusHelperTest.class);
+
+    protected Collection collection;
+    protected Community owningCommunity;
+    protected Item itemWithoutBundle;
+    protected Item itemWithoutBitstream;
+    protected Item itemWithBitstream;
+    protected Item itemWithEmbargo;
+    protected Item itemWithDateRestriction;
+    protected Item itemWithGroupRestriction;
+    protected Item itemWithoutPolicy;
+    protected Item itemWithoutPrimaryBitstream;
+    protected Item itemWithPrimaryAndMultipleBitstreams;
+    protected Item itemWithoutPrimaryAndMultipleBitstreams;
+    protected AccessStatusHelper helper;
+    protected LocalDate threshold;
+
+    protected CommunityService communityService =
+            ContentServiceFactory.getInstance().getCommunityService();
+    protected CollectionService collectionService =
+            ContentServiceFactory.getInstance().getCollectionService();
+    protected ItemService itemService =
+            ContentServiceFactory.getInstance().getItemService();
+    protected WorkspaceItemService workspaceItemService =
+            ContentServiceFactory.getInstance().getWorkspaceItemService();
+    protected InstallItemService installItemService =
+            ContentServiceFactory.getInstance().getInstallItemService();
+    protected BundleService bundleService =
+            ContentServiceFactory.getInstance().getBundleService();
+    protected BitstreamService bitstreamService =
+            ContentServiceFactory.getInstance().getBitstreamService();
+    protected ResourcePolicyService resourcePolicyService =
+            AuthorizeServiceFactory.getInstance().getResourcePolicyService();
+    protected GroupService groupService =
+            EPersonServiceFactory.getInstance().getGroupService();
+    protected EPersonService ePersonService =
+            EPersonServiceFactory.getInstance().getEPersonService();
+
+    /**
+     * This method will be run before every test as per @Before. It will
+     * initialize resources required for the tests.
+     *
+     * Other methods can be annotated with @Before here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @Before
+    @Override
+    public void init() {
+        super.init();
+        try {
+            context.turnOffAuthorisationSystem();
+            owningCommunity = communityService.create(null, context);
+            collection = collectionService.create(context, owningCommunity);
+            itemWithoutBundle = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutBitstream = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithBitstream = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithEmbargo = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithDateRestriction = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithGroupRestriction = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutPolicy = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutPrimaryBitstream = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithPrimaryAndMultipleBitstreams = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            itemWithoutPrimaryAndMultipleBitstreams = installItemService.installItem(context,
+                    workspaceItemService.create(context, collection, true));
+            context.restoreAuthSystemState();
+        } catch (AuthorizeException ex) {
+            log.error("Authorization Error in init", ex);
+            fail("Authorization Error in init: " + ex.getMessage());
+        } catch (SQLException ex) {
+            log.error("SQL Error in init", ex);
+            fail("SQL Error in init: " + ex.getMessage());
+        }
+        threshold = LocalDate.of(10000, 1, 1);
+    }
+
+    /**
+     * This method will be run after every test as per @After. It will
+     * clean resources initialized by the @Before methods.
+     *
+     * Other methods can be annotated with @After here or in subclasses
+     * but no execution order is guaranteed
+     */
+    @After
+    @Override
+    public void destroy() {
+        context.turnOffAuthorisationSystem();
+        try {
+            itemService.delete(context, itemWithoutBundle);
+            itemService.delete(context, itemWithoutBitstream);
+            itemService.delete(context, itemWithBitstream);
+            itemService.delete(context, itemWithEmbargo);
+            itemService.delete(context, itemWithDateRestriction);
+            itemService.delete(context, itemWithGroupRestriction);
+            itemService.delete(context, itemWithoutPolicy);
+            itemService.delete(context, itemWithoutPrimaryBitstream);
+            itemService.delete(context, itemWithPrimaryAndMultipleBitstreams);
+            itemService.delete(context, itemWithoutPrimaryAndMultipleBitstreams);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            collectionService.delete(context, collection);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            communityService.delete(context, owningCommunity);
+        } catch (Exception e) {
+            // ignore
+        }
+        context.restoreAuthSystemState();
+        itemWithoutBundle = null;
+        itemWithoutBitstream = null;
+        itemWithBitstream = null;
+        itemWithEmbargo = null;
+        itemWithDateRestriction = null;
+        itemWithGroupRestriction = null;
+        itemWithoutPolicy = null;
+        itemWithoutPrimaryBitstream = null;
+        itemWithPrimaryAndMultipleBitstreams = null;
+        itemWithoutPrimaryAndMultipleBitstreams = null;
+        collection = null;
+        owningCommunity = null;
+        helper = null;
+        threshold = null;
+        communityService = null;
+        collectionService = null;
+        itemService = null;
+        workspaceItemService = null;
+        installItemService = null;
+        bundleService = null;
+        bitstreamService = null;
+        resourcePolicyService = null;
+        groupService = null;
+        try {
+            super.destroy();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    /**
+     * Test for a null item
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithNullItem() throws Exception {
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithNullItem 1", availabilityDate);
+    }
+
+    /**
+     * Test for an item with no bundle
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutBundle() throws Exception {
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutBundle, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithoutBundle 1", availabilityDate);
+    }
+
+    /**
+     * Test for an item with no bitstream
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        bundleService.create(context, itemWithoutBitstream, Constants.CONTENT_BUNDLE_NAME);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithoutBitstream 1", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithoutBitstream 4", bitstreamAvailabilityDate);
+    }
+
+    /**
+     * Test for an item with a basic bitstream (open access)
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithBitstream, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithBitstream 1", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithBitstream 4", bitstreamAvailabilityDate);
+    }
+
+    /**
+     * Test for an item with an embargo
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargo() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargo 1", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargo 4", bitstreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with an anonymous date restriction
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithDateRestriction() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithDateRestriction, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Restriction");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(10000, 1, 1);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithDateRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithDateRestriction 1", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithDateRestriction 4", bistreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with a group restriction
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithGroupRestriction() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithGroupRestriction, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Restriction");
+        policy.setAction(Constants.READ);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithGroupRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithGroupRestriction 1", availabilityDate, equalTo(threshold));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithGroupRestriction 4", bitstreamAvailabilityDate, equalTo(threshold));
+    }
+
+    /**
+     * Test for an item with no policy
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutPolicy() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithoutPolicy, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        authorizeService.removeAllPolicies(context, bitstream);
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutPolicy, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithoutPolicy 1", availabilityDate, equalTo(threshold));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithoutPolicy 4", bitstreamAvailabilityDate, equalTo(threshold));
+    }
+
+    /**
+     * Test for an item with no primary bitstream
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithoutPrimaryBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithoutPrimaryBitstream, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "first");
+        context.restoreAuthSystemState();
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutPrimaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithoutPrimaryBitstream 1", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithoutPrimaryBitstream 4", bitstreamAvailabilityDate);
+    }
+
+    /**
+     * Test for an item with an embargo for both configurations (current, anonymous) and as a guest
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargoForCurrentOrAnonymousAsGuest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        EPerson admin = ePersonService.create(context);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy adminPolicy = resourcePolicyService.create(context, admin, adminGroup);
+        adminPolicy.setRpName("Open Access For Admin");
+        adminPolicy.setAction(Constants.READ);
+        policies.add(adminPolicy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        // Configuration: current
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 1", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 2", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 3", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 4", bistreamAvailabilityDate, equalTo(startDate));
+        // Configuration: anonymous
+        // getAccessStatusFromItem
+        accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 5", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 6", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 7", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 8", bistreamAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test for an item with an embargo for both configurations (current, anonymous) and as an admin
+     * @throws java.lang.Exception passed through.
+     */
+    @Test
+    public void testWithEmbargoForCurrentOrAnonymousAsAdmin() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithEmbargo, Constants.CONTENT_BUNDLE_NAME);
+        Bitstream bitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        bitstream.setName(context, "primary");
+        bundle.setPrimaryBitstreamID(bitstream);
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        EPerson admin = ePersonService.create(context);
+        Group adminGroup = groupService.findByName(context, Group.ADMIN);
+        ResourcePolicy adminPolicy = resourcePolicyService.create(context, admin, adminGroup);
+        adminPolicy.setRpName("Open Access For Admin");
+        adminPolicy.setAction(Constants.READ);
+        policies.add(adminPolicy);
+        authorizeService.removeAllPolicies(context, bitstream);
+        authorizeService.addPolicies(context, policies, bitstream);
+        context.restoreAuthSystemState();
+        EPerson currentUser = context.getCurrentUser();
+        context.setCurrentUser(admin);
+        // Configuration: current
+        // getAccessStatusFromItem
+        AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 1", status,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate availabilityDate = accessStatus.getAvailabilityDate();
+        assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 2", availabilityDate);
+        // getAccessStatusFromBitstream
+        AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        String bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 3", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 4", bitstreamAvailabilityDate);
+        // Configuration: anonymous
+        accessStatus = helper.getAccessStatusFromItem(context,
+                itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        status = accessStatus.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 5", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        availabilityDate = accessStatus.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 6", availabilityDate, equalTo(startDate));
+        // getAccessStatusFromBitstream
+        accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
+                bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
+        bitstreamStatus = accessStatusBitstream.getStatus();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 7", bitstreamStatus,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+        bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
+        assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 8", bitstreamAvailabilityDate, equalTo(startDate));
+        context.setCurrentUser(currentUser);
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/access/status/OrderedAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/OrderedAccessStatusHelperTest.java
@@ -30,17 +30,19 @@ import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.Before;
 import org.junit.Test;
 
-public class DefaultAccessStatusHelperTest extends AbstractAccessStatusHelperTest {
+public class OrderedAccessStatusHelperTest extends AbstractAccessStatusHelperTest {
+
+    private ConfigurationService configurationService;
 
     @Before
     @Override
     public void init() {
         super.init();
-        ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
         PluginService pluginService = CoreServiceFactory.getInstance().getPluginService();
         configurationService.setProperty(
             "plugin.single.org.dspace.access.status.AccessStatusHelper",
-            "org.dspace.access.status.DefaultAccessStatusHelper"
+            "org.dspace.access.status.OrderedAccessStatusHelper"
         );
         helper = (AccessStatusHelper) pluginService.getSinglePlugin(AccessStatusHelper.class);
     }
@@ -125,10 +127,10 @@ public class DefaultAccessStatusHelperTest extends AbstractAccessStatusHelperTes
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status,
-            equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 1", status,
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
-        assertNull("testWithNoPrimaryAndMultipleBitstreams 1", availabilityDate);
+        assertThat("testWithNoPrimaryAndMultipleBitstreams 2", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream -> first
         AccessStatus accessStatusFirstBitstream = helper.getAccessStatusFromBitstream(context,
                 firstBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
@@ -145,6 +147,61 @@ public class DefaultAccessStatusHelperTest extends AbstractAccessStatusHelperTes
                 equalTo(DefaultAccessStatusHelper.EMBARGO));
         LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getAvailabilityDate();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 6", otherAvailabilityDate, equalTo(startDate));
+    }
+
+    /**
+     * Test that reversing the configured access.status.order flips the precedence: an item with one
+     * open-access and one embargoed bitstream resolves to OPEN_ACCESS instead of the default EMBARGO.
+     * @throws Exception passed through.
+     */
+    @Test
+    public void testReversedAccessStatusOrder() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Bundle bundle = bundleService.create(context, itemWithoutPrimaryAndMultipleBitstreams,
+                Constants.CONTENT_BUNDLE_NAME);
+        bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        Bitstream embargoedBitstream = bitstreamService.create(context, bundle,
+                new ByteArrayInputStream("1".getBytes(StandardCharsets.UTF_8)));
+        List<ResourcePolicy> policies = new ArrayList<>();
+        Group group = groupService.findByName(context, Group.ANONYMOUS);
+        ResourcePolicy policy = resourcePolicyService.create(context, null, group);
+        policy.setRpName("Embargo");
+        policy.setAction(Constants.READ);
+        LocalDate startDate = LocalDate.of(9999, 12, 31);
+        policy.setStartDate(startDate);
+        policies.add(policy);
+        authorizeService.removeAllPolicies(context, embargoedBitstream);
+        authorizeService.addPolicies(context, policies, embargoedBitstream);
+        context.restoreAuthSystemState();
+
+        // With the default order, EMBARGO wins over OPEN_ACCESS
+        AccessStatus defaultStatus = helper.getAccessStatusFromItem(context,
+                itemWithoutPrimaryAndMultipleBitstreams, threshold,
+                DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+        assertThat("testReversedAccessStatusOrder default", defaultStatus.getStatus(),
+                equalTo(DefaultAccessStatusHelper.EMBARGO));
+
+        try {
+            // OPEN_ACCESS now has the highest precedence
+            configurationService.setProperty(
+                    OrderedAccessStatusHelper.ACCESS_STATUS_ORDER_PROPERTY,
+                    String.join(",",
+                            DefaultAccessStatusHelper.OPEN_ACCESS,
+                            DefaultAccessStatusHelper.UNKNOWN,
+                            DefaultAccessStatusHelper.RESTRICTED,
+                            DefaultAccessStatusHelper.EMBARGO));
+
+            AccessStatus reversedStatus = helper.getAccessStatusFromItem(context,
+                    itemWithoutPrimaryAndMultipleBitstreams, threshold,
+                    DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
+            assertThat("testReversedAccessStatusOrder reversed", reversedStatus.getStatus(),
+                    equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+            assertNull("testReversedAccessStatusOrder reversed availability",
+                    reversedStatus.getAvailabilityDate());
+        } finally {
+            configurationService.setProperty(OrderedAccessStatusHelper.ACCESS_STATUS_ORDER_PROPERTY, null);
+        }
     }
 
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemDefaultAccessStatusRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemDefaultAccessStatusRestRepositoryIT.java
@@ -1,0 +1,129 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.time.Period;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.junit.Test;
+
+public class ItemDefaultAccessStatusRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void findAccessStatusForItemBadRequestTest() throws Exception {
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", "1"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findAccessStatusForItemNotFoundTest() throws Exception {
+        UUID fakeUUID = UUID.randomUUID();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", fakeUUID))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findAccessStatusForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", notNullValue()))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoDateForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is = IOUtils.toInputStream("dummy", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+            .withName("test.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", notNullValue()))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        InputStream is2 = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-embargo.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("open.access")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemOrderedAccessStatusRestRepositoryIT.java
@@ -1,0 +1,306 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.time.Period;
+import java.util.UUID;
+
+import org.apache.commons.io.IOUtils;
+import org.dspace.access.status.AccessStatusServiceImpl;
+import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.GroupBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.core.Constants;
+import org.dspace.eperson.Group;
+import org.dspace.services.ConfigurationService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ItemOrderedAccessStatusRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AccessStatusService accessStatusService;
+
+    @Before
+    public void setup() throws Exception {
+        configurationService.setProperty(
+            "plugin.single.org.dspace.access.status.AccessStatusHelper",
+            "org.dspace.access.status.OrderedAccessStatusHelper"
+        );
+        // This is needed because the AccessStatusHelper is a plugin that is created and set in the
+        // AccessStatusServiceImpl.init method. AccessStatusService is a spring managed bean, and the context has
+        // already been created by the time the test method runs.
+        ReflectionTestUtils.setField(accessStatusService, "helper", null);
+        ((AccessStatusServiceImpl) accessStatusService).init();
+    }
+
+    @After
+    public void reset() throws Exception {
+        configurationService.setProperty(
+            "plugin.single.org.dspace.access.status.AccessStatusHelper",
+            "org.dspace.access.status.DefaultAccessStatusHelper"
+        );
+        // This is needed because the AccessStatusHelper is a plugin that is created and set in the
+        // AccessStatusServiceImpl.init method. AccessStatusService is a spring managed bean, and the context has
+        // already been created by the time the test method runs.
+        ReflectionTestUtils.setField(accessStatusService, "helper", null);
+        ((AccessStatusServiceImpl) accessStatusService).init();
+    }
+
+    @Test
+    public void findAccessStatusForItemBadRequestTest() throws Exception {
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", "1"))
+                   .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findAccessStatusForItemNotFoundTest() throws Exception {
+        UUID fakeUUID = UUID.randomUUID();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", fakeUUID))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findAccessStatusWithMetatdataOnlyForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Owning Collection")
+                                                       .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+                               .withTitle("Test item")
+                               .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.status", is("metadata.only")))
+                   .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+            .withName("test.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("open.access")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                       .withName("Owning Collection")
+                                                       .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+                               .withTitle("Test item")
+                               .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+                                             .withName(Constants.DEFAULT_BUNDLE_NAME)
+                                             .build();
+        InputStream is = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is)
+                                              .withName("test.pdf")
+                                              .withMimeType("application/pdf")
+                                              .withEmbargoPeriod(Period.ofMonths(6))
+                                              .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.status", is("embargo")))
+                   .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithRestrictedForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        GroupBuilder internalGroupBuilder = GroupBuilder.createGroup(context)
+            .withName("Internal Group");
+        Group internalGroup = internalGroupBuilder.build();
+        InputStream is2 = IOUtils.toInputStream("restrictedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-restricted.pdf")
+            .withMimeType("application/pdf")
+            .withReaderGroup(internalGroup)
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("restricted")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        InputStream is2 = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-embargo.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("embargo")))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithRestrictedAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        GroupBuilder internalGroupBuilder = GroupBuilder.createGroup(context)
+            .withName("Internal Group");
+        Group internalGroup = internalGroupBuilder.build();
+        InputStream is2 = IOUtils.toInputStream("restrictedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-restricted.pdf")
+            .withMimeType("application/pdf")
+            .withReaderGroup(internalGroup)
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("restricted")))
+            .andExpect(jsonPath("$.embargoDate", nullValue()));
+    }
+
+    @Test
+    public void findAccessStatusWithEmbargoAndRestrictedAndOpenAccessForItemTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+        Collection owningCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Owning Collection")
+            .build();
+        Item item = ItemBuilder.createItem(context, owningCollection)
+            .withTitle("Test item")
+            .build();
+        Bundle originalBundle = BundleBuilder.createBundle(context, item)
+            .withName(Constants.DEFAULT_BUNDLE_NAME)
+            .build();
+        InputStream is1 = IOUtils.toInputStream("openaccesstext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is1)
+            .withName("test-open.pdf")
+            .withMimeType("application/pdf")
+            .build();
+        GroupBuilder internalGroupBuilder = GroupBuilder.createGroup(context)
+            .withName("Internal Group");
+        Group internalGroup = internalGroupBuilder.build();
+        InputStream is2 = IOUtils.toInputStream("restrictedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is2)
+            .withName("test-restricted.pdf")
+            .withMimeType("application/pdf")
+            .withReaderGroup(internalGroup)
+            .build();
+        InputStream is3 = IOUtils.toInputStream("embargoedtext", "utf-8");
+        BitstreamBuilder.createBitstream(context, originalBundle, is3)
+            .withName("test-embargo.pdf")
+            .withMimeType("application/pdf")
+            .withEmbargoPeriod(Period.ofMonths(6))
+            .build();
+        context.restoreAuthSystemState();
+        getClient().perform(get("/api/core/items/{uuid}/accessStatus", item.getID()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status", is("embargo")))
+            .andExpect(jsonPath("$.embargoDate", notNullValue()));
+    }
+
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1197,6 +1197,12 @@ access.status.for-user.bitstream = current
 # bitstream (or first bitstream in the original bundles if no primary file is specified).
 plugin.single.org.dspace.access.status.AccessStatusHelper = org.dspace.access.status.DefaultAccessStatusHelper
 
+# Ordered list of access statuses used by the OrderedAccessStatusHelper to select the access status
+# with the highest precedence when there are multiple bitstreams in the original bundle.
+# The status at the first position has the highest precedence. Every status must be present.
+# Defaults to: embargo, restricted, unknown, open.access
+# access.status.order = embargo, restricted, unknown, open.access
+
 #### Checksum Checker Settings ####
 # Default dispatcher in case none specified
 plugin.single.org.dspace.checker.BitstreamDispatcher=org.dspace.checker.SimpleDispatcher


### PR DESCRIPTION
## References
* Fixes #12345 

## Description

In order to better support multiple bitstreams in the original bundle with different access policies, a new AccessStatusHelper implementation has been added named OrderedAccessStatusHelper.

The new helper provides a way to ensure that the most conservative access status is chosen for an item which has multiple bitstreams with different access policies.

## Instructions for Reviewers

OrderedAccessStatusHelper extends DefaultAccessStatusHelper and overrides the logic for computing the AccessStatus object for an Item. The logic is to iterate over all the bitstreams in the Orginal bundle, create AccessStatus objects for each, then return the AccessStatus with the highest precedence as determine by the matching value in ORDERED_BITSTREAM_STATUSES list.

The unit and integration tests for DefaultAccessStatusHelper were refactored so that tests could be run for both DefaultAccessStatusHelper and OrderedAccessStatusHelper where appropriate, along with some new tests for OrderedAccessStatusHelper. See ItemDefaultAccessStatusRestRepositoryIT and ItemOrderedAccessStatusRestRepositoryIT for integration tests.

In order to do manual testing setup your `local.cfg` with 
```
plugin.single.org.dspace.access.status.AccessStatusHelper = org.dspace.access.status.OrderedAccessStatusHelper
```

Note that you can set `access.status.order` to change the precedence which has the default:
```
access.status.order = embargo, restricted, unknown, open.access

```

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
