### PR TITLE
Fix missing OAI identifier interpolation on config change

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/services/api/config/ConfigurationService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/api/config/ConfigurationService.java
@@ -15,4 +15,6 @@ public interface ConfigurationService {
     boolean getBooleanProperty(String module, String key, boolean defaultValue);
 
     boolean getBooleanProperty(String key, boolean defaultValue);
+
+    void ensureRequiredConfiguration();
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/config/DSpaceConfigurationService.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/config/DSpaceConfigurationService.java
@@ -20,12 +20,18 @@ public class DSpaceConfigurationService implements ConfigurationService {
      * Initialize the OAI Configuration Service
      */
     public DSpaceConfigurationService() {
-        // Check the DSpace ConfigurationService for required OAI-PMH settings.
-        // If they do not exist, set sane defaults as needed.
+        ensureRequiredConfiguration();
+    }
 
-        // Per OAI Spec, "oai.identifier.prefix" should be the hostname / domain name of the site.
-        // This configuration is needed by the [dspace]/config/crosswalks/oai/description.xml template, so if
-        // unspecified we will dynamically set it to the hostname of the "dspace.ui.url" configuration.
+    /**
+     * Check the DSpace ConfigurationService for required OAI-PMH settings.
+     * If they do not exist, set sane defaults as needed.
+     * <br>
+     * Per OAI Spec, "oai.identifier.prefix" should be the hostname / domain name of the site.
+     * This configuration is needed by the [dspace]/config/crosswalks/oai/description.xml template, so if
+     * unspecified we will dynamically set it to the hostname of the "dspace.ui.url" configuration.
+     */
+    public void ensureRequiredConfiguration() {
         if (!configurationService.hasProperty("oai.identifier.prefix")) {
             configurationService.setProperty("oai.identifier.prefix",
                                              Utils.getHostName(configurationService.getProperty("dspace.ui.url")));

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceRepositoryConfiguration.java
@@ -133,6 +133,7 @@ public class DSpaceRepositoryConfiguration implements RepositoryConfiguration {
 
     @Override
     public List<String> getDescription() {
+        configurationService.ensureRequiredConfiguration();
         List<String> result = new ArrayList<String>();
         String descriptionFile = configurationService.getProperty("oai.description.file");
         if (descriptionFile == null) {

--- a/dspace-services/src/main/java/org/dspace/services/ConfigurationService.java
+++ b/dspace-services/src/main/java/org/dspace/services/ConfigurationService.java
@@ -251,6 +251,8 @@ public interface ConfigurationService {
      * Set a configuration property (setting) in the system.
      * Type is not important here since conversion happens automatically
      * when properties are requested.
+     * <br>
+     * Note: use with care, the value will be reset when the configuration is reloaded!
      *
      * @param name  the property name
      * @param value the property value (set this to null to clear out the property)


### PR DESCRIPTION
Fixes https://github.com/DSpace/DSpace/issues/12505

## Description
When `dspace.cfg` is updated while Tomcat is running, the `oai.identifier.prefix` fallback from `dspace-oai`'s `DSpaceConfigurationService` gets cleared out. If the cached Identify request gets invalidated after this, it will be regenerated with `${oai.identifier.prefix}` in place, instead of the interpolated value.

We re-initialize this fallback when re-creating the Identify content to account for this.

## Instructions for Reviewers

Confirm that you can no longer replicate the original issue:
- Run a local DSpace instance
- Go to `http://localhost:8080/server/oai` and select `Identify` for any context
    - It should use `localhost` for its OAI prefix
- Make a random change to `dspace.cfg` in the "live" DSpace directory
- Run `./dspace oai clean-cache`    
- Reload the OAI Identify page
    - It should use `localhost` for its OAI prefix (unlike current `main`)

## Discussion

This is the only place where `setProperty` is used outside of tests, so this seems reasonable.

If we want to support "dynamic default" better we could also update the `dspace-services` `ConfigurationService` interface to add a method to define them in a way where we can re-apply them after configuration is reloaded (e.g. with an event listener that calls a list of methods that we can add to at will)

I'd argue that we shouldn't encourage this and keep the configuration system simple instead.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
