### PR TITLE
Fix #12409: double escaped characters in oai

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/util/ItemUtils.java
@@ -18,7 +18,6 @@ import java.util.List;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import com.lyncode.xoai.util.Base64Utils;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.factory.UtilServiceFactory;
@@ -160,7 +159,7 @@ public class ItemUtils {
 
     /**
      * Sanitizes a string to remove characters that are invalid
-     * in XML 1.0 using the Apache Commons Text library.
+     * in XML 1.0 using a hardcoded regex to avoid escaping special characters twice.
      * @param value The string to sanitize.
      * @return A sanitized string, or null if the input was null.
      */
@@ -168,7 +167,15 @@ public class ItemUtils {
         if (value == null) {
             return null;
         }
-        return StringEscapeUtils.escapeXml10(value);
+
+        // Strips characters that are illegal in XML 1.0 (per the XML spec, https://www.w3.org/TR/xml/#charsets)
+        // The allowed character set is: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+        // This regex matches everything OUTSIDE that allowed set, i.e. it removes:
+        //   - C0 control characters other than tab (\x09), LF (\x0A), and CR (\x0D)
+        //   (i.e. \x00-\x08, \x0B, \x0C, \x0E-\x1F)
+        //   - The UTF-16 surrogate range \uD800-\uDFFF
+        //   - The non-characters \uFFFE and \uFFFF
+        return value.replaceAll("[^\\x09\\x0A\\x0D\\x20-\\uD7FF\\uE000-\\uFFFD]", "");
     }
 
     /**


### PR DESCRIPTION
## References
Fixes #12409 

## Description
Characters were escaped twice because of the unnecessary use of `sanatize()`. 
Special characters are automatically escaped using the `com.lyncode.xoai.dataprovider.xml.xoai` `Metadata#write()` method.

## Instructions for Reviewers
Create an item that has the value `p < 0.05` for metadata field `dc.description`.
Request it though the oai interface and verify the escaped value is `p &lt; 0.05` and NOT the double escaped value `p &amp;lt; 0.05`

List of changes in this PR:
Removed the unnecessary `sanatize()` call.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
