### PR TITLE
Compress rotated logs by default

### DIFF
--- a/dspace/config/log4j2-cli.xml
+++ b/dspace/config/log4j2-cli.xml
@@ -23,7 +23,7 @@
     <Appenders>
         <!-- A1 is for most DSpace activity -->
         <Appender name='A1'
-                  filePattern="${log.dir}/dspace-cli.log-%d{yyyy-MM-dd}"
+                  filePattern="${log.dir}/dspace-cli.log-%d{yyyy-MM-dd}.gz"
                   type='RollingFile'
                   fileName='${log.dir}/dspace-cli.log'
         >

--- a/dspace/config/log4j2.xml
+++ b/dspace/config/log4j2.xml
@@ -23,7 +23,7 @@
     <Appenders>
         <!-- A1 is for most DSpace activity -->
         <Appender name='A1'
-                  filePattern="${log.dir}/dspace.log-%d{yyyy-MM-dd}"
+                  filePattern="${log.dir}/dspace.log-%d{yyyy-MM-dd}.gz"
                   type='RollingFile'
                   fileName='${log.dir}/dspace.log'
 


### PR DESCRIPTION
## Description
This PR enables automatic compression of rotated logs.

It's been documented that DSpace produces a lot of logging information, which can fill the free space in disk for systems where operators do not master the configuration options of DSpace yet:

* https://groups.google.com/g/dspace-tech/c/2_eUbQI7AxE/m/XzNdM1FKAgAJ
* https://groups.google.com/g/dspace-tech/c/lRr1Nj6TLd8/m/ExUdpzXbAwAJ

This PR simply changes the default to a safer value. See the log4j documentation for further information: https://logging.apache.org/log4j/2.x/manual/appenders/rolling-file.html#RolloverStrategy-compress

Experienced operators can simply tweak this default (or move to other solutions, such as logrotate).

## Instructions for Reviewers

Simply run DSpace, and see how log files are "gzipped" when rotated.

To force a rotation, reviewers may want to tweak the "filePattern" property during testing to force a rotation on a minute basis. To do so, change:

```
filePattern="${log.dir}/dspace.log-%d{yyyy-MM-dd}.gz"
```
to 
```
filePattern="${log.dir}/dspace.log-%d{yyyy-MM-dd-HH-mm}.gz"
```

in `log4j2.xml` and/or `log4j2-cli.xml`

Since rotating on a minute basis is a too short period, restarting the server may help to force a rotation of the logs.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
