### PR TITLE
Fix process cleanup startup timing

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ProcessRestRepository.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import jakarta.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.LogManager;
@@ -39,6 +38,8 @@ import org.dspace.scripts.ProcessQueryParameterContainer;
 import org.dspace.scripts.Process_;
 import org.dspace.scripts.service.ProcessService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -67,7 +68,10 @@ public class ProcessRestRepository extends DSpaceRestRepository<ProcessRest, Int
     @Autowired
     private EPersonService epersonService;
 
-    @PostConstruct
+    /**
+     * Marks any processes left running before the previous shutdown as failed after the application is ready.
+     */
+    @EventListener(ApplicationReadyEvent.class)
     public void init() throws SQLException, AuthorizeException, IOException {
         Context context = new Context();
         processService.failRunningProcesses(context);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/repository/ProcessRestRepositoryTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/repository/ProcessRestRepositoryTest.java
@@ -1,0 +1,35 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Method;
+
+import jakarta.annotation.PostConstruct;
+import org.junit.Test;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+
+/**
+ * Unit tests for {@link ProcessRestRepository}.
+ */
+public class ProcessRestRepositoryTest {
+
+    @Test
+    public void testInitRunsAfterApplicationReady() throws Exception {
+        Method init = ProcessRestRepository.class.getMethod("init");
+        EventListener eventListener = init.getAnnotation(EventListener.class);
+
+        assertNotNull(eventListener);
+        assertArrayEquals(new Class<?>[] { ApplicationReadyEvent.class }, eventListener.value());
+        assertNull(init.getAnnotation(PostConstruct.class));
+    }
+}


### PR DESCRIPTION
## References

Fixes #12503.

No corresponding DSpace/RestContract PR is needed; this change does not alter the REST API contract.

## Description

Move failed-process cleanup from `@PostConstruct` to `ApplicationReadyEvent` so the cleanup runs after the Spring Boot application is ready.

## Instructions for Reviewers

List of changes in this PR:
* `ProcessRestRepository.init()` now runs on `ApplicationReadyEvent` instead of during bean post-construction.
* The cleanup still marks stale `RUNNING` processes as failed and writes the existing error message.
* A unit test verifies the lifecycle hook uses `ApplicationReadyEvent` and no longer uses `@PostConstruct`.

Suggested review/testing:
* Review the lifecycle annotation change in `ProcessRestRepository`.
* Run the focused test:
  `mvn --no-transfer-progress -pl dspace-server-webapp -am -DskipUnitTests=false -Dtest=org.dspace.app.rest.repository.ProcessRestRepositoryTest -DfailIfNoTests=false test`
* Run Checkstyle for the module:
  `mvn --no-transfer-progress -pl dspace-server-webapp -DskipTests -DskipUnitTests=true -DskipIntegrationTests=true checkstyle:check`

Validation run locally:
* `mvn --no-transfer-progress -pl dspace-server-webapp -am -DskipUnitTests=false -Dtest=org.dspace.app.rest.repository.ProcessRestRepositoryTest -DfailIfNoTests=false test` - BUILD SUCCESS; 1 test, 0 failures/errors/skips.
* `mvn --no-transfer-progress -pl dspace-server-webapp -DskipTests -DskipUnitTests=true -DskipIntegrationTests=true checkstyle:check` - BUILD SUCCESS; 0 Checkstyle violations.
* `git diff HEAD~1..HEAD --check` - passed.
* `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` - no leaks found.

I did not run the full integration suite; this change is covered by the focused lifecycle annotation test and module Checkstyle.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. N/A: this PR does not add or modify public API methods or classes.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. N/A: no dependency changes.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. N/A: no REST contract change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. N/A: no configuration changes.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
