### PR TITLE
[Port dspace-8_x] Fix S3 leaks when performing a HEAD request

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
+++ b/dspace-api/src/main/java/org/dspace/app/requestitem/RequestItemEmailNotifier.java
@@ -9,7 +9,9 @@
 package org.dspace.app.requestitem;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.annotation.ManagedBean;
@@ -186,6 +188,7 @@ public class RequestItemEmailNotifier {
         email.setSubject(subject);
         email.addRecipient(ri.getReqEmail());
         // Attach bitstreams.
+        List<InputStream> bitstreamInputStreams = new ArrayList<>();
         try {
             if (ri.isAccept_request()) {
                 if (ri.isAllfiles()) {
@@ -200,11 +203,13 @@ public class RequestItemEmailNotifier {
                                 // #8636 Anyone receiving the email can respond to the
                                 // request without authenticating into DSpace
                                 context.turnOffAuthorisationSystem();
+                                InputStream is = bitstreamService.retrieve(context, bitstream);
                                 email.addAttachment(
-                                        bitstreamService.retrieve(context, bitstream),
+                                        is,
                                         bitstream.getName(),
                                         bitstream.getFormat(context).getMIMEType());
                                 context.restoreAuthSystemState();
+                                bitstreamInputStreams.add(is);
                             }
                         }
                     }
@@ -212,10 +217,12 @@ public class RequestItemEmailNotifier {
                     Bitstream bitstream = ri.getBitstream();
                     // #8636 Anyone receiving the email can respond to the request without authenticating into DSpace
                     context.turnOffAuthorisationSystem();
-                    email.addAttachment(bitstreamService.retrieve(context, bitstream),
+                    InputStream is = bitstreamService.retrieve(context, bitstream);
+                    email.addAttachment(is,
                             bitstream.getName(),
                             bitstream.getFormat(context).getMIMEType());
                     context.restoreAuthSystemState();
+                    bitstreamInputStreams.add(is);
                 }
                 email.send();
             } else {
@@ -231,6 +238,10 @@ public class RequestItemEmailNotifier {
             LOG.warn(LogHelper.getHeader(context,
                     "error_mailing_requestItem", e.getMessage()));
             throw new IOException("Reply not sent:  " + e.getMessage());
+        } finally {
+            for (InputStream bitstreamInputStream : bitstreamInputStreams) {
+                bitstreamInputStream.close();
+            }
         }
         LOG.info(LogHelper.getHeader(context,
                 "sent_attach_requestItem", "token={}"), ri.getToken());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -92,7 +92,7 @@ public class BitstreamResource extends AbstractResource {
     public InputStream getInputStream() throws IOException {
         fetchDocument();
 
-        return document.inputStream();
+        return document.getInputstream();
     }
 
     @Override
@@ -110,7 +110,7 @@ public class BitstreamResource extends AbstractResource {
     public String getChecksum() {
         fetchDocument();
 
-        return document.etag();
+        return document.getEtag();
     }
 
     private void fetchDocument() {
@@ -123,13 +123,13 @@ public class BitstreamResource extends AbstractResource {
             if (shouldGenerateCoverPage) {
                 var coverPage = getCoverpageByteArray(context, bitstream);
 
-                this.document = new BitstreamDocument(etag(bitstream),
+                this.document = new BitstreamDocumentCoverPage(etag(bitstream),
                         coverPage.length,
                         new ByteArrayInputStream(coverPage));
             } else {
-                this.document = new BitstreamDocument(bitstream.getChecksum(),
+                this.document = new BitstreamDocumentInputstream(bitstream.getChecksum(),
                         bitstream.getSizeBytes(),
-                        bitstreamService.retrieve(context, bitstream));
+                        bitstream.getID());
             }
         } catch (SQLException | AuthorizeException | IOException e) {
             throw new RuntimeException(e);
@@ -158,12 +158,63 @@ public class BitstreamResource extends AbstractResource {
     }
 
     private Context initializeContext() throws SQLException {
-        Context context = new Context();
+        Context context = new Context(Context.Mode.READ_ONLY);
         EPerson currentUser = ePersonService.find(context, currentUserUUID);
         context.setCurrentUser(currentUser);
         currentSpecialGroups.forEach(context::setSpecialGroup);
         return context;
     }
 
-    private record BitstreamDocument(String etag, long length, InputStream inputStream) {}
+    protected abstract class BitstreamDocument {
+        private final String etag;
+        private final long length;
+
+        protected BitstreamDocument(String etag, long length) {
+            this.etag = etag;
+            this.length = length;
+        }
+
+        abstract InputStream getInputstream();
+
+        public String getEtag() {
+            return etag;
+        }
+
+        public long length() {
+            return length;
+        }
+    }
+
+    protected class BitstreamDocumentInputstream extends BitstreamDocument {
+        protected final UUID bitstreamUUID;
+
+        public BitstreamDocumentInputstream(String etag, long length, UUID bitstreamUUID) {
+            super(etag, length);
+            this.bitstreamUUID = bitstreamUUID;
+        }
+
+        @Override
+        public InputStream getInputstream() {
+            try (Context context = initializeContext()) {
+                return bitstreamService.retrieve(context, bitstreamService.find(context, bitstreamUUID));
+            } catch (SQLException | AuthorizeException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    protected class BitstreamDocumentCoverPage extends BitstreamDocument {
+        private final ByteArrayInputStream coverpage;
+
+        public BitstreamDocumentCoverPage(String etag, long length, ByteArrayInputStream byteArrayInputStream) {
+            super(etag, length);
+            this.coverpage = byteArrayInputStream;
+        }
+
+        @Override
+        public InputStream getInputstream() {
+            return coverpage;
+        }
+    }
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/BitstreamResource.java
@@ -28,6 +28,7 @@ import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.EPersonService;
 import org.dspace.utils.DSpace;
 import org.springframework.core.io.AbstractResource;
+import org.springframework.core.io.InputStreamSource;
 import org.springframework.util.DigestUtils;
 
 /**
@@ -92,7 +93,7 @@ public class BitstreamResource extends AbstractResource {
     public InputStream getInputStream() throws IOException {
         fetchDocument();
 
-        return document.getInputstream();
+        return document.getInputStream();
     }
 
     @Override
@@ -165,7 +166,7 @@ public class BitstreamResource extends AbstractResource {
         return context;
     }
 
-    protected abstract class BitstreamDocument {
+    protected abstract class BitstreamDocument implements InputStreamSource {
         private final String etag;
         private final long length;
 
@@ -173,8 +174,6 @@ public class BitstreamResource extends AbstractResource {
             this.etag = etag;
             this.length = length;
         }
-
-        abstract InputStream getInputstream();
 
         public String getEtag() {
             return etag;
@@ -194,7 +193,7 @@ public class BitstreamResource extends AbstractResource {
         }
 
         @Override
-        public InputStream getInputstream() {
+        public InputStream getInputStream() throws IOException {
             try (Context context = initializeContext()) {
                 return bitstreamService.retrieve(context, bitstreamService.find(context, bitstreamUUID));
             } catch (SQLException | AuthorizeException | IOException e) {
@@ -212,7 +211,7 @@ public class BitstreamResource extends AbstractResource {
         }
 
         @Override
-        public InputStream getInputstream() {
+        public InputStream getInputStream() {
             return coverpage;
         }
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -89,6 +89,7 @@ import org.dspace.statistics.SolrLoggerServiceImpl;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.dspace.statistics.service.SolrLoggerService;
 import org.dspace.storage.bitstore.factory.StorageServiceFactory;
+import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1521,4 +1522,173 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
         }
     }
 
+    @Test
+    public void bitstreamInputStreamClosesWithGetRequestTest() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after GET request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithHeadRequestTest() throws Exception {
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after HEAD request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithGetRequestAndCitationPageEnabledTest() throws Exception {
+        configurationService.setProperty("citation-page.enable_globally", true);
+        citationDocumentService.afterPropertiesSet();
+
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(get("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after GET request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
+
+    @Test
+    public void bitstreamInputStreamClosesWithHeadRequestAndCitationPageEnabledTest() throws Exception {
+        configurationService.setProperty("citation-page.enable_globally", true);
+        citationDocumentService.afterPropertiesSet();
+
+        InputStream realStream = new ByteArrayInputStream("abc".getBytes());
+        InputStream spyStream = Mockito.spy(realStream);
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, community).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, realStream).build();
+        context.restoreAuthSystemState();
+
+        BitstreamStorageService originalService =
+                StorageServiceFactory.getInstance().getBitstreamStorageService();
+        BitstreamStorageService spyService = spy(originalService);
+
+        doReturn(spyStream).when(spyService).retrieve(any(), eq(bitstream));
+
+        ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", spyService);
+
+        try {
+            getClient().perform(head("/api/core/bitstreams/" + bitstream.getID() + "/content"))
+                       .andExpect(status().isOk());
+
+            boolean bitstreamRetrieved = Mockito.mockingDetails(spyService)
+                                                .getInvocations().stream()
+                                                .filter(i -> i.getMethod().getName().equals("retrieve"))
+                                                .mapToInt(i -> 1)
+                                                .sum() > 0;
+
+            if (bitstreamRetrieved) {
+                Mockito.verify(spyStream, times(1)
+                               .description("InputStream should have been closed after HEAD request"))
+                       .close();
+            }
+        } finally {
+            ReflectionTestUtils.setField(bitstreamService, "bitstreamStorageService", originalService);
+        }
+    }
 }


### PR DESCRIPTION
## References
backport of #12249 to dspace-8_x

## Changes compared to #12249 
Removed 2 tests from `BitstreamRestControllerIT` that were testing functionalities not yet implemented in dspace-8_x.
Removed 2 tests from `RequestItemEmailNotifierTest` since I couldn't quickly find a way to port them.
