### PR TITLE
Velocity template engine configuration improvements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -175,9 +175,6 @@ public class Email {
 
     private static final Logger LOG = LogManager.getLogger();
 
-    private static final ConfigurationService configurationService =
-            DSpaceServicesFactory.getInstance().getConfigurationService();
-
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "Email";
 
@@ -200,6 +197,13 @@ public class Email {
         template = null;
         replyTo = null;
         charset = null;
+    }
+
+    /**
+     * Get configuration service
+     */
+    private static ConfigurationService getConfigurationService() {
+        return DSpaceServicesFactory.getInstance().getConfigurationService();
     }
 
     /**
@@ -343,7 +347,7 @@ public class Email {
     public void send() throws MessagingException, IOException {
         build();
 
-        if (isMailServerDisabled(configurationService)) {
+        if (isMailServerDisabled(getConfigurationService())) {
             LOG.info(format(message, body));
         } else {
             Transport.send(message);
@@ -372,11 +376,11 @@ public class Email {
         }
 
         // Get the mail configuration properties
-        String from = configurationService.getProperty("mail.from.address");
+        String from = getConfigurationService().getProperty("mail.from.address");
 
         // If no character set specified, attempt to retrieve a default
         if (charset == null) {
-            charset = configurationService.getProperty("mail.charset");
+            charset = getConfigurationService().getProperty("mail.charset");
         }
 
         // Get session
@@ -386,10 +390,10 @@ public class Email {
         message = new MimeMessage(session);
 
         // Get the mail configuration properties for catchAllRecipient
-        String[] catchAllRecipient = getCatchAllRecipient(configurationService);
+        String[] catchAllRecipient = getCatchAllRecipient(getConfigurationService());
 
         // Get headers defined by the template.
-        String[] templateHeaders = configurationService.getArrayProperty("mail.message.headers");
+        String[] templateHeaders = getConfigurationService().getArrayProperty("mail.message.headers");
 
         // Format the mail message body
         VelocityContext vctx = new VelocityContext();

--- a/dspace-api/src/main/java/org/dspace/core/Email.java
+++ b/dspace-api/src/main/java/org/dspace/core/Email.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Properties;
 
 import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;
@@ -44,18 +43,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.Velocity;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
-import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.apache.velocity.runtime.resource.util.StringResourceRepository;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
- * Builder representing an e-mail message.  The {@link send} method causes the
+ * Builder representing an e-mail message.  The {@link #send} method causes the
  * assembled message to be formatted and sent.
  * <p>
  * Typical use:
@@ -72,7 +69,7 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * Apache Velocity</a>.  They may contain VTL directives and property
  * placeholders.
  * <p>
- * {@link addArgument(string)} adds a property to the {@code params} array
+ * {@link #addArgument(Object)} adds a property to the {@code params} array
  * in the Velocity context, which can be used to replace placeholder tokens
  * in the message.  These arguments are indexed by number in the order they were
  * added to the message.
@@ -80,9 +77,9 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * The DSpace configuration properties are also available to templates as the
  * array {@code config}, indexed by name.  Example:  {@code ${config.get('dspace.name')}}
  * <p>
- * Recipients and attachments may be added as needed.  See {@link addRecipient},
- * {@link addAttachment(File, String)}, and
- * {@link addAttachment(InputStream, String, String)}.
+ * Recipients and attachments may be added as needed.  See {@link #addRecipient},
+ * {@link #addAttachment(File, String)}, and
+ * {@link #addAttachment(InputStream, String, String)}.
  * <p>
  * Headers such as Subject may be supplied by the template, by defining them
  * using the VTL directive {@code #set()}.  Only headers named in the DSpace
@@ -125,8 +122,8 @@ import org.dspace.services.factory.DSpaceServicesFactory;
  * </pre>
  * <p>
  * There are two ways to load a message body.  One can create an instance of
- * {@link Email} and call {@link setContent} on it, passing the body as a String.  Or
- * one can use the static factory method {@link getEmail} to load a file by its
+ * {@link Email} and call {@link #setContent} on it, passing the body as a String.  Or
+ * one can use the static factory method {@link #getEmail} to load a file by its
  * complete filesystem path.  In either case the text will be loaded into a
  * Velocity template.
  *
@@ -178,20 +175,11 @@ public class Email {
 
     private static final Logger LOG = LogManager.getLogger();
 
+    private static final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "Email";
-    private static final Properties VELOCITY_PROPERTIES = new Properties();
-    static {
-        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADERS, "string");
-        VELOCITY_PROPERTIES.put("resource.loader.string.description",
-                "Velocity StringResource loader");
-        VELOCITY_PROPERTIES.put("resource.loader.string.class",
-                StringResourceLoader.class.getName());
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.name",
-                RESOURCE_REPOSITORY_NAME);
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.static",
-                "false");
-    }
 
     /** Velocity template for a message body */
     private Template template;
@@ -236,7 +224,7 @@ public class Email {
         arguments.clear();
 
         VelocityEngine templateEngine = new VelocityEngine();
-        templateEngine.init(VELOCITY_PROPERTIES);
+        templateEngine.init(Utils.getSecureVelocityProperties(RESOURCE_REPOSITORY_NAME));
 
         StringResourceRepository repo = (StringResourceRepository)
                 templateEngine.getApplicationAttribute(RESOURCE_REPOSITORY_NAME);
@@ -355,8 +343,7 @@ public class Email {
     public void send() throws MessagingException, IOException {
         build();
 
-        ConfigurationService config = DSpaceServicesFactory.getInstance().getConfigurationService();
-        if (isMailServerDisabled(config)) {
+        if (isMailServerDisabled(configurationService)) {
             LOG.info(format(message, body));
         } else {
             Transport.send(message);
@@ -369,7 +356,7 @@ public class Email {
      * {@code mail.message.headers} then that name and its value will be added
      * to the message's headers.
      *
-     * <p>"subject" is treated specially:  if {@link setSubject()} has not been
+     * <p>"subject" is treated specially:  if {@link #setSubject} has not been
      * called, the value of any "subject" property will be used as if setSubject
      * had been called with that value.  Thus a template may define its subject,
      * but the caller may override it.
@@ -384,15 +371,12 @@ public class Email {
             throw new MessagingException("Email has no body");
         }
 
-        ConfigurationService config
-                = DSpaceServicesFactory.getInstance().getConfigurationService();
-
         // Get the mail configuration properties
-        String from = config.getProperty("mail.from.address");
+        String from = configurationService.getProperty("mail.from.address");
 
         // If no character set specified, attempt to retrieve a default
         if (charset == null) {
-            charset = config.getProperty("mail.charset");
+            charset = configurationService.getProperty("mail.charset");
         }
 
         // Get session
@@ -402,14 +386,16 @@ public class Email {
         message = new MimeMessage(session);
 
         // Get the mail configuration properties for catchAllRecipient
-        String[] catchAllRecipient = getCatchAllRecipient(config);
+        String[] catchAllRecipient = getCatchAllRecipient(configurationService);
 
         // Get headers defined by the template.
-        String[] templateHeaders = config.getArrayProperty("mail.message.headers");
+        String[] templateHeaders = configurationService.getArrayProperty("mail.message.headers");
 
         // Format the mail message body
         VelocityContext vctx = new VelocityContext();
-        vctx.put("config", new UnmodifiableConfigurationService(config));
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        vctx.put("config", Utils.getAllowedTemplateConfig());
         vctx.put("params", Collections.unmodifiableList(arguments));
 
         StringWriter writer = new StringWriter();
@@ -758,33 +744,6 @@ public class Email {
         @Override
         public OutputStream getOutputStream() throws IOException {
             throw new IOException("Cannot write to this read-only resource");
-        }
-    }
-
-    /**
-     * Wrap ConfigurationService to prevent templates from modifying
-     * the configuration.
-     */
-    public static class UnmodifiableConfigurationService {
-        private final ConfigurationService configurationService;
-
-        /**
-         * Swallow an instance of ConfigurationService.
-         *
-         * @param cs the real instance, to be wrapped.
-         */
-        public UnmodifiableConfigurationService(ConfigurationService cs) {
-            configurationService = cs;
-        }
-
-        /**
-         * Look up a key in the actual ConfigurationService.
-         *
-         * @param key to be looked up in the DSpace configuration.
-         * @return whatever value ConfigurationService associates with {@code key}.
-         */
-        public String get(String key) {
-            return configurationService.getProperty(key);
         }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/LDN.java
+++ b/dspace-api/src/main/java/org/dspace/core/LDN.java
@@ -18,7 +18,6 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 import jakarta.mail.MessagingException;
 import org.apache.commons.lang3.StringUtils;
@@ -26,15 +25,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
-import org.apache.velocity.app.Velocity;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
-import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.apache.velocity.runtime.resource.util.StringResourceRepository;
-import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
 
 /**
  * Class representing an LDN message json
@@ -57,18 +52,6 @@ public class LDN {
 
     /** Velocity template settings. */
     private static final String RESOURCE_REPOSITORY_NAME = "LDN";
-    private static final Properties VELOCITY_PROPERTIES = new Properties();
-    static {
-        VELOCITY_PROPERTIES.put(Velocity.RESOURCE_LOADERS, "string");
-        VELOCITY_PROPERTIES.put("resource.loader.string.description",
-                "Velocity StringResource loader");
-        VELOCITY_PROPERTIES.put("resource.loader.string.class",
-                StringResourceLoader.class.getName());
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.name",
-                RESOURCE_REPOSITORY_NAME);
-        VELOCITY_PROPERTIES.put("resource.loader.string.repository.static",
-                "false");
-    }
 
     /** Velocity template for the message*/
     private Template template;
@@ -112,14 +95,13 @@ public class LDN {
      * @throws IOException        if IO error
      */
     public String generateLDNMessage() {
-        ConfigurationService config
-            = DSpaceServicesFactory.getInstance().getConfigurationService();
-
         VelocityEngine templateEngine = new VelocityEngine();
-        templateEngine.init(VELOCITY_PROPERTIES);
+        templateEngine.init(Utils.getSecureVelocityProperties(RESOURCE_REPOSITORY_NAME));
 
         VelocityContext vctx = new VelocityContext();
-        vctx.put("config", new LDN.UnmodifiableConfigurationService(config));
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        vctx.put("config", Utils.getAllowedTemplateConfig());
         vctx.put("params", Collections.unmodifiableList(arguments));
 
         if (null == template) {
@@ -181,32 +163,5 @@ public class LDN {
         LDN ldn = new LDN();
         ldn.setContent(ldnMessageFile, contentBuffer.toString());
         return ldn;
-    }
-
-    /**
-     * Wrap ConfigurationService to prevent templates from modifying
-     * the configuration.
-     */
-    public static class UnmodifiableConfigurationService {
-        private final ConfigurationService configurationService;
-
-        /**
-         * Swallow an instance of ConfigurationService.
-         *
-         * @param cs the real instance, to be wrapped.
-         */
-        public UnmodifiableConfigurationService(ConfigurationService cs) {
-            configurationService = cs;
-        }
-
-        /**
-         * Look up a key in the actual ConfigurationService.
-         *
-         * @param key to be looked up in the DSpace configuration.
-         * @return whatever value ConfigurationService associates with {@code key}.
-         */
-        public String get(String key) {
-            return configurationService.getProperty(key);
-        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
@@ -527,8 +528,11 @@ public final class Utils {
         List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
                     "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
         return allowedConfigurationKeys.stream()
-            .map(key -> Map.entry(key, configurationService.getProperty(key)))
-            .filter(entry -> entry.getValue() != null)
+            .map(key -> {
+                String value = configurationService.getProperty(key);
+                return value != null ? Map.entry(key, value) : null;
+            })
+            .filter(Objects::nonNull)
             .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         Map.Entry::getValue

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -112,9 +112,6 @@ public final class Utils {
         "dspace.name", "dspace.shortname", "dspace.ui.url",
         "mail.helpdesk", "mail.message.helpdesk.telephone", "mail.admin", "mail.admin.name"};
 
-    private static final ConfigurationService configurationService =
-            DSpaceServicesFactory.getInstance().getConfigurationService();
-
     /**
      * Private constructor
      */
@@ -525,6 +522,8 @@ public final class Utils {
     public static Map<String, String> getAllowedTemplateConfig() {
         // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
         // template lookup
+        ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
         List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
                     "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
         return allowedConfigurationKeys.stream()

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -32,16 +32,22 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.coverity.security.Escape;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.velocity.app.Velocity;
+import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -99,6 +105,14 @@ public final class Utils {
     // for formatISO8601Date
     // output canonical format
     private static final DateTimeFormatter outFmt = DateTimeFormatter.ISO_INSTANT;
+
+    // Allowed configuration properties to pass to Velocity templates (Email, LDN)
+    private static final String[] DEFAULT_ALLOWED_TEMPLATE_CONFIGS = {
+        "dspace.name", "dspace.shortname", "dspace.ui.url",
+        "mail.helpdesk", "mail.message.helpdesk.telephone", "mail.admin", "mail.admin.name"};
+
+    private static final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
 
     /**
      * Private constructor
@@ -500,6 +514,56 @@ public final class Utils {
     public static Instant getMinTimestamp() {
         return LocalDateTime.of(-4713, 11, 12, 0, 0, 0)
                 .toInstant(ZoneOffset.UTC);
+    }
+
+    /**
+     * Get a list of allowed DSpace configuration property keys that will be exposed to Velocity templates
+     * (used in Email and LDN messages) as a simple Map of strings.
+     * @return Map of strings representing resolved configuration properties
+     */
+    public static Map<String, String> getAllowedTemplateConfig() {
+        // Pass a restricted (via configuration) list of resolved Configuration keys and values, for
+        // template lookup
+        List<String> allowedConfigurationKeys = List.of(configurationService.getArrayProperty(
+                    "message.templates.allowed-config", DEFAULT_ALLOWED_TEMPLATE_CONFIGS));
+        return allowedConfigurationKeys.stream()
+            .map(key -> Map.entry(key, configurationService.getProperty(key)))
+            .filter(entry -> entry.getValue() != null)
+            .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue
+                        ));
+    }
+
+    /**
+     * Create and return a set of default, secure Velocity configuration properties.
+     * @see {@link LDN}, {@link Email}
+     *
+     * @param resourceRepositoryName the templating context e.g. "LDN", "Email"
+     * @returns secure Velocity configuration for use with templating
+     */
+    public static Properties getSecureVelocityProperties(String resourceRepositoryName) {
+        Properties secureVelocityProperties = new Properties();
+        // Basic Velocity configuration
+        secureVelocityProperties.setProperty(Velocity.RESOURCE_LOADERS, "string");
+        secureVelocityProperties.setProperty("resource.loader.string.description",
+                "Velocity StringResource loader");
+        secureVelocityProperties.setProperty("resource.loader.string.class",
+                StringResourceLoader.class.getName());
+        secureVelocityProperties.setProperty("resource.loader.string.repository.name",
+                resourceRepositoryName);
+        secureVelocityProperties.setProperty("resource.loader.string.repository.static",
+                "false");
+        // Set secure default introspection and class restriction handling in Velocity
+        secureVelocityProperties.setProperty("introspector.uberspect.class",
+                "org.apache.velocity.util.introspection.SecureUberspector");
+        secureVelocityProperties.setProperty("introspector.restrict.classes",
+                "java.lang.Class,java.lang.Runtime,java.lang.System");
+        secureVelocityProperties.setProperty( "introspector.restrict.packages",
+                "java.lang.reflect,java.io,java.nio");
+        secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+
+        return secureVelocityProperties;
     }
 
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -162,6 +162,7 @@ mail.from.address = dspace-noreply@myu.edu
 # will use the above settings to create a Session.
 #mail.session.name = Session
 
+
 # When feedback is submitted via the Feedback form, it is sent to this address
 # Currently limited to one recipient!
 # if this property is empty or commented out, feedback form is disabled
@@ -232,6 +233,17 @@ mail.message.headers = charset
 
 # Helpdesk telephone.  Not email, but should be with other contact info.  Optional.
 #mail.message.helpdesk.telephone = +1 555 555 5555
+
+# Allowed configuration properties, to pass in a "config" map to email and LDN templates.
+# This allows templates to easily access dynamic configuration properties, without
+# exposing sensitive information to the templating engine
+message.templates.allowed-config = dspace.name
+message.templates.allowed-config = dspace.shortname
+message.templates.allowed-config = dspace.ui.url
+message.templates.allowed-config = mail.helpdesk
+message.templates.allowed-config = mail.message.helpdesk.telephone
+message.templates.allowed-config = mail.admin
+message.templates.allowed-config = mail.admin.name
 
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml


### PR DESCRIPTION
## Description

Several improvements to Velocity template engine configuration, including introspection, and centralising for both LDN and Email usage:

1. Velocity configuration matches current recommended version for simple text-based templates
2. New configuration to determine which properties are exposed to LDN and Email templates
3. The two points above are centralised into utility methods to avoid code duplication

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.(https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
