### PR TITLE
Remove strict mode Velocity engine configuration (allow nulls)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -564,7 +564,11 @@ public final class Utils {
                 "java.lang.Class,java.lang.Runtime,java.lang.System");
         secureVelocityProperties.setProperty( "introspector.restrict.packages",
                 "java.lang.reflect,java.io,java.nio");
-        secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+        // Set strict mode if configured (default: false, as we've always treated null values as blanks)
+        if (DSpaceServicesFactory.getInstance().getConfigurationService()
+                .getBooleanProperty("message.templates.strict_mode", false)) {
+            secureVelocityProperties.setProperty("runtime.strict_mode.enable", "true");
+        }
 
         return secureVelocityProperties;
     }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -245,6 +245,11 @@ message.templates.allowed-config = mail.message.helpdesk.telephone
 message.templates.allowed-config = mail.admin
 message.templates.allowed-config = mail.admin.name
 
+# Whether to run Velocity in strict mode (null parameter values in templates for LDN or Email will result
+# in an Exception instead of a blank string)
+# Default: false (this can introduce unwanted side-effects if e.g. a submitter eperson is deleted for a workflow task)
+#message.templates.strict_mode = false
+
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml
 


### PR DESCRIPTION
Small fix to default behaviour in https://github.com/DSpace/DSpace/pull/12536

Allows missing/null parameter values to be treated as blank strings/null rather than throwing a hard Exception when building an email. Strict mode can be optionally enabled for those who want it.