### PR TITLE
adjust value of User-Agent header in SEO health checks

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/health/SEOHealthIndicator.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/health/SEOHealthIndicator.java
@@ -24,7 +24,16 @@ public class SEOHealthIndicator extends AbstractHealthIndicator {
 
     ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate = createRestTemplate();
+
+    private static RestTemplate createRestTemplate() {
+        RestTemplate template = new RestTemplate();
+        template.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().set("User-Agent", "DSpace Backend SEO Health Check");
+            return execution.execute(request, body);
+        });
+        return template;
+    }
 
     @Override
     protected void doHealthCheck(Health.Builder builder) {


### PR DESCRIPTION
## Description

This PR updates the `SEOHealthIndicator` to improve the SEO health checks by setting a custom `User-Agent` HTTP header to all outgoing HTTP requests, which helps identify these HTTP requests as coming from the DSpace backend itself. Otherwise a generic header (Java/Version) is used.