### PR TITLE
Fix for issue of deleted files when importing malformed SAF ZIP package

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -362,7 +362,14 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
 
             workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR
                     + File.separator + context.getCurrentUser().getID());
-            sourcedir = itemImportService.unzip(workFile, workDir.getAbsolutePath());
+
+            try {
+                sourcedir = itemImportService.unzip(workFile, workDir.getAbsolutePath());
+            } catch (Exception e) {
+                // avoid removing user files
+                sourcedir = null;
+                throw e;
+            }
         } finally {
             optionalFileStream.ifPresent(IOUtils::closeQuietly);
             validationFileStream.ifPresent(IOUtils::closeQuietly);

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
@@ -120,8 +120,14 @@ public class ItemImportCLI extends ItemImport {
 
                 workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR
                         + File.separator + context.getCurrentUser().getID());
-                sourcedir = itemImportService.unzip(
-                        new File(sourcedir + File.separator + zipfilename), workDir.getAbsolutePath());
+                try {
+                    sourcedir = itemImportService.unzip(
+                            new File(sourcedir + File.separator + zipfilename), workDir.getAbsolutePath());
+                } catch (Exception e) {
+                    // avoid removing user files
+                    sourcedir = null;
+                    throw e;
+                }
             } else {
                 // manage zip via remote url
                 Optional<InputStream> optionalFileStream = Optional.ofNullable(new URL(zipfilename).openStream());
@@ -139,7 +145,13 @@ public class ItemImportCLI extends ItemImport {
                         FileUtils.copyInputStreamToFile(optionalFileStream.get(), workFile);
                         workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR
                                 + File.separator + context.getCurrentUser().getID());
-                        sourcedir = itemImportService.unzip(workFile, workDir.getAbsolutePath());
+                        try {
+                            sourcedir = itemImportService.unzip(workFile, workDir.getAbsolutePath());
+                        } catch (Exception e) {
+                            // avoid removing user files
+                            sourcedir = null;
+                            throw e;
+                        }
                     } else {
                         throw new IllegalArgumentException(
                                 "Error reading file, the file couldn't be found for filename: " + zipfilename);

--- a/dspace-api/src/test/java/org/dspace/app/itemimport/ItemImportCLIMalformedZipIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemimport/ItemImportCLIMalformedZipIT.java
@@ -1,0 +1,219 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.itemimport;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedOutputStream;
+import java.io.DataOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.CRC32;
+
+import org.apache.commons.io.file.PathUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.content.Collection;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression test for the destructive-cleanup bug in {@link ItemImportCLI}.
+ *
+ * When a zip package contains entry names whose bytes are not valid UTF-8
+ * (e.g. a SAF zip created on Windows with Hungarian accents in filenames),
+ * {@code java.util.zip.ZipFile} throws
+ * {@code ZipException: invalid CEN header (bad entry name)} during unzip.
+ * The original code left {@code sourcedir} pointing at the user-supplied
+ * {@code --source} path, and the {@code finally} block then called
+ * {@code FileUtils.deleteDirectory(sourcedir)} — destroying user data.
+ *
+ * The fix nulls {@code sourcedir} when {@code unzip()} throws, so the
+ * cleanup block skips the destructive branch.
+ */
+public class ItemImportCLIMalformedZipIT extends AbstractIntegrationTestWithDatabase {
+
+    private final ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+
+    private Collection collection;
+    private Path tempDir;
+    private Path workDir;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        collection = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection")
+                .build();
+        context.restoreAuthSystemState();
+
+        tempDir = Files.createTempDirectory("safMalformedZipTest");
+        java.io.File wd = new java.io.File(
+                configurationService.getProperty("org.dspace.app.batchitemimport.work.dir"));
+        if (!wd.exists()) {
+            Files.createDirectories(wd.toPath());
+        }
+        workDir = wd.toPath();
+    }
+
+    @After
+    @Override
+    public void destroy() throws Exception {
+        PathUtils.deleteOnExit(tempDir);
+        if (Files.exists(workDir)) {
+            try (var stream = Files.list(workDir)) {
+                stream.forEach(PathUtils::deleteOnExit);
+            }
+        }
+        super.destroy();
+    }
+
+    /**
+     * Bug repro: import a malformed zip whose entry names are CP-852 bytes
+     * (not valid UTF-8). With the Layer-1 fix in place, the user-supplied
+     * source directory MUST survive the failed import.
+     */
+    @Test
+    public void malformedZipMustNotDeleteSourceDir() throws Exception {
+        // sandbox = the directory the user would pass as --source
+        Path sandbox = Files.createDirectory(tempDir.resolve("sandbox"));
+        Path sentinel = sandbox.resolve("DO_NOT_DELETE.txt");
+        Files.writeString(sentinel, "this file must survive a failed import");
+
+        Path malformedZip = sandbox.resolve("malformed.zip");
+        writeMalformedZip(malformedZip);
+
+        String[] args = new String[] {
+            "import", "-a",
+            "-e", admin.getEmail(),
+            "-c", collection.getID().toString(),
+            "-s", sandbox.toString(),
+            "-m", tempDir.resolve("mapfile.out").toString(),
+            "-z", "malformed.zip"
+        };
+
+        boolean threw = false;
+        try {
+            runDSpaceScript(args);
+        } catch (Throwable expected) {
+            threw = true;
+        }
+
+        if (!threw) {
+            fail("Expected the import to fail on a malformed zip (invalid CEN header),"
+                 + " but it returned normally.");
+        }
+
+        assertTrue("BUG: malformed zip triggered destructive cleanup —"
+                   + " sandbox directory was deleted!",
+                   Files.exists(sandbox));
+        assertTrue("BUG: malformed zip triggered destructive cleanup —"
+                   + " sentinel file inside sandbox was deleted!",
+                   Files.exists(sentinel));
+    }
+
+    /**
+     * Write a structurally valid zip whose single entry name uses raw CP-852
+     * bytes (Hungarian "á" = 0xA0 and "ű" = 0xFB). These are not valid UTF-8
+     * sequences, so {@link java.util.zip.ZipFile} (UTF-8 strict by default)
+     * throws "invalid CEN header (bad entry name)" when opening it.
+     *
+     * Done by hand against the PKZIP spec so the test has no extra deps.
+     */
+    private static void writeMalformedZip(Path target) throws Exception {
+        // "futás.pdf" — but the bytes are CP-852, NOT UTF-8.
+        // f=0x66 u=0x75 t=0x74 á=0xA0 (cp852) s=0x73 . p d f
+        byte[] badName = new byte[] {
+            0x66, 0x75, 0x74, (byte) 0xA0, 0x73, 0x2E, 0x70, 0x64, 0x66
+        };
+        byte[] data = "%PDF-1.4\n%dummy payload\n".getBytes();
+        CRC32 crc32 = new CRC32();
+        crc32.update(data);
+        long crc = crc32.getValue();
+
+        try (OutputStream raw = Files.newOutputStream(target);
+             BufferedOutputStream buf = new BufferedOutputStream(raw);
+             DataOutputStream out = new DataOutputStream(buf)) {
+
+            int localOffset = 0;
+
+            // ---- Local file header (PK\x03\x04) ----
+            writeIntLE(out, 0x04034b50);
+            writeShortLE(out, 20);          // version needed
+            writeShortLE(out, 0);           // flags — bit 11 (UTF-8) NOT set
+            writeShortLE(out, 0);           // compression: stored
+            writeShortLE(out, 0);           // dos time
+            writeShortLE(out, 0x21);        // dos date (1980-01-01)
+            writeIntLE(out, (int) crc);
+            writeIntLE(out, data.length);   // compressed size
+            writeIntLE(out, data.length);   // uncompressed size
+            writeShortLE(out, badName.length);
+            writeShortLE(out, 0);           // extra field length
+            out.write(badName);
+            out.write(data);
+
+            int cdOffset = 30 + badName.length + data.length;
+
+            // ---- Central directory file header (PK\x01\x02) ----
+            writeIntLE(out, 0x02014b50);
+            writeShortLE(out, 20);          // version made by
+            writeShortLE(out, 20);          // version needed
+            writeShortLE(out, 0);           // flags
+            writeShortLE(out, 0);           // compression
+            writeShortLE(out, 0);           // dos time
+            writeShortLE(out, 0x21);        // dos date
+            writeIntLE(out, (int) crc);
+            writeIntLE(out, data.length);
+            writeIntLE(out, data.length);
+            writeShortLE(out, badName.length);
+            writeShortLE(out, 0);           // extra field
+            writeShortLE(out, 0);           // file comment
+            writeShortLE(out, 0);           // disk number
+            writeShortLE(out, 0);           // internal attrs
+            writeIntLE(out, 0);             // external attrs
+            writeIntLE(out, localOffset);
+            out.write(badName);
+
+            int cdSize = 46 + badName.length;
+
+            // ---- End of central directory (PK\x05\x06) ----
+            writeIntLE(out, 0x06054b50);
+            writeShortLE(out, 0);           // disk number
+            writeShortLE(out, 0);           // disk with CD
+            writeShortLE(out, 1);           // CD entries this disk
+            writeShortLE(out, 1);           // total CD entries
+            writeIntLE(out, cdSize);
+            writeIntLE(out, cdOffset);
+            writeShortLE(out, 0);           // zip comment length
+        }
+    }
+
+    private static void writeIntLE(DataOutputStream out, int v) throws Exception {
+        out.write(v & 0xff);
+        out.write((v >>> 8) & 0xff);
+        out.write((v >>> 16) & 0xff);
+        out.write((v >>> 24) & 0xff);
+    }
+
+    private static void writeShortLE(DataOutputStream out, int v) throws Exception {
+        out.write(v & 0xff);
+        out.write((v >>> 8) & 0xff);
+    }
+}


### PR DESCRIPTION
## References
Poorly related to this issue: #10646

## Description
Debian 12, DSpace 8.x (but 6, 7 and above may be affected).
The issue is that the SAF import process executed from the command line may delete user files under specific conditions if a ZIP package is created under Windows and the file name(s) contain accented character(s) encoded as e.g. codepage 852.

## Instructions for Reviewers
#### Reproduce the issue
1. Create a ZIP package based on the SAF layout. I have attached a small example package and Python script which can create one. 
[malformed_zip.py](https://github.com/user-attachments/files/28460804/malformed_zip.py)
[saf-zip-test.zip](https://github.com/user-attachments/files/28461051/saf-zip-test.zip)


2. Upload this package to the server e.g. to import-test/ and ssh and cd to that folder. 
3. Issue the import command `bin/dspace import --add --eperson=<admin-user> --collection=<collection-handle> --source=. -m ../importtest.map --zip=saf-zip-test.zip [--validate]`
4. The CLI log will show this kind of error:
```bash
java.lang.Exception: Error committing changes to database: Error reading file, the file couldn't be found for filename: saf-zip-test.zip, aborting most recent changes
        at org.dspace.app.itemimport.ItemImport.internalRun(ItemImport.java:234)
        at org.dspace.scripts.DSpaceRunnable.run(DSpaceRunnable.java:150)
        at org.dspace.app.launcher.ScriptLauncher.executeScript(ScriptLauncher.java:155)
        at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:133)
        at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:100)
Caused by: java.lang.IllegalArgumentException: Error reading file, the file couldn't be found for filename: saf-zip-test.zip
        at org.dspace.app.itemimport.ItemImportCLI.readZip(ItemImportCLI.java:109)
        at org.dspace.app.itemimport.ItemImport.internalRun(ItemImport.java:225)
        ... 4 more
```
This is due to the bug that all of the files are removed by the ItemImport script.
Executing the import command with some additional options we may see the core issue:
```bash
JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true" bin/dspace import --add --eperson=<admin-user> --collection=<collection-handle> --source=/home/dspace/import-test/ -m ../importtest.map --zip=saf-zip-test.zip --validate 2>&1 | tee import.log
java.lang.Exception: Error committing changes to database: invalid CEN header (bad entry name), aborting most recent changes
    at org.dspace.app.itemimport.ItemImport.internalRun(ItemImport.java:234)
    at org.dspace.scripts.DSpaceRunnable.run(DSpaceRunnable.java:150)
    at org.dspace.app.launcher.ScriptLauncher.executeScript(ScriptLauncher.java:155)
    at org.dspace.app.launcher.ScriptLauncher.handleScript(ScriptLauncher.java:133)
    at org.dspace.app.launcher.ScriptLauncher.main(ScriptLauncher.java:100)
Caused by: java.util.zip.ZipException: invalid CEN header (bad entry name)
    at java.base/java.util.zip.ZipFile$Source.zerror(ZipFile.java:1769)
    at java.base/java.util.zip.ZipFile$Source.checkAndAddEntry(ZipFile.java:1242)
    at java.base/java.util.zip.ZipFile$Source.initCEN(ZipFile.java:1708)
    at java.base/java.util.zip.ZipFile$Source.<init>(ZipFile.java:1483)
    at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1445)
    at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:717)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:251)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:180)
    at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:194)
    at org.dspace.app.itemimport.ItemImportServiceImpl.unzip(ItemImportServiceImpl.java:1993)
    at org.dspace.app.itemimport.ItemImportCLI.readZip(ItemImportCLI.java:123)
    at org.dspace.app.itemimport.ItemImport.internalRun(ItemImport.java:225)
    ... 4 more
```
So the issue is due to the malformed ZIP packaged: `invalid CEN header (bad entry name)`
If the user executes this command under /home/dspace with `--source=.` it removes all of the files under the user's home as well.
The import process should not delete files without a permission of the user.
        
One workaround is to move the package into a temp folder and the `source` parameter has to be set to this temp. So any failure with the ZIP package removes only the temp folder's content.
Also, the ZIP package should be inspected with a script or simply checking the package content by hand looking for not utf-8 characters.

I have added three fixes to the import code which are simply catching any error produced by the function `ItemImportService.unzip`. When having error we simply set `sourcedir` to `null` to avoid deleting the user files. I think it should be enough because the correction of a malformed ZIP package is not the task of the import process.

I have added an iteration test named `org.dspace.app.itemimport.ItemImportCLIMalformedZipIT` as well. It generates a malformed package and a test file on-the-fly and it checks if the test file has remained in place after an import process. (This has been generated by Claude but revisioned by me.)

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
