### PR TITLE
[GitHub Actions] Update dependabot to monitor dspace-10_x and demo.dspace.org to redeploy for 10.x changes.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -163,6 +163,164 @@ updates:
     cooldown:
       default-days: 7
   ######################
+  ## dspace-10_x branch
+  ######################
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: dspace-10_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
+    # Allow up to 10 open PRs for dependencies
+    open-pull-requests-limit: 10
+    # Group together some upgrades in a single PR
+    groups:
+      # Group together all Build Tools in a single PR
+      build-tools:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "*:*-maven-plugin"
+          - "*:maven-*-plugin"
+          - "com.github.spotbugs:spotbugs"
+          - "com.google.code.findbugs:*"
+          - "com.google.errorprone:*"
+          - "com.puppycrawl.tools:checkstyle"
+          - "org.sonatype.*:*"
+        exclude-patterns:
+          # Exclude anything from Spring, as that is in a separate group
+          - "org.springframework.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      test-tools:
+        applies-to: version-updates
+        patterns:
+          - "junit:*"
+          - "com.adobe.testing:*"
+          - "com.github.stefanbirker:system-rules"
+          - "com.h2database:*"
+          - "io.findify:s3mock*"
+          - "io.netty:*"
+          - "org.apache.httpcomponents.client5:*"
+          - "org.hamcrest:*"
+          - "org.mock-server:*"
+          - "org.mockito:*"
+          - "org.testcontainers:*"
+          - "org.xmlunit:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Amazon S3 deps in a single PR
+      amazon-s3:
+        applies-to: version-updates
+        patterns:
+          - "software.amazon.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Apache Commons deps in a single PR
+      apache-commons:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:commons-*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all fasterxml deps in a single PR
+      fasterxml:
+        applies-to: version-updates
+        patterns:
+          - "com.fasterxml:*"
+          - "com.fasterxml.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+        # Group together all Hibernate deps in a single PR
+      hibernate:
+        applies-to: version-updates
+        patterns:
+          - "org.hibernate.*:*"
+        update-types:
+          - "patch"
+      # Group together all Jakarta deps in a single PR
+      jakarta:
+        applies-to: version-updates
+        patterns:
+          - "jakarta.*:*"
+          - "org.eclipse.angus:jakarta.mail"
+          - "org.glassfish.jaxb:jaxb-runtime"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all Spring deps in a single PR
+      spring:
+        applies-to: version-updates
+        patterns:
+          - "org.springframework:*"
+          - "org.springframework.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group together all WebJARs deps in a single PR
+      webjars:
+        applies-to: version-updates
+        patterns:
+          - "org.webjars:*"
+          - "org.webjars.*:*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group Tika, bouncycastle, and asm because they are tightly integrated
+      # and we theoretically want to keep them in sync.
+      tika:
+        applies-to: version-updates
+        patterns:
+          - "org.apache.tika:*:*"
+          - "org.bouncycastle:*:*"
+          - "org.ow2.asm:*:*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Don't try to auto-update any DSpace dependencies
+      - dependency-name: "org.dspace:*"
+      - dependency-name: "org.dspace.*:*"
+      # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
+      # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
+      - dependency-name: "org.bouncycastle:*"
+      # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
+      - dependency-name: "org.hibernate.*:*"
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+      # Ignore updates for jboss-logging because it is a "convergence only" dependency
+      # that we do not use directly (see comments in pom.xml).
+      - dependency-name: "org.jboss.logging:*"
+      # Don't try to update antlr4-runtime because it is a transitive dependency
+      # used by Hibernate and Solr. The version is pinned in pom.xml and should
+      # only be updated when required. See: https://github.com/DSpace/DSpace/pull/11989
+      - dependency-name: "org.antlr:antlr4-runtime"
+      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
+  # Also automatically update all our GitHub actions on the dspace-10_x branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: dspace-10_x
+    # Monthly dependency updates
+    schedule:
+      interval: "monthly"
+      time: "02:00"
+    # Allow updates to be delayed for a configurable number of days to mitigate
+    # some classes of supply chain attacks
+    cooldown:
+      default-days: 7
+  ######################
   ## dspace-9_x branch
   ######################
   - package-ecosystem: "maven"
@@ -474,178 +632,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: dspace-8_x
-    # Monthly dependency updates
-    schedule:
-      interval: "monthly"
-      time: "02:00"
-    # Allow updates to be delayed for a configurable number of days to mitigate
-    # some classes of supply chain attacks
-    cooldown:
-      default-days: 7
-  ######################
-  ## dspace-7_x branch
-  ######################
-  - package-ecosystem: "maven"
-    directory: "/"
-    target-branch: dspace-7_x
-    schedule:
-      interval: "monthly"
-      time: "02:00"
-    # Allow updates to be delayed for a configurable number of days to mitigate
-    # some classes of supply chain attacks
-    cooldown:
-      default-days: 7
-    # Allow up to 10 open PRs for dependencies
-    open-pull-requests-limit: 10
-    # Group together some upgrades in a single PR
-    groups:
-      # Group together all Build Tools in a single PR
-      build-tools:
-        applies-to: version-updates
-        patterns:
-          - "org.apache.maven.plugins:*"
-          - "*:*-maven-plugin"
-          - "*:maven-*-plugin"
-          - "com.github.spotbugs:spotbugs"
-          - "com.google.code.findbugs:*"
-          - "com.google.errorprone:*"
-          - "com.puppycrawl.tools:checkstyle"
-          - "org.sonatype.*:*"
-        exclude-patterns:
-          # Exclude anything from Spring, as that is in a separate group
-          - "org.springframework.*:*"
-        update-types:
-          - "minor"
-          - "patch"
-      test-tools:
-        applies-to: version-updates
-        patterns:
-          - "junit:*"
-          - "com.adobe.testing:*"
-          - "com.github.stefanbirker:system-rules"
-          - "com.h2database:*"
-          - "io.findify:s3mock*"
-          - "io.netty:*"
-          - "org.hamcrest:*"
-          - "org.mock-server:*"
-          - "org.mockito:*"
-          - "org.testcontainers:*"
-          - "org.xmlunit:*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all Amazon S3 deps in a single PR
-      amazon-s3:
-        applies-to: version-updates
-        patterns:
-          - "software.amazon.*:*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all Apache Commons deps in a single PR
-      apache-commons:
-        applies-to: version-updates
-        patterns:
-          - "org.apache.commons:*"
-          - "commons-*:commons-*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all fasterxml deps in a single PR
-      fasterxml:
-        applies-to: version-updates
-        patterns:
-          - "com.fasterxml:*"
-          - "com.fasterxml.*:*"
-        update-types:
-          - "minor"
-          - "patch"
-        # Group together all Hibernate deps in a single PR
-      hibernate:
-        applies-to: version-updates
-        patterns:
-          - "org.hibernate.*:*"
-        update-types:
-          - "patch"
-      # Group together all Javax deps in a single PR
-      # NOTE: Javax is only used in 7.x and has been replaced by Jakarta in 8.x and later
-      jakarta:
-        applies-to: version-updates
-        patterns:
-          - "javax.*:*"
-          - "*:javax.mail"
-          - "org.glassfish.jaxb:jaxb-runtime"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all Google deps in a single PR
-      # NOTE: These Google deps are only used in 7.x and have been removed in 8.x and later
-      google-apis:
-        applies-to: version-updates
-        patterns:
-          - "com.google.apis:*"
-          - "com.google.api-client:*"
-          - "com.google.http-client:*"
-          - "com.google.oauth-client:*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all Spring deps in a single PR
-      spring:
-        applies-to: version-updates
-        patterns:
-          - "org.springframework:*"
-          - "org.springframework.*:*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group together all WebJARs deps in a single PR
-      webjars:
-        applies-to: version-updates
-        patterns:
-          - "org.webjars:*"
-          - "org.webjars.*:*"
-        update-types:
-          - "minor"
-          - "patch"
-      # Group Tika, bouncycastle, and asm because they are tightly integrated
-      # and we theoretically want to keep them in sync.
-      tika:
-        applies-to: version-updates
-        patterns:
-        - "org.apache.tika:*:*"
-        - "org.bouncycastle:*:*"
-        - "org.ow2.asm:*:*"
-        update-types:
-        - "minor"
-        - "patch"
-    ignore:
-      # Don't try to auto-update any DSpace dependencies
-      - dependency-name: "org.dspace:*"
-      - dependency-name: "org.dspace.*:*"
-      # Last version of errorprone to support JDK 11 is 2.31.0
-      - dependency-name: "com.google.errorprone:*"
-        versions: [">=2.32.0"]
-      # Don't automatically update BouncyCastle because maven-gpg-plugin REQUIRES a very specific version or release
-      # errors will occur. See https://github.com/DSpace/DSpace/pull/11696
-      - dependency-name: "org.bouncycastle:*"
-      # Spring Security 5.8 changes the behavior of CSRF Tokens in a way which is incompatible with DSpace 7
-      # See https://github.com/DSpace/DSpace/pull/9888#issuecomment-2408165545
-      - dependency-name: "org.springframework.security:*"
-        versions: [">=5.8.0"]
-      # Ignore major/minor updates for Hibernate. Only patch updates can be automated.
-      - dependency-name: "org.hibernate.*:*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # Ignore updates for jboss-logging because it is a "convergence only" dependency
-      # that we do not use directly (see comments in pom.xml).
-      - dependency-name: "org.jboss.logging:*"
-      # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-major" ]
-  # Also automatically update all our GitHub actions on the dspace-7_x branch
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: dspace-7_x
     # Monthly dependency updates
     schedule:
       interval: "monthly"

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -55,7 +55,7 @@ env:
   # For a new commit on other branches, use the branch name as the tag for Docker image.
   # For a new tag, copy that tag name as the tag for Docker image.
   # For a pull request, use the name of the base branch that the PR was created against or "latest" (for main).
-  #   e.g. PR against 'main' will use "latest". a PR against 'dspace-7_x' will use 'dspace-7_x'.
+  #   e.g. PR against 'main' will use "latest". a PR against 'dspace-9_x' will use 'dspace-9_x'.
   IMAGE_TAGS: |
     type=raw,value=latest,enable=${{ github.ref_name == github.event.repository.default_branch }}
     type=ref,event=branch,enable=${{ github.ref_name != github.event.repository.default_branch }}
@@ -72,7 +72,7 @@ env:
   REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_URL }}
   REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
   # Current DSpace branches (and architecture) which are deployed to demo.dspace.org & sandbox.dspace.org respectively
-  DEPLOY_DEMO_BRANCH: 'dspace-9_x'
+  DEPLOY_DEMO_BRANCH: 'dspace-10_x'
   DEPLOY_SANDBOX_BRANCH: 'main'
   DEPLOY_ARCH: 'linux/amd64'
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)


### PR DESCRIPTION
## Description
This PR represents post-10.0 release cleanup. A corresponding PR exists for the frontend, see https://github.com/DSpace/dspace-angular/pull/5770

It makes the following setting updates:
* Updates `dependabot` settings to *add* monitoring of the `dspace-10_x` branch and *remove* monitoring of the `dspace-7_x` branch.
* Update our `reusable-docker-build.yml` script to redeploy demo.dspace.org on updates to `dspace-10_x`, as that site will be updated to use 10.x.

## Instructions for Reviewers
* These updates are all configuration of our automated tooling.  They can only be tested by merging.