### PR TITLE
[GitHub Actions] Update demo config to redeploy when changes made to dspace-10_x branch

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -72,7 +72,7 @@ env:
   REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_URL }}
   REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
   # Current DSpace branches (and architecture) which are deployed to demo.dspace.org & sandbox.dspace.org respectively
-  DEPLOY_DEMO_BRANCH: 'dspace-9_x'
+  DEPLOY_DEMO_BRANCH: 'dspace-10_x'
   DEPLOY_SANDBOX_BRANCH: 'main'
   DEPLOY_ARCH: 'linux/amd64'
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)


### PR DESCRIPTION
## References
* Partial backport of #12602 to `dspace-10_x`
 
## Description
Tiny PR to update the demo configuration to auto-redeploy whenever changes are made to the `dspace-10_x` branch.  This configuration needs to be backported to `dspace-10_x` and `dspace-9_x` branches as they all use their local copy of this `reusable-docker-build.yml`