### PR TITLE
[Port dpace-9_x] [GitHub Actions] Update demo config to redeploy when changes made to dspace-10_x branch

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -72,7 +72,7 @@ env:
   REDEPLOY_SANDBOX_URL: ${{ secrets.REDEPLOY_SANDBOX_URL }}
   REDEPLOY_DEMO_URL: ${{ secrets.REDEPLOY_DEMO_URL }}
   # Current DSpace branches (and architecture) which are deployed to demo.dspace.org & sandbox.dspace.org respectively
-  DEPLOY_DEMO_BRANCH: 'dspace-9_x'
+  DEPLOY_DEMO_BRANCH: 'dspace-10_x'
   DEPLOY_SANDBOX_BRANCH: 'main'
   DEPLOY_ARCH: 'linux/amd64'
   # Registry used during building of Docker images. (All images are later copied to docker.io registry)


### PR DESCRIPTION
## Description

Manual port of #12627 to `dspace-9_x`.  NOTE: This backport PR is necessary to essentially *disable* redeploying of demo for any changes to the `dspace-9_x` branch.
