### PR TITLE
Add additional OA fee in OPF response

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/openpolicyfinder/v2/OpenPolicyFinderPermittedVersion.java
+++ b/dspace-api/src/main/java/org/dspace/app/openpolicyfinder/v2/OpenPolicyFinderPermittedVersion.java
@@ -50,6 +50,8 @@ public class OpenPolicyFinderPermittedVersion implements Serializable {
     private List<String> licenses;
     // Embargo
     private OpenPolicyFinderEmbargo embargo;
+    // Additional OA fee
+    private Boolean additionalOpenAccessFee;
 
     public String getArticleVersion() {
         return articleVersion;
@@ -97,6 +99,14 @@ public class OpenPolicyFinderPermittedVersion implements Serializable {
 
     public void setEmbargo(OpenPolicyFinderEmbargo embargo) {
         this.embargo = embargo;
+    }
+
+    public Boolean getAdditionalOpenAccessFee() {
+        return additionalOpenAccessFee;
+    }
+
+    public void setAdditionalOpenAccessFee(Boolean additionalOpenAccessFee) {
+        this.additionalOpenAccessFee = additionalOpenAccessFee;
     }
 
     public int getOption() {

--- a/dspace-api/src/main/java/org/dspace/app/openpolicyfinder/v2/OpenPolicyFinderResponse.java
+++ b/dspace-api/src/main/java/org/dspace/app/openpolicyfinder/v2/OpenPolicyFinderResponse.java
@@ -378,6 +378,12 @@ public class OpenPolicyFinderResponse implements Serializable {
                             publishedOption++;
                             currentOption = publishedOption;
                         }
+
+                        permittedVersion.setAdditionalOpenAccessFee(
+                            permitted.has("additional_oa_fee")
+                            && "yes".equals(permitted.getString("additional_oa_fee"))
+                        );
+
                         permittedVersion.setOption(currentOption);
                         permittedVersions.add(permittedVersion);
                     }


### PR DESCRIPTION
## References

Related front-end PR: https://github.com/DSpace/dspace-angular/pull/5795

## Description

Adds information about additional OA fee in the OPF response.

From the [schema](https://openpolicyfinder.jisc.ac.uk/help/developers/metadata-schema) (tab _Publication_), this information is returned in the field `additional_oa_fee`, with a string value of `"yes"` or `"no"`.

## Instructions for Reviewers
To test this PR, add your OPF API key in the configuration `openpolicyfinder.apikey`, in `external-providers.cfg` or `local.cfg`, for example.

Also, you should enable/uncomment `<step id="opfPolicies"/>` in `item-submission.xml`. 

In the [front-end](https://github.com/DSpace/dspace-angular/pull/5795), start a new submission and enter some ISSN containing an additional OA fee.
It should now be displayed in the OPF section in the form.

List of changes in this PR:
* Adds a propertie `additionalOpenAccessFee` in `OpenPolicyFinderPermittedVersion.java`
* Sets the propertie in method `parsePublisherPolicy` in `OpenPolicyFinderResponse.java`

## Checklist

I have tried to add a new test to `OpenPolicyFinderServiceTest`, but it seems that the mock generated from `thelancet.json` is not up-to-date. Testing this same journal from the front-end shows the new additional OA fee information as expected. Updating `thelancet.json` with the actual API response makes the test for this new field to work, but fails other existing tests.

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
