### PR TITLE
Allow a type-bind to a custom field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInput.java
@@ -145,6 +145,7 @@ public class DCInput {
      * allowed document types
      */
     private List<String> typeBind = null;
+    private String typeBindToField = null;
 
     private boolean isRelationshipField = false;
     private boolean isMetadataField = false;
@@ -221,12 +222,14 @@ public class DCInput {
         // parsing of the <type-bind> element (using the colon as split separator)
         typeBind = new ArrayList<>();
         String typeBindDef = fieldMap.get("type-bind");
+        String typeBindSeparator = fieldMap.get("type-bind-separator");
         if (typeBindDef != null && typeBindDef.trim().length() > 0) {
-            String[] types = typeBindDef.split(",");
+            String[] types = typeBindDef.split(typeBindSeparator);
             for (String type : types) {
                 typeBind.add(type.trim());
             }
         }
+        typeBindToField = fieldMap.get("type-bind-to-field");
         style = fieldMap.get("style");
         isRelationshipField = fieldMap.containsKey("relationship-type");
         isMetadataField = fieldMap.containsKey("dc-schema");
@@ -417,6 +420,15 @@ public class DCInput {
      */
     public String getPairsType() {
         return valueListName;
+    }
+
+    /**
+     * Get fieldname to bind to
+     *
+     * @return fieldname
+     */
+    public String getTypeBindToField() {
+        return typeBindToField;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -404,6 +404,17 @@ public class DCInputsReader {
                 field.put(tagName, value);
                 if (tagName.equals("input-type")) {
                     handleInputTypeTagName(formName, field, nd, value);
+                } else if (tagName.equals("type-bind")) {
+                    String typeBindSeparator = getAttribute(nd, "separator");
+                    if (StringUtils.isBlank(typeBindSeparator)) {
+                        typeBindSeparator = TypeBindUtils.getTypeBindValueSeparator();
+                    }
+                    field.put("type-bind-separator", typeBindSeparator);
+
+                    String typeBindToField = getAttribute(nd, "to-field");
+                    if (StringUtils.isNotBlank(typeBindToField)) {
+                        field.put("type-bind-to-field", typeBindToField);
+                    }
                 } else if (tagName.equals("vocabulary")) {
                     String closedVocabularyString = getAttribute(nd, "closed");
                     field.put("closedVocabulary", closedVocabularyString);

--- a/dspace-api/src/main/java/org/dspace/app/util/TypeBindUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/TypeBindUtils.java
@@ -9,6 +9,7 @@ package org.dspace.app.util;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
@@ -41,7 +42,11 @@ public class TypeBindUtils {
      *
      * @return the field used for type-bind.
      */
-    public static String getTypeBindField() {
+    public static String getTypeBindField(String typeBindToField) {
+        if (StringUtils.isNotEmpty(typeBindToField)) {
+            return typeBindToField;
+        }
+
         return configurationService.getProperty("submit.type-bind.field", "dc.type");
     }
 
@@ -51,8 +56,12 @@ public class TypeBindUtils {
      * @param obj the in-progress submission
      * @return the list of MetadataValue objects of the type-bind field
      */
-    public static List<MetadataValue> getTypeBindMetadataValues(InProgressSubmission<?> obj) {
-        return itemService.getMetadataByMetadataString(obj.getItem(), getTypeBindField());
+    public static List<MetadataValue> getTypeBindMetadataValues(InProgressSubmission<?> obj, DCInput input) {
+        return itemService.getMetadataByMetadataString(obj.getItem(), getTypeBindField(input.getTypeBindToField()));
+    }
+
+    public static String getTypeBindValueSeparator() {
+        return configurationService.getProperty("submit.type-bind.value-separator", ",");
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -80,14 +80,15 @@ public class MetadataValidator implements SubmissionStepValidator {
         List<ValidationError> errors = new ArrayList<>();
 
         DCInputSet inputConfig = getDCInputSet(config);
-        List<MetadataValue> documentTypes = TypeBindUtils.getTypeBindMetadataValues(obj);
-
-        // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames =
-            inputConfig.populateAllowedFieldNames(documentTypes.stream().map(MetadataValue::getValue).toList());
 
         for (DCInput[] row : inputConfig.getFields()) {
             for (DCInput input : row) {
+                List<MetadataValue> documentTypes = TypeBindUtils.getTypeBindMetadataValues(obj, input);
+
+                // Get list of all field names allowed for the type-bound field
+                List<String> allowedFieldNames =
+                    inputConfig.populateAllowedFieldNames(documentTypes.stream().map(MetadataValue::getValue).toList());
+
                 String fieldKey = metadataAuthorityService.makeFieldKey(input.getSchema(), input.getElement(),
                                                                         input.getQualifier());
                 boolean isAuthorityControlled = metadataAuthorityService.isAuthorityControlled(fieldKey);

--- a/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/submission-forms.xml
@@ -293,11 +293,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>contributor</dc-element>
          <dc-qualifier>author</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Author</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required>You must enter at least the author.</required>
          <hint>Enter the names of the authors of this item in the form Lastname, Firstname [i.e. Smith, Josh or Smith, J].</hint>
+         <required>You must enter at least the author.</required>
        </field>
      </row>
      <row>
@@ -305,11 +305,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>oairecerif</dc-schema>
          <dc-element>author</dc-element>
          <dc-qualifier>affiliation</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Affiliation</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>Enter the affiliation of the author as stated on the publication.</hint>
+         <required />
        </field>
      </row>
    </form>
@@ -319,21 +319,21 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>contributor</dc-element>
          <dc-qualifier>editor</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Editor</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required>You must enter at least the author.</required>
          <hint>The editors of this publication.</hint>
+         <required>You must enter at least the author.</required>
        </field>
        <field>
          <dc-schema>oairecerif</dc-schema>
          <dc-element>editor</dc-element>
          <dc-qualifier>affiliation</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Affiliation</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>Enter the affiliation of the editor as stated on the publication.</hint>
+         <required />
        </field>
      </row>
    </form>
@@ -429,11 +429,11 @@ it, please enter the types and the actual numbers or codes.</hint>
           <dc-schema>dc</dc-schema>
           <dc-element>contributor</dc-element>
           <dc-qualifier>author</dc-qualifier>
+          <repeatable>false</repeatable>
           <label>Author</label>
           <input-type>name</input-type>
-          <repeatable>false</repeatable>
-          <required>You must enter at least the author.</required>
           <hint>Enter the names of the authors of this item in the form Lastname, Firstname [i.e. Smith, Josh or Smith, J].</hint>
+          <required>You must enter at least the author.</required>
         </field>
       </row>
       <row>
@@ -441,11 +441,11 @@ it, please enter the types and the actual numbers or codes.</hint>
           <dc-schema>person</dc-schema>
           <dc-element>affiliation</dc-element>
           <dc-qualifier>name</dc-qualifier>
+          <repeatable>false</repeatable>
           <label>Affiliation</label>
           <input-type>onebox</input-type>
-          <repeatable>false</repeatable>
-          <required />
           <hint>Enter the affiliation of the author as stated on the publication.</hint>
+          <required />
         </field>
       </row>
    </form>
@@ -497,6 +497,7 @@ it, please enter the types and the actual numbers or codes.</hint>
          <repeatable>false</repeatable>
          <label>Title</label>
          <input-type>onebox</input-type>
+         <hint/>
          <required>Field required</required>
        </field>
      </row>
@@ -511,6 +512,7 @@ it, please enter the types and the actual numbers or codes.</hint>
          <repeatable>false</repeatable>
          <label>Type</label>
          <input-type>onebox</input-type>
+         <hint/>
          <required>Field required</required>
        </field>
      </row>
@@ -571,11 +573,11 @@ it, please enter the types and the actual numbers or codes.</hint>
              <field>
                  <dc-schema>dc</dc-schema>
                  <dc-element>title</dc-element>
+                 <repeatable>false</repeatable>
                  <label>Organization name</label>
                  <input-type>onebox</input-type>
-                 <repeatable>false</repeatable>
-                 <required>You must enter the oganization name.</required>
                  <hint />
+                 <required>You must enter the oganization name.</required>
              </field>
          </row>
      </form>
@@ -586,23 +588,23 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>title</dc-element>
+         <repeatable>false</repeatable>
          <label>Title</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required>You must specify a title for the patent</required>
          <hint>The title of the patent</hint>
+         <required>You must specify a title for the patent</required>
        </field>
      </row>
      <row>
        <field>
          <dc-schema>dcterms</dc-schema>
          <dc-element>dateAccepted</dc-element>
+         <repeatable>false</repeatable>
          <label>Approval Date</label>
          <input-type>date</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>The Approval date.
     You can leave out the day and/or month if they aren't applicable.</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -610,12 +612,12 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>date</dc-element>
          <dc-qualifier>issued</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Registration Date</label>
          <input-type>date</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>The registration date of the patent.
     You can leave out the day and/or month if they aren't applicable.</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -623,33 +625,33 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>contributor</dc-element>
          <dc-qualifier>author</dc-qualifier>
+         <repeatable>true</repeatable>
          <label>Inventor(s)</label>
          <input-type>name</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>The inventor: The actual devisor of an invention that is the subject of a patent.</hint>
+         <required />
        </field>
      </row>
      <row>
        <field>
          <dc-schema>dcterms</dc-schema>
          <dc-element>rightsHolder</dc-element>
+         <repeatable>true</repeatable>
          <label>Holder</label>
          <input-type>onebox</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>The holders of this patent</hint>
+         <required />
        </field>
      </row>
      <row>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>publisher</dc-element>
+         <repeatable>true</repeatable>
          <label>Issuer</label>
          <input-type>onebox</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>The issuer of the patent: the patent office</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -657,11 +659,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>identifier</dc-element>
          <dc-qualifier>patentno</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Patent Number</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>The patent number.</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -669,22 +671,22 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>identifier</dc-element>
          <dc-qualifier>patentnumber</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Patent Number</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>The patent number.</hint>
+         <required />
        </field>
      </row>
      <row>
         <field>
           <dc-schema>dc</dc-schema>
           <dc-element>type</dc-element>
+          <repeatable>false</repeatable>
           <label>Type</label>
           <input-type>onebox</input-type>
-          <repeatable>false</repeatable>
-          <required>You must select a patent type</required>
           <hint>Select the type of content of the patent.</hint>
+          <required>You must select a patent type</required>
         </field>
      </row>
      <row>
@@ -692,11 +694,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>identifier</dc-element>
          <dc-qualifier>applicationnumber</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Application Number</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>The Application number.</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -704,11 +706,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>date</dc-element>
          <dc-qualifier>filled</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Date filled</label>
          <input-type>date</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>The date Filled.</hint>
+         <required />
        </field>
      </row>
     </form>
@@ -718,22 +720,22 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>language</dc-element>
          <dc-qualifier>iso</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Language</label>
          <input-type value-pairs-name="common_iso_languages">dropdown</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>Select the country and its language.</hint>
+         <required />
        </field>
      </row>
      <row>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>subject</dc-element>
+         <repeatable>true</repeatable>
          <label>Subject Keyword(s)</label>
          <input-type>onebox</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>Enter appropriate subject keywords or phrases.</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -741,11 +743,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>description</dc-element>
          <dc-qualifier>abstract</dc-qualifier>
+         <repeatable>false</repeatable>
          <label>Abstract</label>
          <input-type>textarea</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint>Enter the description of the patent.</hint>
+         <required />
        </field>
      </row>
     </form>
@@ -754,11 +756,11 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>relation</dc-element>
+         <repeatable>true</repeatable>
          <label>Originates From</label>
          <input-type>onebox</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>Enter the name of project, if any, that has produced this patent.</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -766,11 +768,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>relation</dc-element>
          <dc-qualifier>patent</dc-qualifier>
+         <repeatable>true</repeatable>
          <label>Predecessor</label>
          <input-type>onebox</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>Patents that precede (i.e., have priority over) this patent</hint>
+         <required />
        </field>
      </row>
      <row>
@@ -778,11 +780,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>dc</dc-schema>
          <dc-element>relation</dc-element>
          <dc-qualifier>references</dc-qualifier>
+         <repeatable>true</repeatable>
          <label>References</label>
          <input-type>onebox</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint>Result outputs that are referenced by this patent</hint>
+         <required />
        </field>
      </row>
     </form>
@@ -792,33 +794,33 @@ it, please enter the types and the actual numbers or codes.</hint>
              <field>
                  <dc-schema>dc</dc-schema>
                  <dc-element>title</dc-element>
+                 <repeatable>false</repeatable>
                  <label>Title</label>
                  <input-type>onebox</input-type>
-                 <repeatable>false</repeatable>
-                 <required>You must enter the project title</required>
                  <hint />
+                 <required>You must enter the project title</required>
              </field>
          </row>
          <row>
              <field>
                  <dc-schema>oairecerif</dc-schema>
                  <dc-element>funder</dc-element>
+                 <repeatable>true</repeatable>
                  <label>Financing</label>
                  <input-type>inline-group</input-type>
-                 <repeatable>true</repeatable>
-                 <required>You must enter financing information</required>
                  <hint />
+                 <required>You must enter financing information</required>
              </field>
          </row>
          <row>
              <field>
                  <dc-schema>dc</dc-schema>
                  <dc-element>type</dc-element>
+                 <repeatable>false</repeatable>
                  <label>Type</label>
                  <input-type value-pairs-name="funding_types">dropdown</input-type>
-                 <repeatable>false</repeatable>
-                 <required />
                  <hint />
+                 <required />
              </field>
          </row>
      </form>
@@ -828,31 +830,31 @@ it, please enter the types and the actual numbers or codes.</hint>
              <field>
                  <dc-schema>oairecerif</dc-schema>
                  <dc-element>funder</dc-element>
-                 <label>Funder</label>
-                 <input-type>onebox</input-type>
                  <repeatable>false</repeatable>
-                 <required>You must enter the funder</required>
+                 <label>Funder</label>
                  <style>col-xs-12 col-md-6 col-lg-3</style>
+                 <input-type>onebox</input-type>
                  <hint />
+                 <required>You must enter the funder</required>
              </field>
              <field>
                  <dc-schema>oairecerif</dc-schema>
                  <dc-element>amount</dc-element>
+                 <repeatable>false</repeatable>
                  <label>Amount</label>
                  <input-type>onebox</input-type>
-                 <repeatable>false</repeatable>
-                 <required />
                  <hint />
+                 <required />
              </field>
              <field>
                  <dc-schema>oairecerif</dc-schema>
                  <dc-element>amount</dc-element>
                  <dc-qualifier>currency</dc-qualifier>
+                 <repeatable>false</repeatable>
                  <label>Currency</label>
                  <input-type value-pairs-name="currency">dropdown</input-type>
-                 <repeatable>false</repeatable>
-                 <required />
                  <hint />
+                 <required />
              </field>
          </row>
      </form>
@@ -862,31 +864,31 @@ it, please enter the types and the actual numbers or codes.</hint>
        <field>
          <dc-schema>dc</dc-schema>
          <dc-element>title</dc-element>
+         <repeatable>false</repeatable>
          <label>Preferred Name</label>
          <input-type>name</input-type>
-         <repeatable>false</repeatable>
-         <required>You must enter least at the Surname.</required>
          <hint />
+         <required>You must enter least at the Surname.</required>
        </field>
      </row>
      <row>
        <field>
          <dc-schema>person</dc-schema>
          <dc-element>givenName</dc-element>
+         <repeatable>false</repeatable>
          <label>First name</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint />
+         <required />
        </field>
        <field>
          <dc-schema>person</dc-schema>
          <dc-element>familyName</dc-element>
+         <repeatable>false</repeatable>
          <label>Family name</label>
          <input-type>onebox</input-type>
-         <repeatable>false</repeatable>
-         <required />
          <hint />
+         <required />
        </field>
      </row>
      <row>
@@ -894,11 +896,11 @@ it, please enter the types and the actual numbers or codes.</hint>
          <dc-schema>oairecerif</dc-schema>
          <dc-element>identifier</dc-element>
          <dc-qualifier>url</dc-qualifier>
+         <repeatable>true</repeatable>
          <label>Personal Site(s)</label>
          <input-type>link</input-type>
-         <repeatable>true</repeatable>
-         <required />
          <hint />
+         <required />
        </field>
      </row>
    </form>

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionFormConverter.java
@@ -184,6 +184,7 @@ public class SubmissionFormConverter implements DSpaceConverter<DCInputSet, Subm
         if (dcinput.isMetadataField()) {
             inputField.setSelectableMetadata(selectableMetadata);
             inputField.setTypeBind(dcinput.getTypeBindList());
+            inputField.setTypeBindToField(dcinput.getTypeBindToField());
         }
         if (dcinput.isRelationshipField()) {
             selectableRelationship = getSelectableRelationships(dcinput);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionFormFieldRest.java
@@ -99,6 +99,11 @@ public class SubmissionFormFieldRest {
     private List<String> typeBind;
 
     /**
+     * The field to type-bind- to (instead of default, which is defined in dspace.cfg
+     */
+    private String typeBindToField;
+
+    /**
      * Getter for {@link #selectableMetadata}
      * 
      * @return {@link #selectableMetadata}
@@ -304,6 +309,14 @@ public class SubmissionFormFieldRest {
 
     public void setTypeBind(List<String> typeBind) {
         this.typeBind = typeBind;
+    }
+
+    public String getTypeBindToField() {
+        return typeBindToField;
+    }
+
+    public void setTypeBindToField(String typeBindToField) {
+        this.typeBindToField = typeBindToField;
     }
 
     public SelectableRelationship getSelectableRelationship() {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/DescribeStep.java
@@ -77,15 +77,16 @@ public class DescribeStep extends AbstractProcessingStep {
 
     private void readField(InProgressSubmission obj, SubmissionStepConfig config, DataDescribe data,
                            DCInputSet inputConfig) throws DCInputsReaderException {
-        List<MetadataValue> documentTypes = TypeBindUtils.getTypeBindMetadataValues(obj);
-
-        // Get list of all field names (including qualdrop names) allowed for this dc.type
-        List<String> allowedFieldNames =
-            inputConfig.populateAllowedFieldNames(documentTypes.stream().map(MetadataValue::getValue).toList());
-
         // Loop input rows and process submitted metadata
         for (DCInput[] row : inputConfig.getFields()) {
             for (DCInput input : row) {
+                // Type-bind handling
+                List<MetadataValue> documentTypes = TypeBindUtils.getTypeBindMetadataValues(obj, input);
+
+                // Get list of all field names (including qualdrop names) allowed for the type-bound filed
+                List<String> allowedFieldNames =
+                    inputConfig.populateAllowedFieldNames(documentTypes.stream().map(MetadataValue::getValue).toList());
+
                 List<String> fieldsName = new ArrayList<String>();
                 if (input.isQualdropValue()) {
                     for (Object qualifier : input.getPairs()) {

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1359,6 +1359,10 @@ metadata.hide.person.email = true
 # This property should not be left commented out, or the REST configuration
 # exposure will fail
 submit.type-bind.field = dc.type
+# Define the default separator when binding to multiple values. You are able to customize the separator
+# for each field in the submission-forms.xml by using the `speparator`attribute inside the `type-bind` node.separator
+# If this config property is removed, the default separator will be a comma (,) as well (hardcoded in java code)
+submit.type-bind.value-separator = ,
 
 # Wheter or not we REQUIRE that the cclicense is provided
 # during the cclicense step in the submission process

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1362,7 +1362,7 @@ submit.type-bind.field = dc.type
 # Define the default separator when binding to multiple values. You are able to customize the separator
 # for each field in the submission-forms.xml by using the `speparator`attribute inside the `type-bind` node.separator
 # If this config property is removed, the default separator will be a comma (,) as well (hardcoded in java code)
-submit.type-bind.value-separator = ,
+submit.type-bind.value-separator = \,
 
 # Wheter or not we REQUIRE that the cclicense is provided
 # during the cclicense step in the submission process

--- a/dspace/config/modules/bulkedit.cfg
+++ b/dspace/config/modules/bulkedit.cfg
@@ -9,7 +9,7 @@
 # bulkedit.valueseparator = ||
 
 # The delimiter used to separate fields (defaults to a comma for CSV)
-# bulkedit.fieldseparator = ,
+# bulkedit.fieldseparator = \,
 
 # The delimiter used to serarate authority data (defaults to a double colon ::)
 # bulkedit.authorityseparator = ::

--- a/dspace/config/submission-forms.dtd
+++ b/dspace/config/submission-forms.dtd
@@ -14,7 +14,9 @@
  <!ELEMENT dc-qualifier (#PCDATA) >
  <!ELEMENT language (#PCDATA)>
  <!ELEMENT type-bind (#PCDATA) >
-
+ <!ATTLIST type-bind
+         separator CDATA #IMPLIED
+         to-field CDATA #IMPLIED>
  <!ELEMENT repeatable (#PCDATA) >
  <!ELEMENT label (#PCDATA) >
  <!ELEMENT style (#PCDATA) >


### PR DESCRIPTION
## References
* (no issue given so far)
* Requires DSpace/Dspace-angular#5801

## Description
These changes allow you to create a type-bind inside a submission (workspace / workflow) to other fields than "dc.type".

## Instructions for Reviewers
Modify you `submission-forms.xml` like that in the "traditionalpageone" step:

```<row>
 <field>
        <dc-schema>dc</dc-schema>
        <dc-element>title</dc-element>
        <dc-qualifier>alternative</dc-qualifier>
        <repeatable>true</repeatable>
        <label>Other Titles</label>
        <type-bind separator=";" to-field="dc.title">Doe, John;Foo;bar<type-bind>
        <input-type>onebox</input-type>
        <hint>If the item has any alternative titles, please enter them here.</hint>
        <required></required>
    </field>
</row>
``` 
List of changes in this PR:
* You can define custom seperator per each form field; if the comma character does not fit your need, feel free to change it (depends on the values you relate to)
  * Omitting the new attribute will result in the default behaviour (",")
  * The default type-bind seperator character is now defined globally in the config (```submit.type-bind.value-separator = \,```, see dspace.cfg); if the config is not set, it will fallback to a hardcoded comma as before

This pull request has been created as a draft. This version works well for us, but it may not be suitable for all cases or needs. Feel free to test and comment. As soon as someone gives an opinion i could remove the draft mode.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
