### PR TITLE
[Backport dspace-9_x] Ensure certain bundles are admin-only (no policies applied) on creation, installation, or inheritance

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -469,7 +469,9 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
      * by remove all resource policies and
      * set derivative bitstreams to be publicly accessible or
      * replace derivative bitstreams policies using
-     * the same in the source bitstream.
+     * the same in the source bitstream. If the bundle name
+     * is configured in the list of restricted-bundles it will
+     * have all policies cleared
      *
      * @param context the context
      * @param bitstream derivative bitstream
@@ -482,6 +484,16 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
                                                      Bitstream source) throws SQLException, AuthorizeException {
 
         authorizeService.removeAllPolicies(context, bitstream);
+
+        // Return early after clearing policies if any bundle of this bitstream
+        // is in the list of admin-only bundles
+        var restrictedBundles = List.of(configurationService.getArrayProperty(
+            "core.authorization.restricted-bundle",Constants.DEFAULT_RESTRICTED_BUNDLES));
+        for (Bundle bundle : bitstream.getBundles()) {
+            if (restrictedBundles.contains(bundle.getName())) {
+                return;
+            }
+        }
 
         if (publicFiltersClasses.contains(formatFilter.getClass().getSimpleName())) {
             Group anonymous = groupService.findByName(context, Group.ANONYMOUS);

--- a/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BundleServiceImpl.java
@@ -37,6 +37,7 @@ import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
 import org.dspace.eperson.Group;
 import org.dspace.event.Event;
+import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -58,6 +59,8 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
 
     @Autowired(required = true)
     protected BitstreamService bitstreamService;
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
     @Autowired(required = true)
     protected ItemService itemService;
     @Autowired(required = true)
@@ -172,9 +175,33 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
                 Constants.BITSTREAM, bitstream.getID(), String.valueOf(bitstream.getSequenceID()),
                 getIdentifiers(context, bundle)));
 
-        // copy authorization policies from bundle to bitstream
-        // FIXME: multiple inclusion is affected by this...
-        authorizeService.inheritPolicies(context, bundle, bitstream);
+        // If this item is archived (not in-progress) and the bundle is restricted
+        // simply clear all policies, otherwise proceed with normal inheritance
+        var restrictedBundles = List.of(configurationService.getArrayProperty(
+            "core.authorization.restricted-bundle",Constants.DEFAULT_RESTRICTED_BUNDLES));
+        if (owningItem != null && owningItem.isArchived()
+            && restrictedBundles.contains(bundle.getName())) {
+            resourcePolicyService.removeAllPolicies(context, bitstream);
+        } else {
+            // add authorization policies from owning bundle and handle embargoes
+            // hmm, not very "multiple-inclusion" friendly
+            authorizeService.inheritPolicies(context, bundle, bitstream, true);
+            applyDefaultReadPermissionsToBitstream(context, owningItem, bitstream);
+        }
+
+
+        bitstreamService.update(context, bitstream);
+    }
+
+    /**
+     * Ensure that any future start dates on the item or bitstream read policies are honoured
+     * and not overwritten by more "open" owning collection or item policies
+     * @param context DSpace context
+     * @param owningItem the item to which the bitstream belongs
+     * @param bitstream the bitstream to which policies are applied
+     */
+    private void applyDefaultReadPermissionsToBitstream(Context context, Item owningItem, Bitstream bitstream)
+        throws SQLException, AuthorizeException {
         // The next logic is a bit overly cautious but ensures that if there are any future start dates
         // on the item or bitstream read policies, that we'll skip inheriting anything from the owning collection
         // just in case. In practice, the item install process would overwrite these anyway but it may satisfy
@@ -207,7 +234,6 @@ public class BundleServiceImpl extends DSpaceObjectServiceImpl<Bundle> implement
                 }
             }
         }
-        bitstreamService.update(context, bitstream);
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -170,6 +170,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
 
     @Autowired(required = true)
     private ResearcherProfileService researcherProfileService;
+
     @Autowired(required = true)
     private RequestItemService requestItemService;
 
@@ -477,9 +478,18 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
             return;
         }
 
-        // now add authorization policies from owning item
-        // hmm, not very "multiple-inclusion" friendly
-        authorizeService.inheritPolicies(context, item, bundle, true);
+        // If this item is archived (not in-progress) and the bundle is restricted
+        // simply clear all policies, otherwise proceed with normal inheritance
+        var restrictedBundles = List.of(configurationService.getArrayProperty(
+            "core.authorization.restricted-bundle",Constants.DEFAULT_RESTRICTED_BUNDLES));
+        if (item.isArchived() && restrictedBundles.contains(bundle.getName())) {
+            resourcePolicyService.removeAllPolicies(context, bundle);
+        } else {
+            // inherit as normal
+            // TODO: does the following comment still apply? misleading?
+            // hmm, not very "multiple-inclusion" friendly
+            authorizeService.inheritPolicies(context, item, bundle, true);
+        }
 
         // Add the bundle to in-memory list
         item.addBundle(bundle);
@@ -1010,6 +1020,11 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
     public void adjustBundleBitstreamPolicies(Context context, Item item, Collection collection,
                                               boolean replaceReadRPWithCollectionRP)
         throws SQLException, AuthorizeException {
+        // Only inherit policies for the new bundle if it is not in
+        // the restricted list. Otherwise, clear all policies (enforce admin only)
+        var restrictedBundles = List.of(configurationService.getArrayProperty(
+            "core.authorization.restricted-bundle",Constants.DEFAULT_RESTRICTED_BUNDLES));
+
         // Bundles should inherit from DEFAULT_ITEM_READ so that if the item is readable, the files
         // can be listed (even if they are themselves not readable as per DEFAULT_BITSTREAM_READ or other
         // policies or embargoes applied
@@ -1037,6 +1052,16 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         // Remove bundles
         List<Bundle> bunds = item.getBundles();
         for (Bundle mybundle : bunds) {
+            // If the bundle is restricted (e.g. LICENSE, TEXT, SWORD) simply
+            // remove all policies and continue to the next bundle
+            boolean restrictedBundle = restrictedBundles.contains(mybundle.getName());
+            if (restrictedBundle) {
+                authorizeService.removeAllPolicies(context, mybundle);
+                for (Bitstream bitstream : mybundle.getBitstreams()) {
+                    authorizeService.removeAllPolicies(context, bitstream);
+                }
+                continue;
+            }
             // If collection has default READ policies, remove the bundle's READ policies.
             if (removeCurrentReadRPBundle) {
                 authorizeService.removePoliciesActionFilter(context, mybundle, Constants.READ);

--- a/dspace-api/src/main/java/org/dspace/core/Constants.java
+++ b/dspace-api/src/main/java/org/dspace/core/Constants.java
@@ -238,6 +238,11 @@ public class Constants {
     public static final String ENTITY_TYPE_NONE = "none";
 
     /**
+     * Default list of bundle names to restrict only to administrators
+     */
+    public static final String[] DEFAULT_RESTRICTED_BUNDLES = {"LICENSE", "TEXT", "SWORD"};
+
+    /**
      * Default constructor
      */
     private Constants() { }

--- a/dspace-api/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkaccesscontrol/BulkAccessControlIT.java
@@ -1635,11 +1635,9 @@ public class BulkAccessControlIT extends AbstractIntegrationTestWithDatabase {
             matches(Constants.READ, anonymousGroup, "lease", TYPE_CUSTOM, null, "2023-06-24", null)
         ));
 
-        assertThat(textBundle.getBitstreams().get(0).getResourcePolicies(), hasSize(2));
-        assertThat(textBundle.getBitstreams().get(0).getResourcePolicies(), containsInAnyOrder(
-            matches(READ, anonymousGroup, "openaccess", TYPE_CUSTOM),
-            matches(Constants.READ, anonymousGroup, "lease", TYPE_CUSTOM, null, "2023-06-24", null)
-        ));
+        // Unlike the previous bundles, we expect TEXT bundle and bitstreams to inherit NO policies from the
+        // item as TEXT is in the default "restricted bundles" list.
+        assertThat(textBundle.getBitstreams().get(0).getResourcePolicies(), hasSize(0));
     }
 
     @Test

--- a/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/mediafilter/MediaFilterIT.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
@@ -206,8 +207,12 @@ public class MediaFilterIT extends AbstractIntegrationTestWithDatabase {
     }
 
     private CharSequence getContent(Bitstream bitstream) throws IOException, SQLException, AuthorizeException {
+        // TEXT bundles are now expected to be admin-only, and this test does not care about authZ
+        context.turnOffAuthorisationSystem();
         try (InputStream input = bitstreamService.retrieve(context, bitstream)) {
-            return IOUtils.toString(input, "UTF-8");
+            return IOUtils.toString(input, StandardCharsets.UTF_8);
+        } finally {
+            context.restoreAuthSystemState();
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ItemBuilder.java
@@ -43,6 +43,7 @@ import org.dspace.profile.OrcidSynchronizationMode;
 public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
 
     private boolean withdrawn = false;
+    private boolean inArchive = false;
     private String handle = null;
     private WorkspaceItem workspaceItem;
     private Item item;
@@ -309,6 +310,11 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
         return this;
     }
 
+    public ItemBuilder inArchive() {
+        inArchive = true;
+        return this;
+    }
+
     /**
      * Set an embargo to end after some time from "now".
      *
@@ -415,6 +421,9 @@ public class ItemBuilder extends AbstractDSpaceObjectBuilder<Item> {
 
             if (withdrawn) {
                 itemService.withdraw(context, item);
+            }
+            if (inArchive) {
+                item.setArchived(inArchive);
             }
 
             if (lastModified != null) {

--- a/dspace-api/src/test/java/org/dspace/content/security/RestrictedBundleBitstreamIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/security/RestrictedBundleBitstreamIT.java
@@ -1,0 +1,142 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.security;
+
+import java.io.InputStream;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.io.IOUtils;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.mediafilter.factory.MediaFilterServiceFactory;
+import org.dspace.app.mediafilter.service.MediaFilterService;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BundleService;
+import org.dspace.content.service.InstallItemService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of the requirement that some bundles and bitstreams should not inherit parent container
+ * policies (e.g. TEXT, LICENSE, SWORD)
+ *
+ * @author Kim Shepherd
+ */
+public class RestrictedBundleBitstreamIT extends AbstractIntegrationTestWithDatabase {
+
+    private final BundleService bundleService = ContentServiceFactory.getInstance().getBundleService();
+    private final MediaFilterService mediaFilterService =
+            MediaFilterServiceFactory.getInstance().getMediaFilterService();
+    private final InstallItemService installItemService = ContentServiceFactory.getInstance().getInstallItemService();
+
+    Collection collection;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        context.turnOffAuthorisationSystem();
+        Community parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("parent community")
+                .build();
+        collection = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Test Restricted Bundle Collection").build();
+        context.restoreAuthSystemState();
+    }
+    @Test
+    public void testRestrictedBundleBitstreamInProgress() throws Exception {
+        context.turnOffAuthorisationSystem();
+        WorkspaceItem workspaceItem = WorkspaceItemBuilder.createWorkspaceItem(context, collection)
+                .withSubmitter(eperson)
+                .withTitle("In-progress item with a license added")
+                .build();
+        context.restoreAuthSystemState();
+
+        Bundle licenseBundle = BundleBuilder.createBundle(context, workspaceItem.getItem())
+            .withName("LICENSE").build();
+        Bitstream licenseBitstream = BitstreamBuilder.createBitstream(context, licenseBundle,
+                IOUtils.toInputStream("TEST LICENCE", CharEncoding.UTF_8)).build();
+
+        // Install the item
+        context.turnOffAuthorisationSystem();
+        installItemService.installItem(context, workspaceItem);
+        context.restoreAuthSystemState();
+
+        Bundle reloadedLicenseBundle = context.reloadEntity(licenseBundle);
+        Bitstream reloadedBitstream = context.reloadEntity(licenseBitstream);
+
+        // Expect license bundle and bitstream to have NO policies
+        Assert.assertTrue("Installed license bundle should have NO policies",
+                reloadedLicenseBundle.getResourcePolicies().isEmpty());
+        Assert.assertTrue("Installed license bitstream should have NO policies",
+                reloadedBitstream.getResourcePolicies().isEmpty());
+
+    }
+
+    @Test
+    public void testRestrictedBundleBitstreamArchived() throws Exception {
+        context.turnOffAuthorisationSystem();
+        // New public item, in archive. Then add a SWORD bundle + bitstream.
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle("Archived item with SWORD bundle added")
+                .inArchive()
+                .build();
+        Bundle swordBundle = BundleBuilder.createBundle(context, item).withName("SWORD").build();
+        InputStream bitstreamContent = IOUtils.toInputStream("Test archived bitstream", CharEncoding.UTF_8);
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, bitstreamContent)
+                .withName("SWORD file").build();
+        bundleService.addBitstream(context, swordBundle, bitstream);
+        context.restoreAuthSystemState();
+
+        // Expect NO policies on bundle or bitstream
+        Bundle reloadedSwordBundle = context.reloadEntity(swordBundle);
+        Bitstream reloadedSwordBitstream = context.reloadEntity(bitstream);
+        Assert.assertTrue("SWORD bundle should contain no resource policies",
+                reloadedSwordBundle.getResourcePolicies().isEmpty());
+        Assert.assertTrue("SWORD bitstream should contain no resource policies",
+                reloadedSwordBitstream.getResourcePolicies().isEmpty());
+    }
+
+    @Test
+    public void testRestrictedBundleBitstreamMediaFilter() throws Exception {
+        context.turnOffAuthorisationSystem();
+        // New public item, in archive. Then add a TEXT bundle + bitstream and call the
+        // "update policies" method with the media filter service, which normally applies additional policies.
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle("Archived item with SWORD bundle added")
+                .inArchive()
+                .build();
+        Bundle textBundle = BundleBuilder.createBundle(context, item).withName("TEXT").build();
+        InputStream bitstreamContent = IOUtils.toInputStream("Test archived bitstream", CharEncoding.UTF_8);
+        Bitstream bitstream = BitstreamBuilder.createBitstream(context, item, bitstreamContent)
+                .withName("Derived fulltext file").build();
+        bundleService.addBitstream(context, textBundle, bitstream);
+        mediaFilterService.updatePoliciesOfDerivativeBitstreams(context, item, bitstream);
+        context.restoreAuthSystemState();
+
+        // Expect NO policies on bundle or bitstream
+        Bundle reloadedSwordBundle = context.reloadEntity(textBundle);
+        Bitstream reloadedSwordBitstream = context.reloadEntity(bitstream);
+        Assert.assertTrue("TEXT bundle should contain no resource policies",
+                reloadedSwordBundle.getResourcePolicies().isEmpty());
+        Assert.assertTrue("TEXT bitstream should contain no resource policies",
+                reloadedSwordBitstream.getResourcePolicies().isEmpty());
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -2180,8 +2180,22 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                          .build();
         }
 
+        // Anonymous users cannot access bitstreams in restricted bundles (LICENSE)
+        getClient().perform(get("/api/core/bitstreams/search/byItemHandle")
+                .param("handle", publicItem1.getHandle())
+                .param("sequence", String.valueOf(bitstream1.getSequenceID()))
+            )
+            .andExpect(status().isNoContent());
 
         getClient().perform(get("/api/core/bitstreams/search/byItemHandle")
+                .param("handle", publicItem1.getHandle())
+                .param("filename", "BitstreamName")
+            )
+            .andExpect(status().isNoContent());
+
+        // Admin users can still access bitstreams in restricted bundles
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/core/bitstreams/search/byItemHandle")
                                     .param("handle", publicItem1.getHandle())
                                     .param("sequence", String.valueOf(bitstream1.getSequenceID()))
         )
@@ -2191,7 +2205,7 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                        BitstreamMatcher.matchProperties(bitstream1)
                    ));
 
-        getClient().perform(get("/api/core/bitstreams/search/byItemHandle")
+        getClient(adminToken).perform(get("/api/core/bitstreams/search/byItemHandle")
                                     .param("handle", publicItem1.getHandle())
                                     .param("filename", "BitstreamName")
         )
@@ -2234,13 +2248,22 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
                                          .build();
         }
 
+        // Anonymous users cannot access bitstreams in restricted bundles (LICENSE)
 
         getClient().perform(get("/api/core/bitstreams/search/byItemHandle")
                                     .param("handle", publicItem1.getHandle())
                                     .param("sequence", String.valueOf(bitstream1.getSequenceID()))
                                     .param("filename", "WrongBitstreamName")
+            )
+            .andExpect(status().isNoContent());
 
-        )
+        // Admin users can still access bitstreams in restricted bundles
+        String adminToken = getAuthToken(admin.getEmail(), password);
+        getClient(adminToken).perform(get("/api/core/bitstreams/search/byItemHandle")
+                .param("handle", publicItem1.getHandle())
+                .param("sequence", String.valueOf(bitstream1.getSequenceID()))
+                .param("filename", "WrongBitstreamName")
+            )
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
                    .andExpect(jsonPath("$",

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -402,6 +402,13 @@ handle.dir = ${dspace.dir}/handle-server
 #core.authorization.item-admin.delete-bitstream = true
 #core.authorization.item-admin.cc-license = true
 
+#### Restrict internal bundles and bitstreams from inheriting permissions ###
+# Any bundles listed here will have READ access only by ADMIN users
+# Default restricted bundle names are: TEXT, LICENSE, SWORD
+#
+#core.authorization.restricted-bundle = TEXT
+#core.authorization.restricted-bundle = LICENSE
+#core.authorization.restricted-bundle = SWORD
 
 #### Restricted item visibility settings ###
 # By default RSS feeds, OAI-PMH and subscription emails will include ALL items
@@ -418,7 +425,6 @@ handle.dir = ${dspace.dir}/handle-server
 #harvest.includerestricted.rss = true
 #harvest.includerestricted.oai = true
 #harvest.includerestricted.subscription = true
-
 
 #### Proxy Settings ######
 # uncomment and specify both properties if proxy server required


### PR DESCRIPTION
## References
* Fixes #11871 
* Backport of #12306 to `dspace-9_x`.

## Description
See #12306 for information.