### PR TITLE
[DS-4445] Normalize blank metadata language tags

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValue.java
@@ -19,6 +19,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.core.Context;
 import org.dspace.core.HibernateProxyHelper;
@@ -147,7 +148,7 @@ public class MetadataValue implements ReloadableEntity<Integer> {
      * @param language new language
      */
     public void setLanguage(String language) {
-        if (Strings.CS.equals(language, Item.ANY)) {
+        if (Strings.CS.equals(language, Item.ANY) || StringUtils.isBlank(language)) {
             language = null;
         }
         this.language = language;

--- a/dspace-api/src/test/java/org/dspace/content/MetadataValueTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/MetadataValueTest.java
@@ -170,6 +170,38 @@ public class MetadataValueTest extends AbstractUnitTest {
     }
 
     /**
+     * Test of setLanguage method, of class MetadataValue.
+     */
+    @Test
+    public void testSetLanguageNormalizesBlankLanguageToNull() {
+        mv.setLanguage(null);
+        assertThat("testSetLanguageNormalizesBlankLanguageToNull null", mv.getLanguage(), nullValue());
+
+        mv.setLanguage(Item.ANY);
+        assertThat("testSetLanguageNormalizesBlankLanguageToNull any", mv.getLanguage(), nullValue());
+
+        mv.setLanguage("");
+        assertThat("testSetLanguageNormalizesBlankLanguageToNull empty", mv.getLanguage(), nullValue());
+
+        mv.setLanguage(" \t\r\n ");
+        assertThat("testSetLanguageNormalizesBlankLanguageToNull whitespace", mv.getLanguage(), nullValue());
+    }
+
+    /**
+     * Test of setLanguage method, of class MetadataValue.
+     */
+    @Test
+    public void testSetLanguagePreservesNonBlankLanguage() {
+        String language = " eng ";
+        mv.setLanguage(language);
+        assertThat("testSetLanguagePreservesNonBlankLanguage spaced", mv.getLanguage(), equalTo(language));
+
+        language = "not-a-language-tag";
+        mv.setLanguage(language);
+        assertThat("testSetLanguagePreservesNonBlankLanguage invalid", mv.getLanguage(), equalTo(language));
+    }
+
+    /**
      * Test of getPlace method, of class MetadataValue.
      */
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EditItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EditItemRestRepositoryIT.java
@@ -340,6 +340,127 @@ public class EditItemRestRepositoryIT extends AbstractControllerIntegrationTest 
     }
 
     @Test
+    public void patchAddAndReplaceMetadataNormalizesBlankLanguagesTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community").build();
+
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                                           .withEntityType("Publication")
+                                           .withSubmissionDefinition("modeA")
+                                           .withName("Collection 1").build();
+
+        Item itemA = ItemBuilder.createItem(context, col1)
+                                .withTitle("Title of item A")
+                                .withIssueDate("2015-06-25").build();
+
+        EditItem editItem = new EditItem(context, itemA);
+
+        context.restoreAuthSystemState();
+
+        String tokenAdmin = getAuthToken(admin.getEmail(), password);
+
+        List<Operation> operations = new ArrayList<Operation>();
+        List<Map<String, String>> values = new ArrayList<Map<String, String>>();
+        Map<String, String> emptyLanguageValue = new HashMap<String, String>();
+        emptyLanguageValue.put("value", "Empty language");
+        emptyLanguageValue.put("language", "");
+        Map<String, String> whitespaceLanguageValue = new HashMap<String, String>();
+        whitespaceLanguageValue.put("value", "Whitespace language");
+        whitespaceLanguageValue.put("language", " \t\r\n ");
+        Map<String, String> anyLanguageValue = new HashMap<String, String>();
+        anyLanguageValue.put("value", "Any language");
+        anyLanguageValue.put("language", Item.ANY);
+        Map<String, String> nonBlankLanguageValue = new HashMap<String, String>();
+        nonBlankLanguageValue.put("value", "English language");
+        nonBlankLanguageValue.put("language", "en");
+        Map<String, String> otherNonBlankLanguageValue = new HashMap<String, String>();
+        otherNonBlankLanguageValue.put("value", "French language");
+        otherNonBlankLanguageValue.put("language", "fr");
+        values.add(emptyLanguageValue);
+        values.add(whitespaceLanguageValue);
+        values.add(anyLanguageValue);
+        values.add(nonBlankLanguageValue);
+        values.add(otherNonBlankLanguageValue);
+
+        operations.add(new AddOperation("/sections/titleAndIssuedDate/dc.subject", values));
+
+        String patchBody = getPatchContent(operations);
+        getClient(tokenAdmin).perform(patch("/api/core/edititems/" + editItem.getID() + ":FIRST")
+                             .content(patchBody)
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate", Matchers.allOf(
+                                     hasJsonPath("$['dc.subject'][0].value", is("Empty language")),
+                                     hasJsonPath("$['dc.subject'][1].value", is("Whitespace language")),
+                                     hasJsonPath("$['dc.subject'][2].value", is("Any language")),
+                                     hasJsonPath("$['dc.subject'][3].value", is("English language")),
+                                     hasJsonPath("$['dc.subject'][3].language", is("en")),
+                                     hasJsonPath("$['dc.subject'][4].value", is("French language")),
+                                     hasJsonPath("$['dc.subject'][4].language", is("fr"))
+                                     )))
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][0].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][1].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][2].language")
+                                     .doesNotExist());
+
+        // verify that the patch changes have been persisted
+        getClient(tokenAdmin).perform(get("/api/core/edititems/" + editItem.getID() + ":FIRST"))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][0].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][1].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][2].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][3].language",
+                                     is("en")))
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][4].language",
+                                     is("fr")));
+
+        operations.clear();
+        Map<String, String> emptyLanguageReplacement = new HashMap<String, String>();
+        emptyLanguageReplacement.put("value", "English language replaced");
+        emptyLanguageReplacement.put("language", "");
+        Map<String, String> whitespaceLanguageReplacement = new HashMap<String, String>();
+        whitespaceLanguageReplacement.put("value", "French language replaced");
+        whitespaceLanguageReplacement.put("language", " \t\r\n ");
+
+        operations.add(new ReplaceOperation("/sections/titleAndIssuedDate/dc.subject/3", emptyLanguageReplacement));
+        operations.add(new ReplaceOperation("/sections/titleAndIssuedDate/dc.subject/4",
+                whitespaceLanguageReplacement));
+
+        patchBody = getPatchContent(operations);
+        getClient(tokenAdmin).perform(patch("/api/core/edititems/" + editItem.getID() + ":FIRST")
+                             .content(patchBody)
+                             .contentType(MediaType.APPLICATION_JSON_PATCH_JSON))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate", Matchers.allOf(
+                                     hasJsonPath("$['dc.subject'][3].value", is("English language replaced")),
+                                     hasJsonPath("$['dc.subject'][4].value", is("French language replaced"))
+                                     )))
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][3].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][4].language")
+                                     .doesNotExist());
+
+        // verify that replacing existing nonblank languages with blank languages has been persisted
+        getClient(tokenAdmin).perform(get("/api/core/edititems/" + editItem.getID() + ":FIRST"))
+                             .andExpect(status().isOk())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][3].value",
+                                     is("English language replaced")))
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][3].language")
+                                     .doesNotExist())
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][4].value",
+                                     is("French language replaced")))
+                             .andExpect(jsonPath("$.sections.titleAndIssuedDate['dc.subject'][4].language")
+                                     .doesNotExist());
+    }
+
+    @Test
     public void notRepeatableFiledValidationErrorsTest() throws Exception {
         context.turnOffAuthorisationSystem();
 


### PR DESCRIPTION
## References

Fixes #7782

## Description

Normalizes blank metadata language values to `null` when metadata values are written, so edit item metadata no longer persists or returns empty language tags.

## Instructions for Reviewers

List of changes in this PR:

* Updates `MetadataValue#setLanguage` to normalize `null`, empty, whitespace-only, and `Item.ANY` language values to `null`.
* Adds unit coverage for blank language normalization and preservation of nonblank language values.
* Adds edit-item REST integration coverage for both adding metadata with blank language payloads and replacing existing nonblank language values with blank language payloads.

Suggested review path:

* Review `MetadataValue#setLanguage`, as it is the write choke point for the edit-item paths involved here.
* Check `EditItemRestRepositoryIT#patchAddAndReplaceMetadataNormalizesBlankLanguagesTest`, which covers both PATCH response serialization and follow-up GET persistence behavior.

Testing run locally:

* `git diff --check`
* Direct scan of the edited REST test file for lines over 120 chars: no matches.
* `mvn -pl dspace-server-webapp -am -DskipUnitTests=true -DskipIntegrationTests=true -DskipTests compile`
* Targeted integration run reached `EditItemRestRepositoryIT`, compiled test sources, and reported `You have 0 Checkstyle violations`, but failed before assertions because local PostgreSQL was unavailable on `localhost:5432`.

I did not get a local PostgreSQL-backed integration assertion run to a passing state. The new integration test should be confirmed by CI or by a local environment with PostgreSQL available.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests).
- [x] My PR **passes Checkstyle** validation based on the Code Style Guide. Targeted integration setup reported `You have 0 Checkstyle violations`; full Checkstyle was not run separately.
- [x] My PR **includes Javadoc** for all new or modified public methods/classes. No public method/class signatures were added or changed.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the Code Testing Guide. New tests are included; local integration assertion execution was blocked by PostgreSQL unavailability and should be confirmed by CI.
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies, licenses align with the DSpace BSD License. Not applicable; no dependencies added.
- [x] If my PR modifies REST API endpoints, I've opened a separate REST Contract PR related to this change. Not applicable; no endpoint contract is changed.
- [x] If my PR fixes an issue ticket, I've linked them together.
