### PR TITLE
Keep language-neutral metadata visible in the default projection

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -1138,7 +1138,17 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
             return metadataValues;
         }
 
-        return matchedValues;
+//        a localized match was found. Values without a language are language-neutral (e.g.
+//        dc.description.provenance, identifiers, dates, or any value added via the REST API without
+//        a language) and are not translations of the localized values, so they must remain visible
+//        alongside the localized matches. Preserve the original order/places.
+        List<MetadataValue> result = new ArrayList<>();
+        for (MetadataValue value : metadataValues) {
+            if (value.getLanguage() == null || matchedValues.contains(value)) {
+                result.add(value);
+            }
+        }
+        return result;
     }
 
     private List<MetadataValue> filterByLanguageInSupportedLocales(List<MetadataValue> metadataValues,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DSpaceRestRepositoryLanguageIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DSpaceRestRepositoryLanguageIT.java
@@ -84,12 +84,14 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
 
         String token = getAuthToken(admin.getEmail(), password);
 
-//        When no projection is requested
+//        When no projection is requested. Language-neutral (null language) values are always
+//        returned alongside the values matching the requested locale.
         getClient(token).perform(get("/api/core/items/" + item.getID())
                             .header("Accept-Language", Locale.ENGLISH.getLanguage()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
-                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 0, "en")))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Item", 0, null)))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 1, "en")))
                         .andExpect(jsonPath("$.metadata",
                             matchMetadata("dc.contributor.author", "english author1", 0, "en")))
                         .andExpect(jsonPath("$.metadata",
@@ -107,7 +109,8 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
                             .header("Accept-Language", "en_US"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
-                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 0, "en")))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Item", 0, null)))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 1, "en")))
                         .andExpect(jsonPath("$.metadata",
                             matchMetadata("dc.contributor.author", "english author1", 0, "en")))
                         .andExpect(jsonPath("$.metadata",
@@ -125,7 +128,8 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
                             .header("Accept-Language", Locale.GERMAN.getLanguage()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$", ItemMatcher.matchItemProperties(item)))
-                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "german title", 0, "de")))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Item", 0, null)))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "german title", 1, "de")))
                         .andExpect(jsonPath("$.metadata",
                             matchMetadata("dc.contributor.author", "german author1", 0, "de")))
                         .andExpect(jsonPath("$.metadata",
@@ -167,6 +171,32 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
 
     }
 
+    /**
+     * A metadata value without a language (language-neutral, e.g. dc.description.provenance or any
+     * value added through the REST API without a language) must remain visible in the default
+     * projection even when the same field also contains a value matching the active locale.
+     */
+    @Test
+    public void testNullLanguageValuesRemainVisibleAlongsideLocalizedValues() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+
+        Item item = ItemBuilder.createItem(context, collection)
+                               .withTitle("Item")
+                               .withTitleForLanguage("english title", "en")
+                               .build();
+
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/core/items/" + item.getID())
+                            .header("Accept-Language", Locale.ENGLISH.getLanguage()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "Item", 0, null)))
+                        .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 1, "en")));
+    }
+
     @Test
     public void testFindCollection() throws Exception {
 
@@ -185,9 +215,9 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
                        .header("Accept-Language", Locale.ENGLISH.getLanguage()))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 0, "en")))
-                   .andExpect(jsonPath("$.metadata", matchMetadataLanguageDoesNotExist("dc.title", "de")))
-                   .andExpect(jsonPath("$.metadata", matchMetadataLanguageDoesNotExist("dc.title", null)));
+                   .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "collection", 0, null)))
+                   .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 1, "en")))
+                   .andExpect(jsonPath("$.metadata", matchMetadataLanguageDoesNotExist("dc.title", "de")));
 
 //        When allLanguages projection is requested
         getClient().perform(get("/api/core/collections/" + collection.getID())
@@ -217,9 +247,9 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
                        .header("Accept-Language", Locale.ENGLISH.getLanguage()))
                    .andExpect(status().isOk())
                    .andExpect(content().contentType(contentType))
-                   .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 0, "en")))
-                   .andExpect(jsonPath("$.metadata", matchMetadataLanguageDoesNotExist("dc.title", "de")))
-                   .andExpect(jsonPath("$.metadata", matchMetadataLanguageDoesNotExist("dc.title", null)));
+                   .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "community", 0, null)))
+                   .andExpect(jsonPath("$.metadata", matchMetadata("dc.title", "english title", 1, "en")))
+                   .andExpect(jsonPath("$.metadata", matchMetadataLanguageDoesNotExist("dc.title", "de")));
 
 //        When allLanguages projection is requested
         getClient().perform(get("/api/core/communities/" + community.getID())
@@ -260,13 +290,13 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
                         .andExpect(jsonPath("$._embedded.item",
                                             ItemMatcher.matchItemProperties(workspaceItem.getItem())))
                         .andExpect(jsonPath("$._embedded.item.metadata",
-                                            matchMetadata("dc.title", "english title", 0, "en")))
+                                            matchMetadata("dc.title", "workspaceItem title", 0, null)))
+                        .andExpect(jsonPath("$._embedded.item.metadata",
+                                            matchMetadata("dc.title", "english title", 1, "en")))
                         .andExpect(jsonPath("$._embedded.item.metadata",
                                             matchMetadata("dspace.entity.type", "Publication", 0, null)))
                         .andExpect(jsonPath("$._embedded.item.metadata",
                                             matchMetadata("dc.subject", "german subject", 0, "de")))
-                        .andExpect(jsonPath("$._embedded.item.metadata",
-                                            matchMetadataLanguageDoesNotExist("dc.title", null)))
                         .andExpect(jsonPath("$._embedded.item.metadata",
                                             matchMetadataLanguageDoesNotExist("dc.title", "de")))
                         .andExpect(jsonPath("$._embedded.item.metadata",
@@ -328,13 +358,13 @@ public class DSpaceRestRepositoryLanguageIT extends AbstractControllerIntegratio
                         .andExpect(jsonPath("$._embedded.item",
                                             ItemMatcher.matchItemProperties(workflowItem.getItem())))
                         .andExpect(jsonPath("$._embedded.item.metadata",
-                                            matchMetadata("dc.title", "english title", 0, "en")))
+                                            matchMetadata("dc.title", "workflowItem title", 0, null)))
+                        .andExpect(jsonPath("$._embedded.item.metadata",
+                                            matchMetadata("dc.title", "english title", 1, "en")))
                         .andExpect(jsonPath("$._embedded.item.metadata",
                                             matchMetadata("dspace.entity.type", "Publication", 0, null)))
                         .andExpect(jsonPath("$._embedded.item.metadata",
                                             matchMetadata("dc.subject", "german subject", 0, "de")))
-                        .andExpect(jsonPath("$._embedded.item.metadata",
-                                            matchMetadataLanguageDoesNotExist("dc.title", null)))
                         .andExpect(jsonPath("$._embedded.item.metadata",
                                             matchMetadataLanguageDoesNotExist("dc.title", "de")))
                         .andExpect(jsonPath("$._embedded.item.metadata",

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenancePatchIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProvenancePatchIT.java
@@ -1,0 +1,65 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.dspace.app.rest.matcher.MetadataMatcher.matchMetadata;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.dspace.app.rest.model.patch.AddOperation;
+import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+
+/**
+ * Regression test for the issue where a dc.description.provenance value added via REST PATCH
+ * returned HTTP 200 and was persisted, but was invisible in the default item projection.
+ *
+ * System provenance is written with language "en" (e.g. by InstallItem), while a PATCH stores the
+ * new value with a null language. The per-field language filter used to drop the null-language
+ * value when a locale-matching value existed for the field. Language-neutral (null-language) values
+ * must remain visible alongside the localized values.
+ */
+public class ProvenancePatchIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void patchAddProvenanceIsVisibleInDefaultProjection() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("Parent Community").build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                                            .build();
+        // An installed item already carries a system provenance value with language "en".
+        Item item = ItemBuilder.createItem(context, col1).withTitle("Public item 1").build();
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        List<Operation> ops = List.of(
+            new AddOperation("/metadata/dc.description.provenance/-", "User added provenance"));
+        getClient(token).perform(patch("/api/core/items/" + item.getID())
+                            .content(getPatchContent(ops))
+                            .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk());
+
+        // The added (null-language) provenance must be visible to an admin in the default projection.
+        getClient(token).perform(get("/api/core/items/" + item.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.metadata",
+                            matchMetadata("dc.description.provenance", "User added provenance")));
+    }
+}


### PR DESCRIPTION
## References

Fixes #12636

## Description

A metadata value added through the REST API to a field that already contains a value in the active locale's language was silently invisible in the default item representation, even though it was persisted.

The most visible case is `dc.description.provenance`:

1. A REST `PATCH add` of `dc.description.provenance` returns `200 OK`.
2. The value is written to the database (and is visible with `?projection=allLanguages`).
3. But it does not appear in a normal `GET /api/core/items/{id}`, so it looks like the operation was silently ignored.

Root cause: the per-field language filter `DSpaceObjectServiceImpl#filterMetadataValuesByLanguage` (introduced with the authority framework port, `2455974852`) returns only the values whose language matches the active/supported locale when at least one such value exists for a field, and drops the `null`-language values. System provenance is written with a hardcoded `"en"` language (InstallItem, the workflow service, importers, the OAI harvester, packagers), while a `PATCH add` stores the new value with a `null` language, so the request locale (`en`) makes the filter drop the user's value.

This filter is not present in 7.x/8.x/9.x or `<= 10.0`; it is present in `dspace-10_x` (10.1) and `main`, so this is a regression for those lines.

This PR makes `null`-language ("language-neutral") values always returned alongside the locale matches. Such values are not translations of the localized values (think `dc.description.provenance`, identifiers, dates, or any value added via the REST API without a language), so they should never be hidden because a localized sibling exists. The `allLanguages` projection and the "no locale match" behavior are unchanged.

## Instructions for Reviewers

List of changes in this PR:

* `DSpaceObjectServiceImpl#filterMetadataValuesByLanguage`: when a localized match is found for a field, also retain the `null`-language values (preserving the original order/places). The "no match returns all values" fallback is unchanged.
* `DSpaceRestRepositoryLanguageIT`: updated the default-projection expectations so the language-neutral values now appear at their original positions alongside the localized ones (the `allLanguages` expectations were already correct and are unchanged), and added `testNullLanguageValuesRemainVisibleAlongsideLocalizedValues`.
* `ProvenancePatchIT`: new regression test that PATCH-adds a `dc.description.provenance` value to an installed item and asserts it is visible in the default projection.

To test:

* `mvn -pl dspace-server-webapp -DskipIntegrationTests=false -Dit.test=DSpaceRestRepositoryLanguageIT,ProvenancePatchIT verify` (after `mvn install`). Both pass locally.
* Manual: PATCH `add /metadata/dc.description.provenance/-` on an archived item as an administrator, then `GET /api/core/items/{id}` (the value is now present) and confirm the `allLanguages` projection is unchanged.

This is a regression that also affects `dspace-10_x` (10.1); a backport would be appropriate if accepted.

## Checklist

_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is created against the `main` branch of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests).
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide). `checkstyle:check` passes for `dspace-api` and `dspace-server-webapp`.
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. No public method/class signatures were added or changed; the modified private method retains its Javadoc, and the new tests are documented.
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR includes details on how to test it.
- [x] If my PR includes new, third-party dependencies, I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE). N/A, no dependencies added.
- [ ] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change. The set of returned metadata values changes (previously-hidden language-neutral values are now returned), but no endpoint or contract structure changes; happy to open a REST Contract note if reviewers prefer.
