### PR TITLE
[Dependabot] For GitHub Actions, group together all actions officially built by GitHub (Port to Backend)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -162,6 +162,20 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*"
+          - "github/*"
+    ignore:
+        # For official GitHub actions, ignore minor & patch releases because we reference these actions
+        # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+        - dependency-name: "actions/*"
+          update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+        - dependency-name: "github/*"
+          update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   ######################
   ## dspace-10_x branch
   ######################
@@ -320,6 +334,20 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*"
+          - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   ######################
   ## dspace-9_x branch
   ######################
@@ -480,6 +508,20 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*"
+          - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   ######################
   ## dspace-8_x branch
   ######################
@@ -640,3 +682,17 @@ updates:
     # some classes of supply chain attacks
     cooldown:
       default-days: 7
+    groups:
+      # Group together all GitHub official actions into a single PR
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "actions/*"
+          - "github/*"
+    ignore:
+      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
+      - dependency-name: "actions/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]

--- a/.github/workflows/issue_opened.yml
+++ b/.github/workflows/issue_opened.yml
@@ -16,7 +16,7 @@ jobs:
       # Only add to project board if issue is flagged as "needs triage" or has no labels
       # NOTE: By default we flag new issues as "needs triage" in our issue template
       if: (contains(github.event.issue.labels.*.name, 'needs triage') || join(github.event.issue.labels.*.name) == '')
-      uses: actions/add-to-project@v1.0.2
+      uses: actions/add-to-project@v2
       # Note, the authentication token below is an ORG level Secret. 
       # It must be created/recreated manually via a personal access token with admin:org, project, public_repo permissions
       # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token


### PR DESCRIPTION
## References
* Port of https://github.com/DSpace/dspace-angular/pull/5806 to `DSpace/DSpace`

## Description
Improves our configuration of `dependabot` for GitHub Actions by doing the following:
* Automatically group all actions officially created by GitHub into a single PR.
* Only update actions officially created by GitHub when a new **major** version is released.  
    * This is because we use a "rolling tag" (e.g. `@v2`) for officially GitHub actions.  For instance `@v2` means run the latest `2.x.x` version...so, it auto-updates already.  We only need to update our GitHub action when version 3 would be released.
    * NOTE: We do not use "rolling tag" versions for non-official actions, just for safety.  So, this only impacts official actions from GitHub.

NOTE: This PR also includes an upgrade to the latest major version of `actions/add-to-project`, as that is the only official GitHub actions in this repository which isn't using a "rolling tag" (as described above)