### PR TITLE
[Dependabot] Disable updating of HAL Browser via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -148,6 +148,8 @@ updates:
       # used by Hibernate and Solr. The version is pinned in pom.xml and should
       # only be updated when required. See: https://github.com/DSpace/DSpace/pull/11989
       - dependency-name: "org.antlr:antlr4-runtime"
+      # The HAL Browser cannot be upgraded automatically as it uses a hash code for versioning.
+      - dependency-name: "org.webjars:hal-browser"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -319,6 +321,8 @@ updates:
       # used by Hibernate and Solr. The version is pinned in pom.xml and should
       # only be updated when required. See: https://github.com/DSpace/DSpace/pull/11989
       - dependency-name: "org.antlr:antlr4-runtime"
+      # The HAL Browser cannot be upgraded automatically as it uses a hash code for versioning.
+      - dependency-name: "org.webjars:hal-browser"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
@@ -493,6 +497,8 @@ updates:
       # used by Hibernate and Solr. The version is pinned in pom.xml and should
       # only be updated when required. See: https://github.com/DSpace/DSpace/pull/11989
       - dependency-name: "org.antlr:antlr4-runtime"
+      # The HAL Browser cannot be upgraded automatically as it uses a hash code for versioning.
+      - dependency-name: "org.webjars:hal-browser"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
@@ -667,6 +673,8 @@ updates:
       # used by Hibernate and Solr. The version is pinned in pom.xml and should
       # only be updated when required. See: https://github.com/DSpace/DSpace/pull/11989
       - dependency-name: "org.antlr:antlr4-runtime"
+      # The HAL Browser cannot be upgraded automatically as it uses a hash code for versioning.
+      - dependency-name: "org.webjars:hal-browser"
       # Ignore all major version updates for all dependencies. We'll only automate minor/patch updates.
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
## References
* Related to #12619 

## Description
Minor update to dependabot settings to disable auto-updating of the `hal-browser`, as it can only be updated manually.  The `hal-browser` versions are based on a hash code rather than a normal version numbering system.  This confuses `dependabot`. See #12619 for example