### PR TITLE
Restrict External Sources in REST API to logged in users

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedModel;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -54,6 +55,7 @@ public class ExternalSourcesRestController {
      * @return              A paginated list of ExternalSourceEntryResource objects that comply with the params
      */
     @RequestMapping(method = RequestMethod.GET, value = "/entries")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public PagedModel<ExternalSourceEntryResource> getExternalSourceEntries(
         @PathVariable("externalSourceName") String externalSourceName,
         @RequestParam(name = "query") String query,
@@ -81,6 +83,7 @@ public class ExternalSourcesRestController {
      * @return              An ExternalSourceEntryResource that complies with the above params
      */
     @RequestMapping(method = RequestMethod.GET, value = "/entryValues/{entryId}")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public ExternalSourceEntryResource getExternalSourceEntryValue(@PathVariable("externalSourceName") String
                                                                            externalSourceName,
                                                                    @PathVariable("entryId") String entryId) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
@@ -82,7 +82,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
     }
 
     @Override
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public ExternalSourceRest findOne(Context context, String externalSourceName) {
         ExternalDataProvider externalDataProvider = externalDataService.getExternalDataProvider(externalSourceName);
         if (externalDataProvider == null) {
@@ -93,7 +93,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
     }
 
     @Override
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public Page<ExternalSourceRest> findAll(Context context, Pageable pageable) {
         List<ExternalDataProvider> externalSources = externalDataService.getExternalDataProviders();
         return converter.toRestPage(externalSources, pageable, utils.obtainProjection());
@@ -107,7 +107,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
      * @param entityType    Entity type label
      * @return
      */
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     @SearchRestMethod(name = "findByEntityType")
     public Page<ExternalSourceRest> findByEntityType(Context context, Pageable pageable,
           @Parameter(required = true, value = "entityType") String entityType) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
@@ -215,6 +215,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void testAuthorityImportDataProviderExternalSource() throws Exception {
         context.turnOffAuthorisationSystem();
+        context.setCurrentUser(admin);
         configurationService.setProperty("choices.externalsource.dc.contributor.author", "authorAuthority");
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
@@ -270,6 +271,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void testAuthorityImportDataProviderExternalSourceWithPlaceholder() throws Exception {
         context.turnOffAuthorisationSystem();
+        context.setCurrentUser(admin);
         configurationService.setProperty("choices.externalsource.dc.contributor.author", "authorAuthority");
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
@@ -324,6 +326,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     @Test
     public void testAuthorityImportDataProviderExternalSourceWithEmptyValue() throws Exception {
         context.turnOffAuthorisationSystem();
+        context.setCurrentUser(admin);
         configurationService.setProperty("choices.externalsource.dc.contributor.author", "authorAuthority");
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
@@ -36,6 +36,7 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.util.UUIDUtils;
 import org.dspace.xmlworkflow.storedcomponents.XmlWorkflowItem;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -47,9 +48,19 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     @Autowired
     private ExternalDataService externalDataService;
 
+    String token;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
+    }
+
     @Test
     public void findAllExternalSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources").param("size", "21"))
+        getClient(token).perform(get("/api/integration/externalsources").param("size", "21"))
                             .andExpect(status().isOk())
                             .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItems(
                                 ExternalSourceMatcher.matchExternalSource("mock", "mock", false),
@@ -89,22 +100,35 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
+    public void findAllExternalSourcesAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources").param("size", "21"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findOneExternalSourcesExistingSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock"))
+        getClient(token).perform(get("/api/integration/externalsources/mock"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceMatcher.matchExternalSource("mock", "mock", false)
                    )));
     }
+
+    @Test
+    public void findOneExternalSourcesExistingSourcesAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/mock"))
+                        .andExpect(status().isUnauthorized());
+    }
+
     @Test
     public void findOneExternalSourcesNotExistingSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock2"))
+        getClient(token).perform(get("/api/integration/externalsources/mock2"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntryValue() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entryValues/one"))
+        getClient(token).perform(get("/api/integration/externalsources/mock/entryValues/one"))
                    .andExpect(status().isOk())
                     .andExpect(jsonPath("$", Matchers.is(
                         ExternalSourceEntryMatcher.matchExternalSourceEntry("one", "one", "one", "mock")
@@ -112,27 +136,33 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
+    public void findOneExternalSourceEntryValueAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/mock/entryValues/one"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findOneExternalSourceEntryValueInvalidEntryId() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entryValues/entryIdInvalid"))
+        getClient(token).perform(get("/api/integration/externalsources/mock/entryValues/entryIdInvalid"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntryValueInvalidSource() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mocktwo/entryValues/one"))
+        getClient(token).perform(get("/api/integration/externalsources/mocktwo/entryValues/one"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntriesInvalidSource() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mocktwo/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mocktwo/entries")
                                 .param("query", "test"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntriesApplicableQuery() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "one"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.containsInAnyOrder(
@@ -143,8 +173,15 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
-    public void findOneExternalSourceEntriesApplicableQueryPagination() throws Exception {
+    public void findOneExternalSourceEntriesApplicableQueryAnonymous() throws Exception {
         getClient().perform(get("/api/integration/externalsources/mock/entries")
+                                     .param("query", "one"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findOneExternalSourceEntriesApplicableQueryPagination() throws Exception {
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "one").param("size", "1"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(
@@ -152,7 +189,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                    )))
                    .andExpect(jsonPath("$.page", PageMatcher.pageEntryWithTotalPagesAndElements(0, 1, 2, 2)));
 
-        getClient().perform(get("/api/integration/externalsources/mock/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "one").param("size", "1").param("page", "1"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(
@@ -163,7 +200,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void findOneExternalSourceEntriesNoReturnQuery() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "randomqueryfornoresults"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded").doesNotExist());
@@ -171,7 +208,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void findOneExternalSourceEntriesNoQuery() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entries"))
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries"))
                    .andExpect(status().isBadRequest());
     }
 
@@ -203,7 +240,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         context.restoreAuthSystemState();
 
         String exteranlSourceId = UUIDUtils.toString(itemUUID) + ":0";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceEntryMatcher.matchItemWithGivenMetadata("dc.title",
@@ -213,7 +251,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                                                                              "Affiliation one", "0"))));
 
         exteranlSourceId = UUIDUtils.toString(itemUUID) + ":1";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceEntryMatcher.matchItemWithGivenMetadata("dc.title",
@@ -223,7 +262,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                                                                              "Affiliation two", "0"))));
 
         exteranlSourceId = UUIDUtils.toString(itemUUID) + ":2";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isBadRequest());
     }
 
@@ -255,7 +295,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         context.restoreAuthSystemState();
 
         String exteranlSourceId = UUIDUtils.toString(itemUUID) + ":0";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceEntryMatcher.matchItemWithGivenMetadata("dc.title",
@@ -265,7 +306,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                                                                              "Affiliation one", "0"))));
 
         exteranlSourceId = UUIDUtils.toString(itemUUID) + ":1";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceEntryMatcher.matchItemWithGivenMetadata("dc.title",
@@ -274,7 +316,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                        ExternalSourceEntryMatcher.matchMetadataDoesNotExist("person.affiliation.name"))));
 
         exteranlSourceId = UUIDUtils.toString(itemUUID) + ":2";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isBadRequest());
     }
 
@@ -305,7 +348,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         context.restoreAuthSystemState();
 
         String exteranlSourceId = UUIDUtils.toString(itemUUID) + ":0";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceEntryMatcher.matchItemWithGivenMetadata("dc.title",
@@ -315,7 +359,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                                                                              "Affiliation one", "0"))));
 
         exteranlSourceId = UUIDUtils.toString(itemUUID) + ":1";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceEntryMatcher.matchItemWithGivenMetadata("dc.title",
@@ -324,7 +369,8 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                        ExternalSourceEntryMatcher.matchMetadataDoesNotExist("person.affiliation.name"))));
 
         exteranlSourceId = UUIDUtils.toString(itemUUID) + ":2";
-        getClient().perform(get("/api/integration/externalsources/authorAuthority/entryValues/" + exteranlSourceId))
+        getClient(token).perform(get("/api/integration/externalsources/authorAuthority/entryValues/" +
+                                         exteranlSourceId))
                    .andExpect(status().isBadRequest());
     }
 
@@ -335,7 +381,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         List<ExternalDataProvider> journalProviders =
                 externalDataService.getExternalDataProvidersForEntityType("Journal");
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Publication"))
                    .andExpect(status().isOk())
                    // Expect that Publication sources match (check a max of 20 as that is default page size)
@@ -344,7 +390,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                               ))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(publicationProviders.size())));
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal"))
                    .andExpect(status().isOk())
                    // Check that Journal sources match (check a max of 20 as that is default page size)
@@ -355,8 +401,15 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
+    public void findExternalSourcesByEntityTypeAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+                        .param("entityType", "Publication"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findExternalSourcesByEntityTypeBadRequestTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType"))
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType"))
                    .andExpect(status().isBadRequest());
     }
 
@@ -370,7 +423,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         int pageSize = 2;
         int numberOfPages = (int) Math.ceil((double) numJournalProviders / pageSize);
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal")
                    .param("size", String.valueOf(pageSize)))
                    .andExpect(status().isOk())
@@ -380,7 +433,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                    .andExpect(jsonPath("$.page.totalPages", Matchers.is(numberOfPages)))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(numJournalProviders)));
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal")
                    .param("page", "1")
                    .param("size", String.valueOf(pageSize)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexFunderExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexFunderExternalSourcesIT.java
@@ -49,15 +49,20 @@ public class OpenAlexFunderExternalSourcesIT extends AbstractControllerIntegrati
     @Qualifier("openalexImportFunderService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
-    public void setUp() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportFunderExternalExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexFunder",
                                                                  "openalexFunder", false))));
@@ -71,11 +76,18 @@ public class OpenAlexFunderExternalSourcesIT extends AbstractControllerIntegrati
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexFunder/entries")
-                                    .param("query", "empty"))
-                       .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
+            getClient(token).perform(get("/api/integration/externalsources/openalexFunder/entries")
+                                         .param("query", "empty"))
+                            .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexFunderExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexFunder/entries")
+                                .param("query", "empty"))
+                   .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -86,7 +98,7 @@ public class OpenAlexFunderExternalSourcesIT extends AbstractControllerIntegrati
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexFunder/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexFunder/entries")
                                     .param("query", "National"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries[0].id").value("F4320321001"))
@@ -168,7 +180,7 @@ public class OpenAlexFunderExternalSourcesIT extends AbstractControllerIntegrati
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexFunder/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexFunder/entries")
                                     .param("query", "National"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexInstitutionExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexInstitutionExternalSourcesIT.java
@@ -49,15 +49,20 @@ public class OpenAlexInstitutionExternalSourcesIT extends AbstractControllerInte
     @Qualifier("openalexImportInstitutionService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
-    public void setUp() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportInstitutionExternalExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexInstitution",
                                                                  "openalexInstitution", false))));
@@ -71,11 +76,18 @@ public class OpenAlexInstitutionExternalSourcesIT extends AbstractControllerInte
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexInstitution/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexInstitution/entries")
                                     .param("query", "empty"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexInstitutionExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexInstitution/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -86,7 +98,7 @@ public class OpenAlexInstitutionExternalSourcesIT extends AbstractControllerInte
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexInstitution/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexInstitution/entries")
                                     .param("query", "Centre"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries[0].id").value("I1294671590"))
@@ -138,7 +150,7 @@ public class OpenAlexInstitutionExternalSourcesIT extends AbstractControllerInte
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexInstitution/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexInstitution/entries")
                                     .param("query", "Centre"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexJournalExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexJournalExternalSourcesIT.java
@@ -53,15 +53,20 @@ public class OpenAlexJournalExternalSourcesIT extends AbstractControllerIntegrat
     @Qualifier("openalexImportJournalService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
-    public void setUp() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportJournalServiceExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexJournal",
                                                                  "openalexJournal", false))));
@@ -76,11 +81,18 @@ public class OpenAlexJournalExternalSourcesIT extends AbstractControllerIntegrat
                 .thenReturn(jsonResponse);
 
 
-            getClient().perform(get("/api/integration/externalsources/openalexJournal/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexJournal/entries")
                                     .param("query", "empty"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexJournalExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexJournal/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -91,7 +103,7 @@ public class OpenAlexJournalExternalSourcesIT extends AbstractControllerIntegrat
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexJournal/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexJournal/entries")
                                     .param("query", "Chem"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries[0].id").value("S41354064"))
@@ -142,7 +154,7 @@ public class OpenAlexJournalExternalSourcesIT extends AbstractControllerIntegrat
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexJournal/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexJournal/entries")
                                     .param("query", "Chem"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPersonExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPersonExternalSourcesIT.java
@@ -49,15 +49,20 @@ public class OpenAlexPersonExternalSourcesIT extends AbstractControllerIntegrati
     @Qualifier("openalexImportPersonService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
-    public void setUp() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportPersonServiceExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexPerson",
                                                                  "openalexPerson", false))));
@@ -72,11 +77,18 @@ public class OpenAlexPersonExternalSourcesIT extends AbstractControllerIntegrati
                 .thenReturn(jsonResponse);
 
 
-            getClient().perform(get("/api/integration/externalsources/openalexPerson/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPerson/entries")
                                     .param("query", "empty"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexPersonExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexPerson/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -86,7 +98,7 @@ public class OpenAlexPersonExternalSourcesIT extends AbstractControllerIntegrati
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPerson/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPerson/entries")
                                     .param("query", "Claudio Cortese"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$.page.number", is(0)))
@@ -141,7 +153,7 @@ public class OpenAlexPersonExternalSourcesIT extends AbstractControllerIntegrati
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPerson/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPerson/entries")
                                     .param("query", "covid"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublicationByAuthorIdExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublicationByAuthorIdExternalSourcesIT.java
@@ -61,16 +61,20 @@ public class OpenAlexPublicationByAuthorIdExternalSourcesIT extends AbstractCont
     @Qualifier("openalexImportPublicationByAuthorIdService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportPublicationByAuthorIdExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexPublicationByAuthorId",
                                                                  "openalexPublicationByAuthorId", false))));
@@ -85,11 +89,18 @@ public class OpenAlexPublicationByAuthorIdExternalSourcesIT extends AbstractCont
                 .thenReturn(jsonResponse);
 
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
                                     .param("query", "W1775749144"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexPublicationByAuthorIdExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
+                                     .param("query", "W1775749144"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -101,7 +112,7 @@ public class OpenAlexPublicationByAuthorIdExternalSourcesIT extends AbstractCont
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
                                     .param("query", "A5050011235"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasSize(1)))
@@ -221,7 +232,7 @@ public class OpenAlexPublicationByAuthorIdExternalSourcesIT extends AbstractCont
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublicationByAuthorId/entries")
                                     .param("query", "A5050011235"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublicationByDOIExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublicationByDOIExternalSourcesIT.java
@@ -60,16 +60,20 @@ public class OpenAlexPublicationByDOIExternalSourcesIT extends AbstractControlle
     @Qualifier("openalexImportPublicationByDOIService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportPublicationByDOIExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexPublicationByDOI",
                                                                  "openalexPublicationByDOI", false))));
@@ -84,11 +88,18 @@ public class OpenAlexPublicationByDOIExternalSourcesIT extends AbstractControlle
                 .thenReturn(jsonResponse);
 
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
                                     .param("query", "W1775749144"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexPublicationByDOIExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
+                                     .param("query", "W1775749144"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -100,7 +111,7 @@ public class OpenAlexPublicationByDOIExternalSourcesIT extends AbstractControlle
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
                                     .param("query", "10.1016/s0021-9258(19)52451-6"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasSize(1)))
@@ -220,7 +231,7 @@ public class OpenAlexPublicationByDOIExternalSourcesIT extends AbstractControlle
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublicationByDOI/entries")
                                     .param("query", "https://doi.org/10.1016/s0021-9258(19)52451-6"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasSize(1)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublicationExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublicationExternalSourcesIT.java
@@ -61,16 +61,20 @@ public class OpenAlexPublicationExternalSourcesIT extends AbstractControllerInte
     @Qualifier("openalexImportPublicationService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportPublicationExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexPublication",
                                                                  "openalexPublication", false))));
@@ -85,11 +89,18 @@ public class OpenAlexPublicationExternalSourcesIT extends AbstractControllerInte
                 .thenReturn(jsonResponse);
 
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublication/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublication/entries")
                                     .param("query", "empty"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexPublicationExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexPublication/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -101,7 +112,7 @@ public class OpenAlexPublicationExternalSourcesIT extends AbstractControllerInte
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublication/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublication/entries")
                                     .param("query", "protein"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasSize(1)))
@@ -200,7 +211,7 @@ public class OpenAlexPublicationExternalSourcesIT extends AbstractControllerInte
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublication/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublication/entries")
                                     .param("query", "covid"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublisherExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenAlexPublisherExternalSourcesIT.java
@@ -49,15 +49,20 @@ public class OpenAlexPublisherExternalSourcesIT extends AbstractControllerIntegr
     @Qualifier("openalexImportPublisherService")
     private OpenAlexImportMetadataSourceServiceImpl openAlexImportMetadataSourceService;
 
+    String token;
 
     @Before
-    public void setUp() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         ReflectionTestUtils.setField(openAlexImportMetadataSourceService, "liveImportClient", liveImportClient);
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
     }
 
     @Test
     public void findOneOpenalexImportPublisherExternalExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources?size=25")).andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                        ExternalSourceMatcher.matchExternalSource("openalexPublisher",
                                                                  "openalexPublisher", false))));
@@ -71,11 +76,18 @@ public class OpenAlexPublisherExternalSourcesIT extends AbstractControllerIntegr
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublisher/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublisher/entries")
                                     .param("query", "empty"))
                        .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
             verify(liveImportClient, times(2)).executeHttpGetRequest(anyInt(), anyString(), anyMap());
         }
+    }
+
+    @Test
+    public void findOpenalexPublisherExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openalexPublisher/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -86,7 +98,7 @@ public class OpenAlexPublisherExternalSourcesIT extends AbstractControllerIntegr
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublisher/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublisher/entries")
                                     .param("query", "Elsevier"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries[0].id").value("P4310320990"))
@@ -143,7 +155,7 @@ public class OpenAlexPublisherExternalSourcesIT extends AbstractControllerIntegr
             when(liveImportClient.executeHttpGetRequest(anyInt(), anyString(), anyMap()))
                 .thenReturn(jsonResponse);
 
-            getClient().perform(get("/api/integration/externalsources/openalexPublisher/entries")
+            getClient(token).perform(get("/api/integration/externalsources/openalexPublisher/entries")
                                     .param("query", "Elsevier"))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", hasSize(2)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenaireFundingExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenaireFundingExternalSourcesIT.java
@@ -17,9 +17,20 @@ import org.dspace.app.rest.matcher.ExternalSourceEntryMatcher;
 import org.dspace.app.rest.matcher.ExternalSourceMatcher;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 
 public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrationTest {
+
+    String token;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
+    }
 
     /**
      * Test openaire funding external source
@@ -28,7 +39,7 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
      */
     @Test
     public void findOneOpenaireFundingExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources")).andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                         ExternalSourceMatcher.matchExternalSource("openaireFunding", "openaireFunding", false))));
     }
@@ -40,9 +51,16 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
      */
     @Test
     public void findOneOpenaireFundingExternalSourceEntriesEmptyWithQueryTest() throws Exception {
-
-        getClient().perform(get("/api/integration/externalsources/openaireFunding/entries").param("query", "empty"))
+        getClient(token).perform(get("/api/integration/externalsources/openaireFunding/entries")
+                                     .param("query", "empty"))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
+    }
+
+    @Test
+    public void findOneOpenaireFundingExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openaireFunding/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     /**
@@ -54,7 +72,7 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
     @Test
     public void findOneOpenaireFundingExternalSourceEntriesWithQueryMultipleKeywordsTest() throws Exception {
 
-        getClient()
+        getClient(token)
                 .perform(
                         get("/api/integration/externalsources/openaireFunding/entries").param("query", "empty+results"))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
@@ -67,7 +85,8 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
      */
     @Test
     public void findOneOpenaireFundingExternalSourceEntriesWithQueryTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/openaireFunding/entries").param("query", "mushroom"))
+        getClient(token).perform(get("/api/integration/externalsources/openaireFunding/entries")
+                                     .param("query", "mushroom"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.externalSourceEntries",
                         Matchers.hasItem(ExternalSourceEntryMatcher.matchExternalSourceEntry(
@@ -90,7 +109,7 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
         String projectName = "Portuguese Wild Mushrooms: Chemical characterization and functional study"
                 + " of antiproliferative and proapoptotic properties in cancer cell lines";
 
-        getClient().perform(get("/api/integration/externalsources/openaireFunding/entryValues/" + projectID))
+        getClient(token).perform(get("/api/integration/externalsources/openaireFunding/entryValues/" + projectID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$",
                         Matchers.allOf(hasJsonPath("$.id", is(projectID)), hasJsonPath("$.display", is(projectName)),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OrcidExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OrcidExternalSourcesIT.java
@@ -25,6 +25,7 @@ import org.dspace.external.provider.impl.OrcidV3AuthorDataProvider;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -57,9 +58,19 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
         }
     }
 
+    String token;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
+    }
+
     @Test
     public void findOneExternalSourcesExistingSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/orcid"))
+        getClient(token).perform(get("/api/integration/externalsources/orcid"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.allOf(
                            hasJsonPath("$.id", is("orcid")),
@@ -70,11 +81,17 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void findOneExternalSourcesExistingSourcesAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/orcid"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findOneExternalSourcesExistingSourcesWithentryValueTest() throws Exception {
         // this test will query the real ORCID API if configured in the CI otherwise will be skipped
         onlyRunIfConfigExists();
         String entry = "0000-0002-9029-1854";
-        getClient().perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.allOf(
                            hasJsonPath("$.id", is(entry)),
@@ -94,7 +111,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
         // this test will query the real ORCID API if configured in the CI otherwise will be skipped
         onlyRunIfConfigExists();
         String q = "orcid:0000-0002-9029-1854";
-        getClient().perform(get("/api/integration/externalsources/orcid/entries")
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                    .param("query", q))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries[0]", Matchers.allOf(
@@ -119,7 +136,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
         // this test will query the real ORCID API if configured in the CI otherwise will be skipped
         onlyRunIfConfigExists();
         String q = "family-name:bollini AND given-names:andrea";
-        getClient().perform(get("/api/integration/externalsources/orcid/entries")
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                    .param("query", q))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(
@@ -160,7 +177,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                     }
                 });
 
-        getClient().perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.allOf(
                            hasJsonPath("$.id", is(entry)),
@@ -202,7 +219,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                         }
                     });
             String q = "orcid:0000-0002-9029-1854";
-            getClient().perform(get("/api/integration/externalsources/orcid/entries")
+            getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                        .param("query", q))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries[0]", Matchers.allOf(
@@ -255,7 +272,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                         }
                     });
             String q = "family-name:bollini AND given-names:andrea";
-            getClient().perform(get("/api/integration/externalsources/orcid/entries")
+            getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                        .param("query", q))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(


### PR DESCRIPTION
## Description

This PR updates our `/api/integration/externalsources/` endpoints to restrict them to authenticated users only.   These endpoints are only used during the submission process, so it makes more sense to require authentication of all users. 

There is a slight risk that anonymous users could make larger amounts of requests to these endpoints, potentially using up a repository's API rate limits / quotas for specific external sources.  If this were to occur, human users may not be able to use the tools until the rate/quota limitation expires. Restricting these endpoints will ensure that only known users can utilize these endpoints as expected.

## Instructions for Reviewers
* Review code changes
* Verify no change in behavior for external sources from the User Interface.  These tools are available from the MyDSpace page, using the Import button and selecting a service to import from.
    * I've done this testing on my end and found no issues so far. But, it could always use more eyes.

List of changes in this PR:
*  Code changes are very minimal, but a larger number of ITs had to be updated.   ITs were also added to verify that anonymous users accessing these endpoints will now receive a `401 Unauthorized` response.
* Minor bug fix to ensure newly created WorkflowItems always are created with a current user in `ExternalSourcesRestControllerIT`.  (This was discovered after updates to these ITs required after restricting these endpoints)