### PR TITLE
Add DOI mapping for PubMed imports

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PubmedImportMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PubmedImportMetadataSourceServiceIT.java
@@ -144,6 +144,7 @@ public class PubmedImportMetadataSourceServiceIT extends AbstractLiveImportInteg
         MetadatumDTO subject4 = createMetadatumDTO("dc", "subject", null, "Educational strategies");
         MetadatumDTO subject5 = createMetadatumDTO("dc", "subject", null, "Nursing education");
         MetadatumDTO subject6 = createMetadatumDTO("dc", "subject", null, "Teaching methodology");
+        MetadatumDTO doi = createMetadatumDTO("dc", "relation", "hasversion", "https://doi.org/10.1016/j.nepr.2023.103548");
 
         metadatums.add(title);
         metadatums.add(description1);
@@ -162,6 +163,7 @@ public class PubmedImportMetadataSourceServiceIT extends AbstractLiveImportInteg
         metadatums.add(subject4);
         metadatums.add(subject5);
         metadatums.add(subject6);
+        metadatums.add(doi);
         ImportRecord record = new ImportRecord(metadatums);
 
         records.add(record);
@@ -190,6 +192,7 @@ public class PubmedImportMetadataSourceServiceIT extends AbstractLiveImportInteg
         MetadatumDTO author2 = createMetadatumDTO("dc", "contributor", "author", "Baxevanis, Andreas D");
         MetadatumDTO date = createMetadatumDTO("dc", "date", "issued", "2011-10");
         MetadatumDTO language = createMetadatumDTO("dc", "language", "iso", "en");
+        MetadatumDTO doi = createMetadatumDTO("dc", "relation", "hasversion", "https://doi.org/10.1002/0471142905.hg0610s71");
 
         metadatums.add(title);
         metadatums.add(description);
@@ -198,6 +201,7 @@ public class PubmedImportMetadataSourceServiceIT extends AbstractLiveImportInteg
         metadatums.add(author2);
         metadatums.add(date);
         metadatums.add(language);
+        metadatums.add(doi);
         ImportRecord record = new ImportRecord(metadatums);
 
         records.add(record);

--- a/dspace/config/spring/api/pubmed-integration.xml
+++ b/dspace/config/spring/api/pubmed-integration.xml
@@ -24,6 +24,7 @@
         <entry key-ref="dc.date.issued" value-ref="dateContrib"/>
         <entry key-ref="dc.language.iso" value-ref="pubmedLanguageContrib"/>
         <entry key-ref="dc.subject" value-ref="keywordContrib"/>
+        <entry key-ref="dc.relation.hasversion" value-ref="pubmedDoiContrib"/>
 
     </util:map>
 
@@ -56,6 +57,11 @@
         <property name="query" value="descendant::ArticleTitle"/>
         <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>
     </bean>
+    <bean id="pubmedDoiContrib" class="org.dspace.importer.external.metadatamapping.contributor.XpathNormalizeDOIMetadatumContributor">  
+        <property name="field" ref="dc.relation.hasversion"/>  
+        <property name="query" value="descendant::ArticleId[@IdType='doi']"/>  
+        <property name="prefixToNamespaceMapping" ref="prefixToNamespaceMapping"/>  
+    </bean>  
 
     <bean id="abstractContrib" class="org.dspace.importer.external.pubmed.metadatamapping.contributor.PubmedAbstractMetadatumContributor">
         <property name="field" ref="dc.description.abstract"/>
@@ -144,6 +150,10 @@
     <bean id="dc.identifier.other" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">
         <constructor-arg value="dc.identifier.other"/>
     </bean>
+
+    <bean id="dc.relation.hasversion" class="org.dspace.importer.external.metadatamapping.MetadataFieldConfig">  
+        <constructor-arg value="dc.relation.hasversion"/>  
+    </bean>  
 
 
     <util:map id="prefixToNamespaceMapping">


### PR DESCRIPTION
## References

* Fixes #11961

## Description

This PR fixes PubMed metadata import so that DOI values are imported from PubMed records and stored in `dc.relation.hasversion` using the normalized `https://doi.org/...` format.

## Instructions for Reviewers

The issue reports that PubMed import currently retrieves the PubMed identifier, but does not map the DOI from PubMed records into `dc.relation.hasversion`.

List of changes in this PR:

* Adds a PubMed DOI metadata mapping for `ArticleId[@IdType='doi']`.
* Maps PubMed DOI values to `dc.relation.hasversion`.
* Uses `XpathNormalizeDOIMetadatumContributor` so DOI values are stored as normalized DOI URLs, e.g. `https://doi.org/...`.
* Keeps the existing PubMed PMID mapping in `dc.identifier.other`.

**Note for backports:** `XpathNormalizeDOIMetadatumContributor` is not available in DSpace 8 and 9. For backports to older versions, `SimpleXpathMetadatumContributor` could be used as an alternative, though this would not include automatic DOI URL normalization.

Guidance for testing/review:

* Test PubMed import with a record that includes both a PMID and a DOI, e.g. Pubmed by ID `15043867`.
* Verify that the PMID continues to be mapped to `dc.identifier.other`.
* Verify that the DOI is mapped to `dc.relation.hasversion`.
* Verify that the DOI value is stored in normalized URL format, e.g. `https://doi.org/...`.

## Checklist

* [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
* [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
* [x] My PR **passes Checkstyle** validation based on the [[Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide)](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
* [ ] My PR **includes Javadoc** for *all new (or modified) public methods and classes*. It also includes Javadoc for large or complex private methods.
* [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [[Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide)](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
* [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
* [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [[DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE)](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [[Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions)](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
* [x] If my PR modifies REST API endpoints, I've opened a separate [[REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md)](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
* [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
* [x] If my PR fixes an issue ticket, I've [[linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).