### PR TITLE
Update `/api/eperson/epersons/search/byEmail` to return 401 instead of 204 for unauthorized users.

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EPersonRestRepository.java
@@ -272,6 +272,7 @@ public class EPersonRestRepository extends DSpaceObjectRestRepository<EPerson, E
      *            is the *required* email address
      * @return a Page of EPersonRest instances matching the user query
      */
+    @PreAuthorize("hasAuthority('ADMIN') || hasAuthority('MANAGE_ACCESS_GROUP')")
     @SearchRestMethod(name = "byEmail")
     public EPersonRest findByEmail(@Parameter(value = "email", required = true) String email) {
         EPerson eperson = null;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -207,7 +207,7 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                             .andExpect(status().isUnauthorized());
         getClient().perform(get("/api/eperson/epersons/search/byEmail")
                                 .param("email", data.getEmail()))
-                   .andExpect(status().isNoContent());
+                   .andExpect(status().isUnauthorized());
     }
 
     @Test


### PR DESCRIPTION
## Description
Currently, the endpoint `/api/eperson/epersons/search/byEmail?email=[email]` returns the wrong status code if you are an unauthenticated user.   

Unauthenticated users will always see a `204 No Content` (as they are properly blocked from seeing results of this search) when it'd be more appropriate to return a `401 Unauthorized`.  This PR corrects the improper status code by ensuring a 401 is returned if you are not authenticated.

Other search paths off this same endpoint already return 401 for unauthorized users, e.g.  `/api/eperson/epersons/search/byMetadata` and  `/api/eperson/epersons/search/isNotMemberOf`.  So, this small PR brings consistency to all these search endpoints.

NOTE: The REST Contract does NOT require updating, as it already states that `byEmail` should return 401 for unauthorized users: https://github.com/DSpace/RestContract/blob/main/epersons.md#byemail

## Instructions for Reviewers
* Review code changes
* Test areas of the UI where this search is used. There are only two places it appears to be used from the UI:
    * From the EPeople Admin page, when searching/filtering all EPersons by email address.  Visit `/access-control/epeople` in the UI, and select "Email (exact)" from the searchbox and search by email.
    * When adding a new EPerson (from the "Add EPerson" button on the EPeople Admin page), if you add a duplicative email address it will show a validation error saying "This email is already taken".
