### PR TITLE
[DSpace-CRIS] Migration from existing Entity Relationships to the Authority Framework relationships

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataValueServiceImpl.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
@@ -129,5 +130,27 @@ public class MetadataValueServiceImpl implements MetadataValueService {
     @Override
     public int countTotal(Context context) throws SQLException {
         return metadataValueDAO.countRows(context);
+    }
+
+    @Override
+    public long countByField(Context context, MetadataField metadataField) throws SQLException {
+        return metadataValueDAO.countByField(context, metadataField);
+    }
+
+    @Override
+    public List<UUID> findObjectIdsByField(Context context, MetadataField metadataField, UUID afterUuid, int limit)
+        throws SQLException {
+        return metadataValueDAO.findObjectIdsByField(context, metadataField, afterUuid, limit);
+    }
+
+    @Override
+    public List<MetadataValue> findByFieldAndObjects(Context context, MetadataField metadataField,
+                                                     List<UUID> objectIds) throws SQLException {
+        return metadataValueDAO.findByFieldAndObjects(context, metadataField, objectIds);
+    }
+
+    @Override
+    public int deleteByIds(Context context, List<Integer> ids) throws SQLException {
+        return metadataValueDAO.deleteByIds(context, ids);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/RelationshipServiceImpl.java
@@ -1049,6 +1049,12 @@ public class RelationshipServiceImpl implements RelationshipService {
     }
 
     @Override
+    public List<Relationship> findByRelationshipTypeAfterId(Context context, RelationshipType relationshipType,
+                                                            int limit, int lastId) throws SQLException {
+        return relationshipDAO.findByRelationshipTypeAfterId(context, relationshipType, limit, lastId);
+    }
+
+    @Override
     public List<Relationship> findByTypeName(Context context, String typeName)
             throws SQLException {
         return this.findByTypeName(context, typeName, -1, -1);

--- a/dspace-api/src/main/java/org/dspace/content/dao/MetadataValueDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/MetadataValueDAO.java
@@ -10,6 +10,7 @@ package org.dspace.content.dao;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataValue;
@@ -40,5 +41,54 @@ public interface MetadataValueDAO extends GenericDAO<MetadataValue> {
         throws SQLException;
 
     int countRows(Context context) throws SQLException;
+
+    /**
+     * Count the metadata values that belong to the given metadata field.
+     *
+     * @param context       the DSpace context
+     * @param metadataField the metadata field
+     * @return the number of metadata values for the field
+     * @throws SQLException if a database error occurs
+     */
+    long countByField(Context context, MetadataField metadataField) throws SQLException;
+
+    /**
+     * Keyset page over the distinct DSpaceObject ids that have at least one value of the given
+     * metadata field, ordered by ascending id and starting strictly after {@code afterUuid}.
+     *
+     * @param context       the DSpace context
+     * @param metadataField the metadata field
+     * @param afterUuid     return only object ids greater than this value; {@code null} starts from the beginning
+     * @param limit         the maximum number of object ids to return
+     * @return an ascending, gap/duplicate-free page of DSpaceObject ids
+     * @throws SQLException if a database error occurs
+     */
+    List<UUID> findObjectIdsByField(Context context, MetadataField metadataField, UUID afterUuid, int limit)
+        throws SQLException;
+
+    /**
+     * Find all metadata values of the given field that belong to any of the given DSpaceObjects,
+     * ordered by object id then place.
+     *
+     * @param context       the DSpace context
+     * @param metadataField the metadata field
+     * @param objectIds     the DSpaceObject ids to restrict to
+     * @return the matching metadata values
+     * @throws SQLException if a database error occurs
+     */
+    List<MetadataValue> findByFieldAndObjects(Context context, MetadataField metadataField, List<UUID> objectIds)
+        throws SQLException;
+
+    /**
+     * Bulk-delete the metadata values with the given ids using a single statement that bypasses the
+     * Hibernate cascade/orphan-removal machinery (so it is safe to delete a value without loading its
+     * owning object).
+     *
+     * @param context the DSpace context
+     * @param ids     the metadata value ids to delete
+     * @return the number of rows deleted
+     * @throws SQLException if a database error occurs
+     */
+    int deleteByIds(Context context, List<Integer> ids) throws SQLException;
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/RelationshipDAO.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/RelationshipDAO.java
@@ -90,6 +90,23 @@ public interface RelationshipDAO extends GenericDAO<Relationship> {
                                               Integer limit, Integer offset) throws SQLException;
 
     /**
+     * Keyset (seek) pagination over the relationships of a given type, ordered by ascending id.
+     * Returns up to {@code limit} relationships whose id is strictly greater than {@code lastId}.
+     * Unlike offset paging, this is stable and gap/duplicate-free across iterations even while rows
+     * are being added/removed, which makes it suitable for large batch processing.
+     *
+     * @param context           The relevant DSpace context
+     * @param relationshipType  The RelationshipType object to be checked on
+     * @param limit             maximum number of relationships to return
+     * @param lastId            return only relationships with id greater than this value
+     *                          (use 0 to start from the beginning)
+     * @return  An id-ordered list of Relationship objects with the given RelationshipType and id &gt; lastId
+     * @throws SQLException If something goes wrong
+     */
+    List<Relationship> findByRelationshipTypeAfterId(Context context, RelationshipType relationshipType,
+                                                     int limit, int lastId) throws SQLException;
+
+    /**
      * This method returns a list of Relationship objects for the given RelationshipType object.
      * It will construct a list of all Relationship objects that have the given RelationshipType object
      * as the relationshipType property

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/MetadataValueDAOImpl.java
@@ -8,8 +8,11 @@
 package org.dspace.content.dao.impl;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.persistence.Query;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -31,6 +34,9 @@ import org.dspace.core.Context;
  * @author kevinvandevelde at atmire.com
  */
 public class MetadataValueDAOImpl extends AbstractHibernateDAO<MetadataValue> implements MetadataValueDAO {
+
+    private static final int MAX_IN_CLAUSE_SIZE = 1000;
+
     protected MetadataValueDAOImpl() {
         super();
     }
@@ -94,6 +100,101 @@ public class MetadataValueDAOImpl extends AbstractHibernateDAO<MetadataValue> im
     @Override
     public int countRows(Context context) throws SQLException {
         return count(createQuery(context, "SELECT count(*) FROM MetadataValue"));
+    }
+
+    @Override
+    public long countByField(Context context, MetadataField metadataField) throws SQLException {
+        Query query = createQuery(context,
+            "SELECT count(mv) FROM MetadataValue mv WHERE mv.metadataField = :field");
+        query.setParameter("field", metadataField);
+        return (Long) query.getSingleResult();
+    }
+
+    @Override
+    public List<UUID> findObjectIdsByField(Context context, MetadataField metadataField, UUID afterUuid, int limit)
+        throws SQLException {
+        StringBuilder hql = new StringBuilder(
+            "SELECT DISTINCT mv.dSpaceObject.id FROM MetadataValue mv WHERE mv.metadataField = :field");
+        if (afterUuid != null) {
+            hql.append(" AND mv.dSpaceObject.id > :after");
+        }
+        hql.append(" ORDER BY mv.dSpaceObject.id");
+
+        Query query = createQuery(context, hql.toString());
+        query.setParameter("field", metadataField);
+        if (afterUuid != null) {
+            query.setParameter("after", afterUuid);
+        }
+        if (limit > 0) {
+            query.setMaxResults(limit);
+        }
+
+        @SuppressWarnings("unchecked")
+        List<UUID> result = query.getResultList();
+        return result;
+    }
+
+    @Override
+    public List<MetadataValue> findByFieldAndObjects(Context context, MetadataField metadataField,
+                                                     List<UUID> objectIds) throws SQLException {
+        if (objectIds == null || objectIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (objectIds.size() <= MAX_IN_CLAUSE_SIZE) {
+            Query query = createQuery(context,
+                "SELECT mv FROM MetadataValue mv WHERE mv.metadataField = :field "
+                    + "AND mv.dSpaceObject.id IN (:ids) ORDER BY mv.dSpaceObject.id, mv.place");
+            query.setParameter("field", metadataField);
+            query.setParameter("ids", objectIds);
+
+            @SuppressWarnings("unchecked")
+            List<MetadataValue> result = query.getResultList();
+            return result;
+        }
+
+        // Chunk into sublists to avoid exceeding database IN-clause limits
+        List<MetadataValue> combined = new ArrayList<>();
+        for (int start = 0; start < objectIds.size(); start += MAX_IN_CLAUSE_SIZE) {
+            int end = Math.min(start + MAX_IN_CLAUSE_SIZE, objectIds.size());
+            List<UUID> chunk = objectIds.subList(start, end);
+
+            Query query = createQuery(context,
+                "SELECT mv FROM MetadataValue mv WHERE mv.metadataField = :field "
+                    + "AND mv.dSpaceObject.id IN (:ids) ORDER BY mv.dSpaceObject.id, mv.place");
+            query.setParameter("field", metadataField);
+            query.setParameter("ids", chunk);
+
+            @SuppressWarnings("unchecked")
+            List<MetadataValue> chunkResult = query.getResultList();
+            combined.addAll(chunkResult);
+        }
+        return combined;
+    }
+
+    @Override
+    public int deleteByIds(Context context, List<Integer> ids) throws SQLException {
+        if (ids == null || ids.isEmpty()) {
+            return 0;
+        }
+        // N.B. Bulk HQL DELETE bypasses the persistence context — callers must
+        // evict affected entities from the session to avoid stale references.
+        if (ids.size() <= MAX_IN_CLAUSE_SIZE) {
+            Query query = createQuery(context, "DELETE FROM MetadataValue mv WHERE mv.id IN (:ids)");
+            query.setParameter("ids", ids);
+            return query.executeUpdate();
+        }
+
+        // Chunk into sublists to avoid exceeding database IN-clause limits
+        int totalDeleted = 0;
+        for (int start = 0; start < ids.size(); start += MAX_IN_CLAUSE_SIZE) {
+            int end = Math.min(start + MAX_IN_CLAUSE_SIZE, ids.size());
+            List<Integer> chunk = ids.subList(start, end);
+
+            Query query = createQuery(context, "DELETE FROM MetadataValue mv WHERE mv.id IN (:ids)");
+            query.setParameter("ids", chunk);
+            totalDeleted += query.executeUpdate();
+        }
+        return totalDeleted;
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/RelationshipDAOImpl.java
@@ -202,6 +202,23 @@ public class RelationshipDAOImpl extends AbstractHibernateDAO<Relationship> impl
     }
 
     @Override
+    public List<Relationship> findByRelationshipTypeAfterId(Context context, RelationshipType relationshipType,
+                                                            int limit, int lastId) throws SQLException {
+        CriteriaBuilder criteriaBuilder = getCriteriaBuilder(context);
+        CriteriaQuery criteriaQuery = getCriteriaQuery(criteriaBuilder, Relationship.class);
+        Root<Relationship> relationshipRoot = criteriaQuery.from(Relationship.class);
+        criteriaQuery.select(relationshipRoot);
+        criteriaQuery.where(
+            criteriaBuilder.equal(relationshipRoot.get(Relationship_.relationshipType), relationshipType),
+            criteriaBuilder.greaterThan(relationshipRoot.get(Relationship_.id), lastId));
+        // Deterministic order is required for stable keyset pagination.
+        criteriaQuery.orderBy(criteriaBuilder.asc(relationshipRoot.get(Relationship_.id)));
+        // offset = -1: no setFirstResult; keyset uses the id cursor instead. Not cacheable: each
+        // page query is unique and these are large one-shot scans.
+        return list(context, criteriaQuery, false, Relationship.class, limit, -1);
+    }
+
+    @Override
     public List<Relationship> findByItemAndRelationshipType(
         Context context, Item item, RelationshipType relationshipType, Integer limit, Integer offset,
         boolean excludeNonLatest

--- a/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMetadataMigrator.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMetadataMigrator.java
@@ -19,6 +19,8 @@ import org.dspace.content.Relationship;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -53,8 +55,6 @@ public class DirectionalMetadataMigrator {
      * @param def the directional migration definition
      * @param handler the script handler for logging
      * @throws SQLException if a database error occurs
-     * @throws IllegalArgumentException if the definition's ownerSide is null or
-     *         not "LEFT"/"RIGHT" (case-insensitive)
      */
     public void migrate(Context context, Relationship relationship,
                         DirectionalMigrationDefinition def,
@@ -66,21 +66,9 @@ public class DirectionalMetadataMigrator {
         int place;
         String directionalValue;
 
-        // Validate the configured ownerSide up front: only "LEFT" or "RIGHT"
-        // (case-insensitive) are acceptable. Anything else (null, a typo, an
-        // unexpected value) is a configuration error and must fail fast rather
-        // than being silently treated as LEFT.
+        // ownerSide is validated at bean-init time by DirectionalMigrationDefinition.
         String ownerSide = def.getOwnerSide();
-        boolean isRight;
-        if ("RIGHT".equalsIgnoreCase(ownerSide)) {
-            isRight = true;
-        } else if ("LEFT".equalsIgnoreCase(ownerSide)) {
-            isRight = false;
-        } else {
-            throw new IllegalArgumentException("Invalid ownerSide '" + ownerSide
-                + "' for relationship id=" + relationship.getID()
-                + "; expected \"LEFT\" or \"RIGHT\" (case-insensitive)");
-        }
+        boolean isRight = "RIGHT".equalsIgnoreCase(ownerSide);
 
         if (isRight) {
             ownerItem = relationship.getRightItem();
@@ -128,6 +116,23 @@ public class DirectionalMetadataMigrator {
 
         String fieldLabel = def.getSchema() + "." + def.getElement()
             + (def.getQualifier() != null ? "." + def.getQualifier() : "");
+
+        // Ensure the target metadata field is configured for authority control.
+        // Without authority.controlled.<schema>.<element>.<qualifier> = true,
+        // the UI will not recognise authority values on this field.
+        ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
+            .getConfigurationService();
+        String authorityControlledKey = "authority.controlled."
+            + def.getSchema() + "." + def.getElement();
+        if (def.getQualifier() != null) {
+            authorityControlledKey += "." + def.getQualifier();
+        }
+        if (!configurationService.getBooleanProperty(authorityControlledKey, false)) {
+            handler.logWarning("Relationship id=" + relationship.getID()
+                + ": target field " + fieldLabel + " is not configured for authority control"
+                + " (" + authorityControlledKey + " not set to true)."
+                + " Authority metadata will be written but may not be recognised by the UI.");
+        }
 
         if (toUpdate != null) {
             toUpdate.setValue(value);

--- a/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMetadataMigrator.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMetadataMigrator.java
@@ -1,0 +1,148 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import static org.dspace.content.authority.Choices.CF_ACCEPTED;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.Relationship;
+import org.dspace.content.service.ItemService;
+import org.dspace.core.Context;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Shared helper that applies the upsert logic for a single
+ * {@link DirectionalMigrationDefinition} against a relationship.
+ *
+ * <p>For each relationship, this migrator:</p>
+ * <ol>
+ *   <li>Determines the owner and related items from the ownerSide config</li>
+ *   <li>Derives the display value from the directional value
+ *       (leftwardValue or rightwardValue), falling back to the related item's
+ *       {@code dc.title}</li>
+ *   <li>Sets the authority to the related item's UUID</li>
+ *   <li>Position-based upsert against STORED metadata only (virtual metadata
+ *       disabled): if a value already occupies the relationship's place it is
+ *       updated with the authority; otherwise a new value is added at that place</li>
+ *   <li>Uses {@code CF_ACCEPTED} as confidence</li>
+ * </ol>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class DirectionalMetadataMigrator {
+
+    @Autowired
+    private ItemService itemService;
+
+    /**
+     * Migrate a single relationship according to the given directional definition.
+     *
+     * @param context the DSpace context
+     * @param relationship the relationship to migrate
+     * @param def the directional migration definition
+     * @param handler the script handler for logging
+     * @throws SQLException if a database error occurs
+     * @throws IllegalArgumentException if the definition's ownerSide is null or
+     *         not "LEFT"/"RIGHT" (case-insensitive)
+     */
+    public void migrate(Context context, Relationship relationship,
+                        DirectionalMigrationDefinition def,
+                        DSpaceRunnableHandler handler)
+        throws SQLException {
+
+        Item ownerItem;
+        Item relatedItem;
+        int place;
+        String directionalValue;
+
+        // Validate the configured ownerSide up front: only "LEFT" or "RIGHT"
+        // (case-insensitive) are acceptable. Anything else (null, a typo, an
+        // unexpected value) is a configuration error and must fail fast rather
+        // than being silently treated as LEFT.
+        String ownerSide = def.getOwnerSide();
+        boolean isRight;
+        if ("RIGHT".equalsIgnoreCase(ownerSide)) {
+            isRight = true;
+        } else if ("LEFT".equalsIgnoreCase(ownerSide)) {
+            isRight = false;
+        } else {
+            throw new IllegalArgumentException("Invalid ownerSide '" + ownerSide
+                + "' for relationship id=" + relationship.getID()
+                + "; expected \"LEFT\" or \"RIGHT\" (case-insensitive)");
+        }
+
+        if (isRight) {
+            ownerItem = relationship.getRightItem();
+            relatedItem = relationship.getLeftItem();
+            place = relationship.getRightPlace();
+            directionalValue = relationship.getRightwardValue();
+        } else {
+            ownerItem = relationship.getLeftItem();
+            relatedItem = relationship.getRightItem();
+            place = relationship.getLeftPlace();
+            directionalValue = relationship.getLeftwardValue();
+        }
+
+        String value = directionalValue;
+        if (StringUtils.isBlank(value)) {
+            // Fallback assumes the related item exposes dc.title; entity types
+            // without dc.title yield no value here and are reported via logError below.
+            value = itemService.getMetadataFirstValue(relatedItem, "dc", "title", null, Item.ANY);
+        }
+
+        if (StringUtils.isBlank(value)) {
+            handler.logError("Relationship id=" + relationship.getID()
+                + ": could not determine value for related item " + relatedItem.getID());
+            return;
+        }
+
+        String authority = relatedItem.getID().toString();
+
+        // Read STORED metadata only (virtual metadata disabled). The upsert must operate
+        // on persistent values; if virtual metadata were included, the place lookup would
+        // match the relationship's own relationship-derived (virtual) value rather than a
+        // real stored value, making the result depend on runtime config.
+        List<MetadataValue> existing = itemService.getMetadata(ownerItem,
+            def.getSchema(), def.getElement(), def.getQualifier(), Item.ANY, false);
+
+        // Position-based upsert: if a stored value already occupies this place, set the
+        // authority on it (update); otherwise add a new value at this place.
+        MetadataValue toUpdate = null;
+        for (MetadataValue mv : existing) {
+            if (mv.getPlace() == place) {
+                toUpdate = mv;
+                break;
+            }
+        }
+
+        String fieldLabel = def.getSchema() + "." + def.getElement()
+            + (def.getQualifier() != null ? "." + def.getQualifier() : "");
+
+        if (toUpdate != null) {
+            toUpdate.setValue(value);
+            toUpdate.setAuthority(authority);
+            toUpdate.setConfidence(CF_ACCEPTED);
+            handler.logInfo("Updated metadata at place=" + toUpdate.getPlace()
+                + " for relationship id=" + relationship.getID()
+                + " -> " + fieldLabel + " on item " + ownerItem.getID()
+                + " [value=" + value + ", authority=" + authority + "]");
+        } else {
+            itemService.addMetadata(context, ownerItem, def.getSchema(), def.getElement(),
+                def.getQualifier(), null, value, authority, CF_ACCEPTED, place);
+            handler.logInfo("Added metadata for relationship id=" + relationship.getID()
+                + " -> " + fieldLabel + " on item " + ownerItem.getID()
+                + " [value=" + value + ", authority=" + authority + ", place=" + place + "]");
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMigrationDefinition.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMigrationDefinition.java
@@ -1,0 +1,86 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+/**
+ * Configuration bean describing a single directional migration of a
+ * relationship type.
+ *
+ * <p>A relationship type links two sides (LEFT and RIGHT). This definition
+ * specifies which side is the <em>owner</em> (where metadata is written) and
+ * which is the <em>related</em> side (providing authority and fallback value).
+ * Each relationship type can have zero, one, or two directional definitions
+ * (leftward and/or rightward), each independently configured and optional.</p>
+ *
+ * <p>Example (Author: Publication LEFT, Person RIGHT, metadata on Publication):</p>
+ * <pre>
+ *   ownerSide = LEFT
+ *   schema = dc
+ *   element = contributor
+ *   qualifier = author
+ * </pre>
+ *
+ * <p>No relationship-type-specific subclassing is needed. The behaviour is
+ * fully driven by the ownerSide and metadata field properties.</p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class DirectionalMigrationDefinition {
+
+    /**
+     * The side that owns the metadata: "LEFT" or "RIGHT".
+     * <ul>
+     *   <li>LEFT  – write metadata to relationship.getLeftItem(),
+     *       use leftPlace and leftwardValue</li>
+     *   <li>RIGHT – write metadata to relationship.getRightItem(),
+     *       use rightPlace and rightwardValue</li>
+     * </ul>
+     */
+    private String ownerSide;
+
+    /** Metadata schema (e.g. "dc"). */
+    private String schema;
+
+    /** Metadata element (e.g. "contributor"). */
+    private String element;
+
+    /** Metadata qualifier (e.g. "author"), or null. */
+    private String qualifier;
+
+    public String getOwnerSide() {
+        return ownerSide;
+    }
+
+    public void setOwnerSide(String ownerSide) {
+        this.ownerSide = ownerSide;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public String getElement() {
+        return element;
+    }
+
+    public void setElement(String element) {
+        this.element = element;
+    }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMigrationDefinition.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/DirectionalMigrationDefinition.java
@@ -7,6 +7,9 @@
  */
 package org.dspace.content.migration;
 
+import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Configuration bean describing a single directional migration of a
  * relationship type.
@@ -82,5 +85,30 @@ public class DirectionalMigrationDefinition {
 
     public void setQualifier(String qualifier) {
         this.qualifier = qualifier;
+    }
+
+    /**
+     * Validates the bean configuration at Spring context startup.
+     *
+     * @throws IllegalStateException if a required property is missing or invalid
+     */
+    @PostConstruct
+    public void validateConfiguration() {
+        if (StringUtils.isBlank(ownerSide)) {
+            throw new IllegalStateException("DirectionalMigrationDefinition: ownerSide is required"
+                + " (value \"LEFT\" or \"RIGHT\")");
+        }
+        if (!"LEFT".equalsIgnoreCase(ownerSide) && !"RIGHT".equalsIgnoreCase(ownerSide)) {
+            throw new IllegalStateException("DirectionalMigrationDefinition: ownerSide must be"
+                + " \"LEFT\" or \"RIGHT\" (case-insensitive), got: '" + ownerSide + "'");
+        }
+        if (StringUtils.isBlank(schema)) {
+            throw new IllegalStateException("DirectionalMigrationDefinition: schema is required"
+                + " (e.g. \"dc\")");
+        }
+        if (StringUtils.isBlank(element)) {
+            throw new IllegalStateException("DirectionalMigrationDefinition: element is required"
+                + " (e.g. \"contributor\")");
+        }
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/migration/MetadataFieldMoveCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/MetadataFieldMoveCliScriptConfiguration.java
@@ -1,0 +1,21 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+/**
+ * The {@link org.dspace.scripts.configuration.ScriptConfiguration} for the {@link MetadataFieldMoveScript} CLI script.
+ *
+ * <p>This script is only exposed via the command line, so this CLI configuration simply inherits the
+ * options declared by {@link MetadataFieldMoveScriptConfiguration}.</p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class MetadataFieldMoveCliScriptConfiguration
+    extends MetadataFieldMoveScriptConfiguration<MetadataFieldMoveScript> {
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/MetadataFieldMoveScript.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/MetadataFieldMoveScript.java
@@ -1,0 +1,440 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.cli.ParseException;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.content.service.MetadataValueService;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.utils.DSpace;
+
+/**
+ * DSpace script that MOVES (renames) metadata values from one metadata field to another, directly
+ * at the database level.
+ *
+ * <p>The source is selected with a full Java regular expression matched against each registered
+ * field's canonical name ({@code schema.element[.qualifier]}). The target is a template that may
+ * reference capture groups, e.g. {@code $1}. Every registered field whose canonical name matches the
+ * regex is moved to the field produced by applying the template.</p>
+ *
+ * <p>Examples:</p>
+ * <pre>
+ *   dspace metadata-field-move -s '^dc\.relation$'   -t 'dc.relation.project'
+ *   dspace metadata-field-move -s '^cris\.(.+)$'     -t 'dspace.$1'
+ * </pre>
+ *
+ * <p>Behaviour:</p>
+ * <ul>
+ *   <li><b>Move</b>: each matching value is reassigned to the target field and removed from the
+ *       source field.</li>
+ *   <li><b>Missing target fails</b>: if any resolved target field is not registered, the run aborts
+ *       with no changes (register the field first).</li>
+ *   <li><b>Collision fails</b>: if two distinct source fields resolve to the same target field, the
+ *       run aborts with no changes.</li>
+ *   <li><b>Skip exact duplicates</b>: a source value is skipped (deleted) when an identical value
+ *       (text value + authority + language) already exists on the target for the same object, or has
+ *       already been moved there during this run.</li>
+ *   <li><b>Place</b>: when the target already has values on an object, moved values are appended
+ *       after the highest existing place; otherwise the original place is preserved. Value, language,
+ *       authority and confidence are always preserved.</li>
+ *   <li><b>Scope</b>: global &mdash; every stored metadata value of the matched fields, regardless of
+ *       object type or workflow state. Virtual (relationship) metadata is not affected.</li>
+ * </ul>
+ *
+ * <p>This script bypasses the DSpace event/indexing pipeline, so after a real run the search index
+ * must be refreshed with {@code dspace index-discovery -b}.</p>
+ *
+ * <p>Commits are performed per batch; the script is not atomic and a failure after a batch has been
+ * committed will leave prior batches applied.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ *   dspace metadata-field-move -s &lt;source-regex&gt; -t &lt;target-template&gt; [-n] [-b &lt;batch-size&gt;]
+ * </pre>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class MetadataFieldMoveScript extends DSpaceRunnable<MetadataFieldMoveScriptConfiguration> {
+
+    /** Default number of objects processed per batch when {@code -b} is not provided. */
+    protected static final int DEFAULT_BATCH_SIZE = 1000;
+
+    /** Token used to represent {@code null} components in the deduplication key. */
+    private static final String NULL_TOKEN = "\u0001";
+
+    /** Delimiter used between the components of the deduplication key. */
+    private static final char KEY_DELIMITER = '\u0000';
+
+    private String sourceRegex;
+    private String targetTemplate;
+    private boolean dryRun;
+    private int batchSize = DEFAULT_BATCH_SIZE;
+
+    private MetadataFieldService metadataFieldService;
+    private MetadataValueService metadataValueService;
+
+    @Override
+    public void setup() throws ParseException {
+        if (commandLine.hasOption('h')) {
+            printHelp();
+            handler.logInfo("Help displayed");
+            return;
+        }
+
+        if (!commandLine.hasOption('s')) {
+            throw new ParseException("Option -s (source field regex) is required");
+        }
+        if (!commandLine.hasOption('t')) {
+            throw new ParseException("Option -t (target field template) is required");
+        }
+        sourceRegex = commandLine.getOptionValue('s');
+        targetTemplate = commandLine.getOptionValue('t');
+
+        if (commandLine.hasOption('b')) {
+            try {
+                batchSize = Integer.parseInt(commandLine.getOptionValue('b'));
+            } catch (NumberFormatException e) {
+                throw new ParseException("Option -b must be a valid integer: " + commandLine.getOptionValue('b'));
+            }
+            if (batchSize <= 0) {
+                throw new ParseException("Option -b (batch size) must be a positive integer, got: " + batchSize);
+            }
+        }
+
+        dryRun = commandLine.hasOption('n');
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+        if (commandLine.hasOption('h')) {
+            return;
+        }
+
+        metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
+        metadataValueService = ContentServiceFactory.getInstance().getMetadataValueService();
+
+        try (Context context = new Context(Context.Mode.READ_WRITE)) {
+            context.turnOffAuthorisationSystem();
+
+            // Resolves the field pairs and validates them; aborts the context and throws on any
+            // missing target field or source-to-target collision (so no changes are made).
+            List<FieldMapping> mappings = resolveMappings(context);
+
+            handler.logInfo("=== Metadata Field Move ===");
+            handler.logInfo("Mode: " + (dryRun ? "DRY RUN (no changes)" : "APPLY"));
+            handler.logInfo("Source field regex: " + sourceRegex);
+            handler.logInfo("Note: the script commits each batch independently and is not atomic.");
+            handler.logInfo("Target field template: " + targetTemplate);
+            handler.logInfo("Batch size (objects): " + batchSize);
+
+            if (mappings.isEmpty()) {
+                handler.logWarning("No registered metadata field matches the source regex: " + sourceRegex);
+                context.complete();
+                return;
+            }
+
+            for (FieldMapping mapping : mappings) {
+                long count = metadataValueService.countByField(context, mapping.source);
+                handler.logInfo("  " + mapping.sourceCanonical + "  ->  " + mapping.targetCanonical
+                    + "  (" + count + " value(s))");
+            }
+
+            if (dryRun) {
+                handler.logInfo("DRY RUN: no changes committed.");
+                return;
+            }
+
+            long totalMoved = 0;
+            long totalSkipped = 0;
+            for (FieldMapping mapping : mappings) {
+                long[] result = moveField(context, mapping);
+                totalMoved += result[0];
+                totalSkipped += result[1];
+                handler.logInfo("Field " + mapping.sourceCanonical + " -> " + mapping.targetCanonical
+                    + ": moved=" + result[0] + ", skipped(duplicates)=" + result[1]);
+            }
+
+            context.complete();
+
+            handler.logInfo("=== Move Complete ===");
+            handler.logInfo("Total moved: " + totalMoved);
+            handler.logInfo("Total skipped (exact duplicates): " + totalSkipped);
+            handler.logInfo("Reindex required: run 'dspace index-discovery -b' to refresh the search index.");
+        } catch (SQLException e) {
+            handler.logError("Database error during metadata field move: " + e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * Resolve the configured source regex into concrete source/target field pairs.
+     *
+     * <p>Aborts the context and throws {@link IllegalArgumentException} if any resolved target field
+     * is not registered, or if two distinct source fields resolve to the same target field.</p>
+     *
+     * @param context the DSpace context
+     * @return the resolved field mappings (possibly empty if nothing matches)
+     * @throws SQLException if a database error occurs
+     */
+    private List<FieldMapping> resolveMappings(Context context) throws SQLException {
+        Pattern pattern;
+        try {
+            pattern = Pattern.compile(sourceRegex);
+        } catch (PatternSyntaxException e) {
+            context.abort();
+            handler.logError("Invalid source regex: " + e.getMessage());
+            throw new IllegalArgumentException("Invalid source regex: " + sourceRegex, e);
+        }
+
+        List<FieldMapping> mappings = new ArrayList<>();
+        List<String> missingTargets = new ArrayList<>();
+        Map<Integer, List<String>> sourcesByTarget = new HashMap<>();
+
+        for (MetadataField field : metadataFieldService.findAll(context)) {
+            String canonical = toCanonical(field);
+            if (!pattern.matcher(canonical).matches()) {
+                continue;
+            }
+            String targetString = canonical.replaceFirst(sourceRegex, targetTemplate);
+            if (targetString.equals(canonical)) {
+                // Source resolves to itself: nothing to move.
+                continue;
+            }
+            if (!isValidFieldName(targetString)) {
+                missingTargets.add(canonical + " -> " + targetString + " (invalid field name)");
+                continue;
+            }
+            MetadataField target = metadataFieldService.findByString(context, targetString, '.');
+            if (target == null) {
+                missingTargets.add(canonical + " -> " + targetString + " (NOT REGISTERED)");
+                continue;
+            }
+            mappings.add(new FieldMapping(field, target, canonical, toCanonical(target)));
+            sourcesByTarget.computeIfAbsent(target.getID(), k -> new ArrayList<>()).add(canonical);
+        }
+
+        if (!missingTargets.isEmpty()) {
+            handler.logError("Target metadata field(s) not registered; register them first, then re-run:");
+            for (String missing : missingTargets) {
+                handler.logError("  " + missing);
+            }
+            context.abort();
+            throw new IllegalArgumentException(
+                "Target metadata field(s) not registered: " + String.join("; ", missingTargets));
+        }
+
+        List<String> collisions = new ArrayList<>();
+        for (Map.Entry<Integer, List<String>> entry : sourcesByTarget.entrySet()) {
+            if (entry.getValue().size() > 1) {
+                collisions.add("target field id " + entry.getKey() + " <- " + String.join(", ", entry.getValue()));
+            }
+        }
+        if (!collisions.isEmpty()) {
+            handler.logError("Multiple source fields resolve to the same target field:");
+            for (String collision : collisions) {
+                handler.logError("  " + collision);
+            }
+            context.abort();
+            throw new IllegalArgumentException(
+                "Multiple source fields map to the same target: " + String.join("; ", collisions));
+        }
+
+        return mappings;
+    }
+
+    /**
+     * Move every value of a single source field to its target field, paging by object with stable
+     * keyset (seek) pagination and committing per batch.
+     *
+     * @param context the DSpace context
+     * @param mapping the source/target field pair
+     * @return a two-element array: {@code [movedCount, skippedDuplicateCount]}
+     * @throws SQLException if a database error occurs
+     */
+    private long[] moveField(Context context, FieldMapping mapping) throws SQLException {
+        long moved = 0;
+        long skipped = 0;
+        UUID after = null;
+        int batchNumber = 0;
+
+        while (true) {
+            List<UUID> objectIds = metadataValueService.findObjectIdsByField(context, mapping.source, after, batchSize);
+            if (objectIds.isEmpty()) {
+                break;
+            }
+            batchNumber++;
+            // Advance the cursor past the highest object id in this page. Processed objects lose the
+            // source field, so this seek guarantees forward progress with no skips or repeats.
+            after = objectIds.get(objectIds.size() - 1);
+
+            List<MetadataValue> sources = metadataValueService.findByFieldAndObjects(context, mapping.source,
+                objectIds);
+            List<MetadataValue> targets = metadataValueService.findByFieldAndObjects(context, mapping.target,
+                objectIds);
+
+            Map<UUID, Set<String>> keysByObject = new HashMap<>();
+            Map<UUID, Integer> maxPlaceByObject = new HashMap<>();
+            Set<UUID> populatedObjects = new HashSet<>();
+            for (MetadataValue target : targets) {
+                UUID oid = target.getDSpaceObject().getID();
+                populatedObjects.add(oid);
+                keysByObject.computeIfAbsent(oid, k -> new HashSet<>()).add(dedupeKey(target));
+                maxPlaceByObject.merge(oid, target.getPlace(), Math::max);
+            }
+
+            List<Integer> duplicateIds = new ArrayList<>();
+            int batchMoved = 0;
+            int batchSkipped = 0;
+            for (MetadataValue source : sources) {
+                UUID oid = source.getDSpaceObject().getID();
+                String key = dedupeKey(source);
+                Set<String> keys = keysByObject.computeIfAbsent(oid, k -> new HashSet<>());
+
+                if (keys.contains(key)) {
+                    // Exact duplicate of an existing/already-moved target value: drop it.
+                    duplicateIds.add(source.getID());
+                    skipped++;
+                    batchSkipped++;
+                    continue;
+                }
+
+                if (populatedObjects.contains(oid)) {
+                    // Append after the current highest target place for this object.
+                    source.setPlace(maxPlaceByObject.merge(oid, 1, Integer::sum));
+                }
+                source.setMetadataField(mapping.target);
+                metadataValueService.update(context, source);
+                keys.add(key);
+                moved++;
+                batchMoved++;
+            }
+
+            // Bulk-delete duplicates with a single statement. Deleting MetadataValue entities directly
+            // through the session would force Hibernate to load their owning object (Item.metadata is an
+            // orphan-removal collection) and then refuse the flush; a bulk delete bypasses that.
+            if (!duplicateIds.isEmpty()) {
+                metadataValueService.deleteByIds(context, duplicateIds);
+            }
+
+            context.commit();
+
+            handler.logInfo("Batch " + batchNumber + " (" + mapping.sourceCanonical + " -> "
+                + mapping.targetCanonical + "): processed " + objectIds.size() + " object(s), moved "
+                + batchMoved + ", skipped duplicates " + batchSkipped + ", deleted duplicates "
+                + duplicateIds.size());
+
+            uncache(context, sources);
+            uncache(context, targets);
+        }
+
+        return new long[] {moved, skipped};
+    }
+
+    /**
+     * Best-effort uncache of the given values. {@code context.commit()} flushes the session but does
+     * not clear the Hibernate cache, so without this the cache grows unbounded on large repositories.
+     *
+     * @param context the DSpace context
+     * @param values  the values to evict from the session cache
+     */
+    private void uncache(Context context, List<MetadataValue> values) {
+        for (MetadataValue value : values) {
+            try {
+                context.uncacheEntity(value);
+            } catch (Exception e) {
+                handler.logError("Error uncaching metadata value id=" + value.getID() + ": " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Build the canonical {@code schema.element[.qualifier]} name for a field.
+     *
+     * @param field the metadata field
+     * @return the canonical field name
+     */
+    private static String toCanonical(MetadataField field) {
+        String canonical = field.getMetadataSchema().getName() + "." + field.getElement();
+        if (field.getQualifier() != null) {
+            canonical += "." + field.getQualifier();
+        }
+        return canonical;
+    }
+
+    /**
+     * @param name a candidate metadata field name
+     * @return {@code true} if it parses into 2 or 3 non-empty dot-separated tokens
+     */
+    private static boolean isValidFieldName(String name) {
+        String[] parts = name.split("\\.");
+        if (parts.length < 2 || parts.length > 3) {
+            return false;
+        }
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Build the deduplication key for a value from its text value, authority and language.
+     *
+     * @param value the metadata value
+     * @return the null-safe deduplication key
+     */
+    private static String dedupeKey(MetadataValue value) {
+        return token(value.getValue()) + KEY_DELIMITER + token(value.getAuthority())
+            + KEY_DELIMITER + token(value.getLanguage());
+    }
+
+    private static String token(String value) {
+        return value == null ? NULL_TOKEN : value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public MetadataFieldMoveScriptConfiguration getScriptConfiguration() {
+        return new DSpace().getServiceManager().getServiceByName(
+            "metadata-field-move", MetadataFieldMoveScriptConfiguration.class);
+    }
+
+    /**
+     * Immutable resolved source-to-target field pair.
+     */
+    private static final class FieldMapping {
+        private final MetadataField source;
+        private final MetadataField target;
+        private final String sourceCanonical;
+        private final String targetCanonical;
+
+        private FieldMapping(MetadataField source, MetadataField target, String sourceCanonical,
+                             String targetCanonical) {
+            this.source = source;
+            this.target = target;
+            this.sourceCanonical = sourceCanonical;
+            this.targetCanonical = targetCanonical;
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/MetadataFieldMoveScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/MetadataFieldMoveScriptConfiguration.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link MetadataFieldMoveScript} script.
+ *
+ * @param <T> the script class type
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class MetadataFieldMoveScriptConfiguration<T extends MetadataFieldMoveScript>
+    extends ScriptConfiguration<T> {
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options newOptions = new Options();
+
+            Option sourceOption = Option.builder("s").longOpt("source-field")
+                .desc("Source metadata field as a Java regex over the canonical name schema.element[.qualifier], "
+                    + "e.g. '^cris\\.(.+)$'")
+                .hasArg().required(true).build();
+            newOptions.addOption(sourceOption);
+
+            Option targetOption = Option.builder("t").longOpt("target-field")
+                .desc("Target field template, supporting $1 backreferences, e.g. 'dspace.$1'")
+                .hasArg().required(true).build();
+            newOptions.addOption(targetOption);
+
+            newOptions.addOption("n", "dry-run", false,
+                "Dry run: list the resolved field pairs and counts without committing changes");
+            newOptions.addOption("b", "batch-size", true,
+                "Number of objects to process per batch (default 1000)");
+            newOptions.addOption("h", "help", false,
+                "Display help for this script");
+
+            super.options = newOptions;
+        }
+        return options;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipMigrationStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipMigrationStrategy.java
@@ -1,0 +1,76 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import java.sql.SQLException;
+
+import org.dspace.content.Relationship;
+import org.dspace.core.Context;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
+
+/**
+ * Strategy interface for migrating relationship types to the CRIS authority
+ * model. Implementations are discovered by the migration script via Spring
+ * bean lookup and matched to a relationship type by its leftward/rightward
+ * type labels ({@link #getLeftwardType()} / {@link #getRightwardType()}).
+ *
+ * <p>Matching by label rather than by numeric ID keeps the configuration stable
+ * across installations: relationship type primary keys are assigned by the
+ * database and vary per environment, whereas the leftward/rightward labels are
+ * defined by the entity model and are deterministic.</p>
+ *
+ * <p>The recommended implementation is
+ * {@link RelationshipTypeMigrationDefinition}, which composes the leftward and
+ * rightward type labels with up to two directional migration definitions
+ * ({@link DirectionalMigrationDefinition}) — one leftward and one rightward,
+ * each optional. This replaces the old class-per-relationship-type pattern
+ * with a single config-driven class.</p>
+ *
+ * <p>To configure a new relationship type for migration, register a
+ * {@code RelationshipTypeMigrationDefinition} bean in
+ * {@code config/spring/api/scripts.xml} with the appropriate
+ * {@code leftwardType}/{@code rightwardType} labels and at least one directional
+ * definition.</p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public interface RelationshipMigrationStrategy {
+
+    /**
+     * @return the leftward type label of the RelationshipType this strategy handles
+     */
+    String getLeftwardType();
+
+    /**
+     * @return the rightward type label of the RelationshipType this strategy handles
+     */
+    String getRightwardType();
+
+    /**
+     * @return a human-readable description of this strategy (for logging)
+     */
+    String getDescription();
+
+    /**
+     * Migrate a single relationship to authority-based metadata.
+     * The implementation should:
+     * <ul>
+     *   <li>Identify the owner item (where metadata will be written)</li>
+     *   <li>Derive the display value from the related item</li>
+     *   <li>Set the authority to the related item's UUID</li>
+     *   <li>Use CF_ACCEPTED as confidence</li>
+     *   <li>Preserve the place (ordering) from the relationship</li>
+     * </ul>
+     *
+     * @param context the DSpace context
+     * @param relationship the relationship to migrate
+     * @param handler the script handler for logging
+     * @throws SQLException if a database error occurs
+     */
+    void migrate(Context context, Relationship relationship, DSpaceRunnableHandler handler) throws SQLException;
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipMigrationStrategy.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipMigrationStrategy.java
@@ -42,17 +42,30 @@ import org.dspace.scripts.handler.DSpaceRunnableHandler;
 public interface RelationshipMigrationStrategy {
 
     /**
-     * @return the leftward type label of the RelationshipType this strategy handles
+     * Returns the leftward type label of the relationship type this strategy handles.
+     * This label matches {@link org.dspace.content.RelationshipType#getLeftwardType()}
+     * and is used by the migration script to match strategies to relationship types.
+     *
+     * @return the leftward type label (never null)
      */
     String getLeftwardType();
 
     /**
-     * @return the rightward type label of the RelationshipType this strategy handles
+     * Returns the rightward type label of the relationship type this strategy handles.
+     * This label matches {@link org.dspace.content.RelationshipType#getRightwardType()}
+     * and is used by the migration script to match strategies to relationship types.
+     *
+     * @return the rightward type label (never null)
      */
     String getRightwardType();
 
     /**
-     * @return a human-readable description of this strategy (for logging)
+     * Returns a human-readable description of this migration strategy, used in
+     * log messages during migration. Implementations should return a
+     * non-null, non-blank string; if no description is configured, a default
+     * derived from the type labels is acceptable.
+     *
+     * @return a human-readable description (never null)
      */
     String getDescription();
 

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationCliScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationCliScriptConfiguration.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link RelationshipToAuthorityMigrationScript} CLI script.
+ *
+ * <p>This script shares the same options between its REST and CLI invocations, so this CLI
+ * configuration simply inherits the options declared by
+ * {@link RelationshipToAuthorityMigrationScriptConfiguration}.</p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class RelationshipToAuthorityMigrationCliScriptConfiguration
+    extends RelationshipToAuthorityMigrationScriptConfiguration<RelationshipToAuthorityMigrationScript> {
+
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScript.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScript.java
@@ -10,10 +10,12 @@ package org.dspace.content.migration;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.cli.ParseException;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Item;
 import org.dspace.content.Relationship;
 import org.dspace.content.RelationshipType;
@@ -56,17 +58,33 @@ import org.dspace.utils.DSpace;
  *       migrated.</li>
  *   <li>{@code -d}: (optional) delete relationships after migration</li>
  *   <li>{@code -n}: (optional) dry-run mode, do not commit changes</li>
- *   <li>{@code -b}: (optional) number of relationships to process per batch
+ * <li>{@code -b}: (optional) number of relationships to process per batch
  *       (default {@value #DEFAULT_BATCH_SIZE})</li>
  * </ul>
+ *
+ * <p>The {@code -d} (delete) option is <strong>destructive</strong>: relationships
+ * are permanently removed with {@code forceDelete}. This bypasses standard
+ * authorization checks because the script operates with the authorization
+ * system turned off. Use with caution and only after verifying the migration
+ * output in a dry-run ({@code -n}).</p>
  *
  * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
  * */
 public class RelationshipToAuthorityMigrationScript
     extends DSpaceRunnable<RelationshipToAuthorityMigrationScriptConfiguration> {
 
-    /** Default batch size used when the {@code -b} option is not provided. */
+    /**
+     * Default batch size (1000 relationships per database page).
+     * Chosen to balance memory usage against database round-trips:
+     * each batch loads related items into the Hibernate session and
+     * uncaches them afterwards to prevent OutOfMemoryError on large
+     * datasets. 1000 is a safe default that works well with H2
+     * (tests) and PostgreSQL (production).
+     */
     protected static final int DEFAULT_BATCH_SIZE = 1000;
+
+    /** Separator used to build composite strategy lookup keys. */
+    private static final String STRATEGY_KEY_SEPARATOR = "::";
 
     private boolean migrateAll;
     private int relationshipTypeId;
@@ -77,6 +95,8 @@ public class RelationshipToAuthorityMigrationScript
     private RelationshipService relationshipService;
     private RelationshipTypeService relationshipTypeService;
     private Map<String, RelationshipMigrationStrategy> strategies;
+
+    private volatile RelationshipToAuthorityMigrationScriptConfiguration scriptConfiguration;
 
     @Override
     public void setup() throws ParseException {
@@ -149,9 +169,10 @@ public class RelationshipToAuthorityMigrationScript
         handler.logInfo("Batch size: " + batchSize);
 
         Context context = new Context(Context.Mode.READ_WRITE);
-        context.turnOffAuthorisationSystem();
-
+        boolean succeeded = false;
         try {
+            context.turnOffAuthorisationSystem();
+
             MigrationResult totals = new MigrationResult();
             int typesProcessed;
 
@@ -171,18 +192,23 @@ public class RelationshipToAuthorityMigrationScript
                 handler.logInfo("DRY RUN: no changes committed.");
             } else {
                 context.complete();
+                succeeded = true;
             }
 
             handler.logInfo("=== Migration Complete ===");
             handler.logInfo("Relationship types processed: " + typesProcessed);
-            handler.logInfo("Total migrated: " + totals.migrated);
-            handler.logInfo("Total errors: " + totals.errors);
+            handler.logInfo("Total migrated: " + totals.migrated.get());
+            handler.logInfo("Total errors: " + totals.errors.get());
 
         } catch (SQLException e) {
-            context.abort();
             handler.logError("Database error during migration: " + e.getMessage());
             throw e;
         } finally {
+            if (!succeeded && !dryRun) {
+                // Ensure abort is called if complete() was never reached
+                // (e.g. exception from migrateAllTypes/migrateSingleType before dryRun check)
+                context.abort();
+            }
             context.restoreAuthSystemState();
         }
     }
@@ -196,8 +222,10 @@ public class RelationshipToAuthorityMigrationScript
      * @param totals accumulator updated with migrated/error counts
      * @return the number of relationship types processed
      * @throws SQLException if a database error occurs
+     * @throws AuthorizeException if an authorization error occurs
      */
-    private int migrateAllTypes(Context context, int batchSize, MigrationResult totals) throws SQLException {
+    private int migrateAllTypes(Context context, int batchSize, MigrationResult totals)
+        throws SQLException, AuthorizeException {
         int typesProcessed = 0;
         for (RelationshipType relationshipType : relationshipTypeService.findAll(context)) {
             RelationshipMigrationStrategy strategy = strategies.get(
@@ -218,8 +246,10 @@ public class RelationshipToAuthorityMigrationScript
      * @param batchSize the relationship paging batch size
      * @param totals accumulator updated with migrated/error counts
      * @throws SQLException if a database error occurs
+     * @throws AuthorizeException if an authorization error occurs
      */
-    private void migrateSingleType(Context context, int batchSize, MigrationResult totals) throws SQLException {
+    private void migrateSingleType(Context context, int batchSize, MigrationResult totals)
+        throws SQLException, AuthorizeException {
         RelationshipType relationshipType = relationshipTypeService.find(context, relationshipTypeId);
         if (relationshipType == null) {
             context.abort();
@@ -254,10 +284,11 @@ public class RelationshipToAuthorityMigrationScript
      * @param batchSize the relationship paging batch size
      * @param totals accumulator updated with migrated/error counts
      * @throws SQLException if a database error occurs
+     * @throws AuthorizeException if an authorization error occurs
      */
     private void migrateRelationshipType(Context context, RelationshipType relationshipType,
                                          RelationshipMigrationStrategy strategy, int batchSize,
-                                         MigrationResult totals) throws SQLException {
+                                         MigrationResult totals) throws SQLException, AuthorizeException {
 
         int total = relationshipService.countByRelationshipType(context, relationshipType);
         handler.logInfo("--- " + strategy.getDescription() + " ["
@@ -283,19 +314,22 @@ public class RelationshipToAuthorityMigrationScript
 
             // Advance the cursor to the highest id in this page (the list is ordered by
             // ascending id) before the entities are committed/uncached.
-            lastId = batch.get(batch.size() - 1).getID();
+            lastId = batch.getLast().getID();
 
             for (Relationship relationship : batch) {
                 try {
                     strategy.migrate(context, relationship, handler);
 
                     if (deleteAfterMigration && !dryRun) {
+                        // forceDelete bypasses authorization checks. This is intentional:
+                        // the script runs with auth disabled (turnOffAuthorisationSystem)
+                        // and the -d option is a deliberate, documented destructive action.
                         relationshipService.forceDelete(context, relationship, false, false);
                     }
 
-                    totals.migrated++;
-                } catch (Exception e) {
-                    totals.errors++;
+                    totals.migrated.incrementAndGet();
+                } catch (RuntimeException e) {
+                    totals.errors.incrementAndGet();
                     handler.logError("Error migrating relationship id=" + relationship.getID()
                         + ": " + e.getMessage(), e);
                 }
@@ -321,35 +355,37 @@ public class RelationshipToAuthorityMigrationScript
                         context.uncacheEntity(rightItem);
                     }
                     context.uncacheEntity(relationship);
-                } catch (Exception e) {
+                } catch (RuntimeException e) {
                     handler.logError("Error uncaching relationship id=" + relationship.getID()
                         + ": " + e.getMessage(), e);
                 }
             }
 
-            handler.logInfo("Progress: " + totals.migrated + " migrated, " + totals.errors + " errors");
+            handler.logInfo("Progress: " + totals.migrated.get() + " migrated, " + totals.errors.get() + " errors");
         }
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public RelationshipToAuthorityMigrationScriptConfiguration getScriptConfiguration() {
-        return new DSpace().getServiceManager().getServiceByName(
-            "relationship-to-authority-migrate",
-            RelationshipToAuthorityMigrationScriptConfiguration.class);
+        if (scriptConfiguration == null) {
+            scriptConfiguration = new DSpace().getServiceManager().getServiceByName(
+                "relationship-to-authority-migrate",
+                RelationshipToAuthorityMigrationScriptConfiguration.class);
+        }
+        return scriptConfiguration;
     }
 
     /**
      * Build the composite lookup key that uniquely identifies a relationship
-     * type by its leftward and rightward type labels. A NUL delimiter is used
-     * so the two labels cannot collide with each other.
+     * type by its leftward and rightward type labels, separated by {@code ::}.
      *
      * @param leftwardType the leftward type label
      * @param rightwardType the rightward type label
      * @return the composite key
      */
     private static String strategyKey(String leftwardType, String rightwardType) {
-        return leftwardType + '\u0000' + rightwardType;
+        return leftwardType + STRATEGY_KEY_SEPARATOR + rightwardType;
     }
 
     /**
@@ -367,7 +403,7 @@ public class RelationshipToAuthorityMigrationScript
      * relationship types.
      */
     private static final class MigrationResult {
-        private int migrated;
-        private int errors;
+        private final AtomicInteger migrated = new AtomicInteger(0);
+        private final AtomicInteger errors = new AtomicInteger(0);
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScript.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScript.java
@@ -1,0 +1,373 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.cli.ParseException;
+import org.dspace.content.Item;
+import org.dspace.content.Relationship;
+import org.dspace.content.RelationshipType;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.RelationshipService;
+import org.dspace.content.service.RelationshipTypeService;
+import org.dspace.core.Context;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.utils.DSpace;
+
+/**
+ * DSpace script that migrates relationships to the CRIS authority model.
+ *
+ * <p>Migration is driven by {@link RelationshipTypeMigrationDefinition} beans
+ * registered in Spring XML config. Each definition binds a relationship type
+ * (by its leftward/rightward labels) to up to two optional
+ * {@link DirectionalMigrationDefinition} beans (leftward and/or rightward).
+ * No per-relationship-type Java classes are needed — everything is configured
+ * via Spring.</p>
+ *
+ * <p>For each relationship of a matched type, this script executes all
+ * configured directional definitions:</p>
+ * <ol>
+ *   <li>Reads the relationship data (items, place, value)</li>
+ *   <li>Adds authority-based metadata on the owner item (UUID as authority,
+ *       CF_ACCEPTED)</li>
+ *   <li>Preserves the place/ordering from the relationship</li>
+ *   <li>Optionally deletes the relationship after successful migration</li>
+ * </ol>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ *   dspace relationship-to-authority-migrate [-t &lt;relationship-type-id&gt;] [-d] [-n] [-b &lt;batch-size&gt;]
+ * </pre>
+ *
+ * <p>Options:</p>
+ * <ul>
+ *   <li>{@code -t}: (optional) the relationship type ID to migrate. When omitted,
+ *       every relationship type that has a configured migration definition is
+ *       migrated.</li>
+ *   <li>{@code -d}: (optional) delete relationships after migration</li>
+ *   <li>{@code -n}: (optional) dry-run mode, do not commit changes</li>
+ *   <li>{@code -b}: (optional) number of relationships to process per batch
+ *       (default {@value #DEFAULT_BATCH_SIZE})</li>
+ * </ul>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ * */
+public class RelationshipToAuthorityMigrationScript
+    extends DSpaceRunnable<RelationshipToAuthorityMigrationScriptConfiguration> {
+
+    /** Default batch size used when the {@code -b} option is not provided. */
+    protected static final int DEFAULT_BATCH_SIZE = 1000;
+
+    private boolean migrateAll;
+    private int relationshipTypeId;
+    private boolean deleteAfterMigration;
+    private boolean dryRun;
+    private int batchSize = DEFAULT_BATCH_SIZE;
+
+    private RelationshipService relationshipService;
+    private RelationshipTypeService relationshipTypeService;
+    private Map<String, RelationshipMigrationStrategy> strategies;
+
+    @Override
+    public void setup() throws ParseException {
+        if (commandLine.hasOption('h')) {
+            printHelp();
+            handler.logInfo("Help displayed");
+            return;
+        }
+
+        // -t is optional: when omitted, all configured relationship types are migrated.
+        if (commandLine.hasOption('t')) {
+            try {
+                relationshipTypeId = Integer.parseInt(commandLine.getOptionValue('t'));
+                migrateAll = false;
+            } catch (NumberFormatException e) {
+                throw new ParseException("Option -t must be a valid integer: " + commandLine.getOptionValue('t'));
+            }
+        } else {
+            migrateAll = true;
+        }
+
+        if (commandLine.hasOption('b')) {
+            try {
+                batchSize = Integer.parseInt(commandLine.getOptionValue('b'));
+            } catch (NumberFormatException e) {
+                throw new ParseException("Option -b must be a valid integer: " + commandLine.getOptionValue('b'));
+            }
+            if (batchSize <= 0) {
+                throw new ParseException("Option -b (batch size) must be a positive integer, got: " + batchSize);
+            }
+        }
+
+        deleteAfterMigration = commandLine.hasOption('d');
+        dryRun = commandLine.hasOption('n');
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+        if (commandLine.hasOption('h')) {
+            return;
+        }
+
+        // Initialize services
+        DSpace dspace = new DSpace();
+        relationshipService = ContentServiceFactory.getInstance().getRelationshipService();
+        relationshipTypeService = ContentServiceFactory.getInstance().getRelationshipTypeService();
+
+        // Load configured type definitions (each implements RelationshipMigrationStrategy),
+        // indexed by a composite key built from the leftward/rightward type labels.
+        List<RelationshipMigrationStrategy> strategyBeans = dspace.getServiceManager()
+            .getServicesByType(RelationshipMigrationStrategy.class);
+        strategies = strategyBeans.stream()
+            .collect(Collectors.toMap(
+                s -> strategyKey(s.getLeftwardType(), s.getRightwardType()), Function.identity(),
+                (existing, duplicate) -> {
+                    String message = "Multiple migration strategies registered for relationship type "
+                        + existing.getLeftwardType() + "/" + existing.getRightwardType()
+                        + ". Each relationship type must map to exactly one strategy;"
+                        + " check the Spring configuration for duplicates.";
+                    handler.logError(message);
+                    throw new IllegalStateException(message);
+                }));
+
+        handler.logInfo("=== Relationship to Authority Migration ===");
+        handler.logInfo(migrateAll
+            ? "Mode: ALL configured relationship types"
+            : "Mode: single relationship type (ID " + relationshipTypeId + ")");
+        handler.logInfo("Delete after migration: " + deleteAfterMigration);
+        handler.logInfo("Dry run: " + dryRun);
+        handler.logInfo("Batch size: " + batchSize);
+
+        Context context = new Context(Context.Mode.READ_WRITE);
+        context.turnOffAuthorisationSystem();
+
+        try {
+            MigrationResult totals = new MigrationResult();
+            int typesProcessed;
+
+            if (migrateAll) {
+                typesProcessed = migrateAllTypes(context, batchSize, totals);
+                if (typesProcessed == 0) {
+                    handler.logWarning("No relationship type in the database matches any configured migration "
+                        + "definition. Configured definitions: " + describeConfiguredStrategies());
+                }
+            } else {
+                migrateSingleType(context, batchSize, totals);
+                typesProcessed = 1;
+            }
+
+            if (dryRun) {
+                context.abort();
+                handler.logInfo("DRY RUN: no changes committed.");
+            } else {
+                context.complete();
+            }
+
+            handler.logInfo("=== Migration Complete ===");
+            handler.logInfo("Relationship types processed: " + typesProcessed);
+            handler.logInfo("Total migrated: " + totals.migrated);
+            handler.logInfo("Total errors: " + totals.errors);
+
+        } catch (SQLException e) {
+            context.abort();
+            handler.logError("Database error during migration: " + e.getMessage());
+            throw e;
+        } finally {
+            context.restoreAuthSystemState();
+        }
+    }
+
+    /**
+     * Migrate every relationship type in the database that has a configured
+     * migration definition (matched by leftward/rightward labels).
+     *
+     * @param context the DSpace context
+     * @param batchSize the relationship paging batch size
+     * @param totals accumulator updated with migrated/error counts
+     * @return the number of relationship types processed
+     * @throws SQLException if a database error occurs
+     */
+    private int migrateAllTypes(Context context, int batchSize, MigrationResult totals) throws SQLException {
+        int typesProcessed = 0;
+        for (RelationshipType relationshipType : relationshipTypeService.findAll(context)) {
+            RelationshipMigrationStrategy strategy = strategies.get(
+                strategyKey(relationshipType.getLeftwardType(), relationshipType.getRightwardType()));
+            if (strategy == null) {
+                continue;
+            }
+            migrateRelationshipType(context, relationshipType, strategy, batchSize, totals);
+            typesProcessed++;
+        }
+        return typesProcessed;
+    }
+
+    /**
+     * Resolve the relationship type given by the {@code -t} option and migrate it.
+     *
+     * @param context the DSpace context
+     * @param batchSize the relationship paging batch size
+     * @param totals accumulator updated with migrated/error counts
+     * @throws SQLException if a database error occurs
+     */
+    private void migrateSingleType(Context context, int batchSize, MigrationResult totals) throws SQLException {
+        RelationshipType relationshipType = relationshipTypeService.find(context, relationshipTypeId);
+        if (relationshipType == null) {
+            context.abort();
+            handler.logError("RelationshipType with ID " + relationshipTypeId + " not found in database");
+            throw new IllegalArgumentException("RelationshipType not found: " + relationshipTypeId);
+        }
+
+        // Match a migration definition by the relationship type's leftward/rightward labels.
+        // Matching by label (rather than numeric ID) keeps configuration stable across installs.
+        RelationshipMigrationStrategy strategy = strategies.get(
+            strategyKey(relationshipType.getLeftwardType(), relationshipType.getRightwardType()));
+        if (strategy == null) {
+            context.abort();
+            handler.logError("No migration definition found for relationship type "
+                + relationshipType.getLeftwardType() + "/" + relationshipType.getRightwardType()
+                + " (ID " + relationshipTypeId + ")");
+            handler.logError("Available relationship types: " + describeConfiguredStrategies());
+            throw new IllegalArgumentException("No migration definition registered for relationship type "
+                + relationshipType.getLeftwardType() + "/" + relationshipType.getRightwardType());
+        }
+
+        migrateRelationshipType(context, relationshipType, strategy, batchSize, totals);
+    }
+
+    /**
+     * Migrate all relationships of a single relationship type, paging in batches
+     * and committing per batch (unless in dry-run mode).
+     *
+     * @param context the DSpace context
+     * @param relationshipType the relationship type to migrate
+     * @param strategy the migration strategy matched to the type
+     * @param batchSize the relationship paging batch size
+     * @param totals accumulator updated with migrated/error counts
+     * @throws SQLException if a database error occurs
+     */
+    private void migrateRelationshipType(Context context, RelationshipType relationshipType,
+                                         RelationshipMigrationStrategy strategy, int batchSize,
+                                         MigrationResult totals) throws SQLException {
+
+        int total = relationshipService.countByRelationshipType(context, relationshipType);
+        handler.logInfo("--- " + strategy.getDescription() + " ["
+            + relationshipType.getLeftwardType() + "/" + relationshipType.getRightwardType()
+            + ", ID " + relationshipType.getID() + "]: " + total + " relationship(s) ---");
+
+        if (total == 0) {
+            return;
+        }
+
+        // Keyset (seek) pagination by ascending relationship id. Unlike LIMIT/OFFSET, this is
+        // stable and gap/duplicate-free across batches even though we commit (and optionally
+        // delete) between pages — so no relationship is processed twice or skipped.
+        int lastId = 0;
+
+        while (true) {
+            List<Relationship> batch = relationshipService.findByRelationshipTypeAfterId(
+                context, relationshipType, batchSize, lastId);
+
+            if (batch.isEmpty()) {
+                break;
+            }
+
+            // Advance the cursor to the highest id in this page (the list is ordered by
+            // ascending id) before the entities are committed/uncached.
+            lastId = batch.get(batch.size() - 1).getID();
+
+            for (Relationship relationship : batch) {
+                try {
+                    strategy.migrate(context, relationship, handler);
+
+                    if (deleteAfterMigration && !dryRun) {
+                        relationshipService.forceDelete(context, relationship, false, false);
+                    }
+
+                    totals.migrated++;
+                } catch (Exception e) {
+                    totals.errors++;
+                    handler.logError("Error migrating relationship id=" + relationship.getID()
+                        + ": " + e.getMessage(), e);
+                }
+            }
+
+            if (!dryRun) {
+                context.commit();
+            }
+
+            // Uncache the entities touched in this batch. context.commit() flushes the
+            // session but does not clear the Hibernate cache, so without this the cache
+            // grows unbounded and large repositories can hit OutOfMemoryError. Uncaching
+            // is best-effort: a relationship deleted by deleteAfterMigration may already
+            // be detached, so any failure here is logged and must not abort the run.
+            for (Relationship relationship : batch) {
+                try {
+                    Item leftItem = relationship.getLeftItem();
+                    if (leftItem != null) {
+                        context.uncacheEntity(leftItem);
+                    }
+                    Item rightItem = relationship.getRightItem();
+                    if (rightItem != null) {
+                        context.uncacheEntity(rightItem);
+                    }
+                    context.uncacheEntity(relationship);
+                } catch (Exception e) {
+                    handler.logError("Error uncaching relationship id=" + relationship.getID()
+                        + ": " + e.getMessage(), e);
+                }
+            }
+
+            handler.logInfo("Progress: " + totals.migrated + " migrated, " + totals.errors + " errors");
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public RelationshipToAuthorityMigrationScriptConfiguration getScriptConfiguration() {
+        return new DSpace().getServiceManager().getServiceByName(
+            "relationship-to-authority-migrate",
+            RelationshipToAuthorityMigrationScriptConfiguration.class);
+    }
+
+    /**
+     * Build the composite lookup key that uniquely identifies a relationship
+     * type by its leftward and rightward type labels. A NUL delimiter is used
+     * so the two labels cannot collide with each other.
+     *
+     * @param leftwardType the leftward type label
+     * @param rightwardType the rightward type label
+     * @return the composite key
+     */
+    private static String strategyKey(String leftwardType, String rightwardType) {
+        return leftwardType + '\u0000' + rightwardType;
+    }
+
+    /**
+     * @return a human-readable, comma-separated list of the configured
+     *         relationship types (leftward/rightward labels), for logging.
+     */
+    private String describeConfiguredStrategies() {
+        return strategies.values().stream()
+            .map(s -> s.getLeftwardType() + "/" + s.getRightwardType())
+            .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Mutable accumulator for migrated/error counts across one or more
+     * relationship types.
+     */
+    private static final class MigrationResult {
+        private int migrated;
+        private int errors;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScriptConfiguration.java
@@ -1,0 +1,53 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import org.apache.commons.cli.Options;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link RelationshipToAuthorityMigrationScript} script.
+ *
+ * @param <T> the script class type
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class RelationshipToAuthorityMigrationScriptConfiguration<T extends RelationshipToAuthorityMigrationScript>
+    extends ScriptConfiguration<T> {
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+            Options newOptions = new Options();
+            newOptions.addOption("t", "type-id", true,
+                "The relationship type ID to migrate. If omitted, all relationship types that have a "
+                + "configured migration definition are migrated");
+            newOptions.addOption("d", "delete", false,
+                "Delete relationships after successful migration");
+            newOptions.addOption("n", "dry-run", false,
+                "Dry run: log what would be done without committing changes");
+            newOptions.addOption("b", "batch-size", true,
+                "Number of relationships to process per batch (default 1000)");
+            newOptions.addOption("h", "help", false,
+                "Display help for this script");
+            super.options = newOptions;
+        }
+        return options;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/migration/RelationshipTypeMigrationDefinition.java
+++ b/dspace-api/src/main/java/org/dspace/content/migration/RelationshipTypeMigrationDefinition.java
@@ -1,0 +1,165 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import java.sql.SQLException;
+
+import jakarta.annotation.PostConstruct;
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.content.Relationship;
+import org.dspace.core.Context;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Config-driven implementation of {@link RelationshipMigrationStrategy} that
+ * composes the leftward/rightward type labels of a relationship type with up to
+ * two optional directional migration definitions (leftward and/or rightward).
+ *
+ * <p>The relationship type is identified by its {@code leftwardType} and
+ * {@code rightwardType} labels rather than by a numeric ID, so the same
+ * configuration works across installations regardless of the database-assigned
+ * primary keys.</p>
+ *
+ * <p>Each direction is independently configured via a
+ * {@link DirectionalMigrationDefinition} bean. When both directions are
+ * configured for a type, the migration script executes them both for each
+ * relationship — writing metadata to the left item for the leftward definition,
+ * and to the right item for the rightward definition.</p>
+ *
+ * <p>This bean replaces the old class-per-relationship-type approach
+ * ({@code AuthorRelationshipMigrationStrategy},
+ * {@code ProjectRelationshipMigrationStrategy}) with a single reusable
+ * implementation driven entirely by Spring bean configuration.</p>
+ *
+ * <p>Example XML config (single direction, leftward):</p>
+ * <pre>
+ * &lt;bean id="authorLeftwardMigration"
+ *       class="o.d.c.m.DirectionalMigrationDefinition"&gt;
+ *     &lt;property name="ownerSide" value="LEFT"/&gt;
+ *     &lt;property name="schema" value="dc"/&gt;
+ *     &lt;property name="element" value="contributor"/&gt;
+ *     &lt;property name="qualifier" value="author"/&gt;
+ * &lt;/bean&gt;
+ *
+ * &lt;bean class="o.d.c.m.RelationshipTypeMigrationDefinition"&gt;
+ *     &lt;property name="leftwardType" value="isAuthorOfPublication"/&gt;
+ *     &lt;property name="rightwardType" value="isPublicationOfAuthor"/&gt;
+ *     &lt;property name="description"
+ *               value="isAuthorOfPublication (Publication &lt;- Person)"/&gt;
+ *     &lt;property name="leftwardMigration" ref="authorLeftwardMigration"/&gt;
+ * &lt;/bean&gt;
+ * </pre>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class RelationshipTypeMigrationDefinition implements RelationshipMigrationStrategy {
+
+    private String leftwardType;
+    private String rightwardType;
+    private String description;
+    private DirectionalMigrationDefinition leftwardMigration;
+    private DirectionalMigrationDefinition rightwardMigration;
+
+    @Autowired
+    private DirectionalMetadataMigrator migrator;
+
+    /**
+     * Validates the bean configuration at Spring context startup. A migration
+     * definition must identify its relationship type (both labels) and must
+     * configure at least one direction; otherwise it would either be
+     * impossible to match or would silently no-op for every relationship of its
+     * type, masking a configuration error. Failing fast here surfaces the
+     * misconfiguration before the migration script runs.
+     *
+     * @throws IllegalStateException if {@code leftwardType} or
+     *                               {@code rightwardType} is blank, or if both
+     *                               {@code leftwardMigration} and
+     *                               {@code rightwardMigration} are {@code null}
+     */
+    @PostConstruct
+    public void validateConfiguration() {
+        if (StringUtils.isBlank(leftwardType) || StringUtils.isBlank(rightwardType)) {
+            throw new IllegalStateException("RelationshipTypeMigrationDefinition must declare both a leftwardType "
+                + "and a rightwardType label (got leftwardType='" + leftwardType
+                + "', rightwardType='" + rightwardType + "').");
+        }
+        if (leftwardMigration == null && rightwardMigration == null) {
+            throw new IllegalStateException("RelationshipTypeMigrationDefinition for relationship type '"
+                + leftwardType + "'/'" + rightwardType + "' has neither a leftwardMigration nor a "
+                + "rightwardMigration configured; at least one direction must be set.");
+        }
+    }
+
+    @Override
+    public String getLeftwardType() {
+        return leftwardType;
+    }
+
+    public void setLeftwardType(String leftwardType) {
+        this.leftwardType = leftwardType;
+    }
+
+    @Override
+    public String getRightwardType() {
+        return rightwardType;
+    }
+
+    public void setRightwardType(String rightwardType) {
+        this.rightwardType = rightwardType;
+    }
+
+    /**
+     * Returns the human-readable description of this migration definition.
+     * When no description has been configured (null or blank), a sensible
+     * default derived from the relationship type labels is returned so callers
+     * (e.g. logging) never receive {@code null}.
+     *
+     * @return the configured description, or a default derived from the labels if none is set
+     */
+    @Override
+    public String getDescription() {
+        if (StringUtils.isBlank(description)) {
+            return leftwardType + "/" + rightwardType + " migration";
+        }
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public DirectionalMigrationDefinition getLeftwardMigration() {
+        return leftwardMigration;
+    }
+
+    public void setLeftwardMigration(DirectionalMigrationDefinition leftwardMigration) {
+        this.leftwardMigration = leftwardMigration;
+    }
+
+    public DirectionalMigrationDefinition getRightwardMigration() {
+        return rightwardMigration;
+    }
+
+    public void setRightwardMigration(DirectionalMigrationDefinition rightwardMigration) {
+        this.rightwardMigration = rightwardMigration;
+    }
+
+    @Override
+    public void migrate(Context context, Relationship relationship,
+                        DSpaceRunnableHandler handler) throws SQLException {
+
+        if (leftwardMigration != null) {
+            migrator.migrate(context, relationship, leftwardMigration, handler);
+        }
+
+        if (rightwardMigration != null) {
+            migrator.migrate(context, relationship, rightwardMigration, handler);
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/content/service/MetadataValueService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/MetadataValueService.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DSpaceObject;
@@ -112,4 +113,52 @@ public interface MetadataValueService {
         throws SQLException;
 
     int countTotal(Context context) throws SQLException;
+
+    /**
+     * Count the metadata values that belong to the given metadata field.
+     *
+     * @param context       dspace context
+     * @param metadataField the metadata field
+     * @return the number of metadata values for the field
+     * @throws SQLException if database error
+     */
+    long countByField(Context context, MetadataField metadataField) throws SQLException;
+
+    /**
+     * Keyset page over the distinct DSpaceObject ids that have at least one value of the given
+     * metadata field, ordered by ascending id and starting strictly after {@code afterUuid}.
+     *
+     * @param context       dspace context
+     * @param metadataField the metadata field
+     * @param afterUuid     return only object ids greater than this value; {@code null} starts from the beginning
+     * @param limit         the maximum number of object ids to return
+     * @return an ascending, gap/duplicate-free page of DSpaceObject ids
+     * @throws SQLException if database error
+     */
+    List<UUID> findObjectIdsByField(Context context, MetadataField metadataField, UUID afterUuid, int limit)
+        throws SQLException;
+
+    /**
+     * Find all metadata values of the given field that belong to any of the given DSpaceObjects,
+     * ordered by object id then place.
+     *
+     * @param context       dspace context
+     * @param metadataField the metadata field
+     * @param objectIds     the DSpaceObject ids to restrict to
+     * @return the matching metadata values
+     * @throws SQLException if database error
+     */
+    List<MetadataValue> findByFieldAndObjects(Context context, MetadataField metadataField, List<UUID> objectIds)
+        throws SQLException;
+
+    /**
+     * Bulk-delete the metadata values with the given ids in a single statement that bypasses the
+     * Hibernate cascade/orphan-removal machinery.
+     *
+     * @param context dspace context
+     * @param ids     the metadata value ids to delete
+     * @return the number of rows deleted
+     * @throws SQLException if database error
+     */
+    int deleteByIds(Context context, List<Integer> ids) throws SQLException;
 }

--- a/dspace-api/src/main/java/org/dspace/content/service/RelationshipService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/RelationshipService.java
@@ -302,6 +302,22 @@ public interface RelationshipService extends DSpaceCRUDService<Relationship> {
                                               Integer offset) throws SQLException;
 
     /**
+     * Keyset (seek) pagination over the relationships of a given type, ordered by ascending id.
+     * Returns up to {@code limit} relationships whose id is strictly greater than {@code lastId}.
+     * Stable and gap/duplicate-free across iterations (unlike offset paging), so it is the
+     * preferred way to iterate large numbers of relationships in batches.
+     *
+     * @param context           The relevant DSpace context
+     * @param relationshipType  The RelationshipType object that will be used to check the Relationship on
+     * @param limit             maximum number of relationships to return
+     * @param lastId            return only relationships with id greater than this value (use 0 to start)
+     * @return  An id-ordered list of Relationship objects with the given type and id &gt; lastId
+     * @throws SQLException If something goes wrong
+     */
+    List<Relationship> findByRelationshipTypeAfterId(Context context, RelationshipType relationshipType,
+                                                     int limit, int lastId) throws SQLException;
+
+    /**
      * This method is used to construct a Relationship object with all it's variables
      * @param c                   The relevant DSpace context
      * @param leftItem            The leftItem Item object for the relationship

--- a/dspace-api/src/test/data/dspaceFolder/config/local.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/local.cfg
@@ -214,3 +214,9 @@ assetstore.jcloud.basedir = target/testing/dspace
 webui.submit.upload.required = true
 rest.cors.allowed-origins = http://localhost:4000
 dspace.name = DSpace at My University
+
+
+# Authority controlled metadata for RelationshipToAuthorityMigrationScriptIT
+authority.controlled.dc.relation.project = true
+authority.controlled.dc.relation.publication = true
+authority.controlled.dc.contributor.author = true

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -123,6 +123,14 @@
                   value="org.dspace.content.migration.RelationshipToAuthorityMigrationScript"/>
     </bean>
 
+    <bean id="metadata-field-move"
+          class="org.dspace.content.migration.MetadataFieldMoveCliScriptConfiguration">
+        <property name="description"
+                  value="Move metadata values from a source field (regex) to a target field (template), DB-level"/>
+        <property name="dspaceRunnableClass"
+                  value="org.dspace.content.migration.MetadataFieldMoveScript"/>
+    </bean>
+
     <!-- ============================================================ -->
     <!-- Directional migration definitions                             -->
     <!-- ============================================================ -->

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -115,4 +115,120 @@
         <property name="dspaceRunnableClass" value="org.dspace.content.enhancer.script.ItemEnhancerScript"/>
     </bean>
 
+    <bean id="relationship-to-authority-migrate"
+          class="org.dspace.content.migration.RelationshipToAuthorityMigrationCliScriptConfiguration">
+        <property name="description"
+                  value="Migrate relationships to CRIS authority model (config-driven, one type at a time)"/>
+        <property name="dspaceRunnableClass"
+                  value="org.dspace.content.migration.RelationshipToAuthorityMigrationScript"/>
+    </bean>
+
+    <!-- ============================================================ -->
+    <!-- Directional migration definitions                             -->
+    <!-- ============================================================ -->
+
+    <bean id="authorLeftwardDef" class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="LEFT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="contributor"/>
+        <property name="qualifier" value="author"/>
+    </bean>
+
+    <bean id="projectLeftwardDef" class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="LEFT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier" value="project"/>
+    </bean>
+
+    <bean id="publicationOfProjectRightwardDef"
+          class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="RIGHT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier" value="publication"/>
+    </bean>
+
+    <bean id="journalIssueOfPublicationRightwardDef"
+          class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="RIGHT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier" value="ispartof"/>
+    </bean>
+
+    <!-- ============================================================ -->
+    <!-- Relationship type migration definitions (matched by labels)   -->
+    <!-- isAuthorOfPublication  -> dc.contributor.author (LEFT)        -->
+    <!-- isProjectOfPublication -> dc.relation (LEFT)                  -->
+    <!-- isAuthorOfPublicationDual -> dual-direction test type         -->
+    <!-- isRelatedToProject     -> dc.relation (RIGHT, rightward-only) -->
+    <!-- ============================================================ -->
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isAuthorOfPublication"/>
+        <property name="rightwardType" value="isPublicationOfAuthor"/>
+        <property name="description"
+                  value="isAuthorOfPublication -> dc.contributor.author (Person isAuthorOf Publication)"/>
+        <property name="leftwardMigration" ref="authorLeftwardDef"/>
+    </bean>
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isProjectOfPublication"/>
+        <property name="rightwardType" value="isPublicationOfProject"/>
+        <property name="description"
+                  value="isProjectOfPublication/isPublicationOfProject -> dc.relation.project (LEFT) + dc.relation.publication (RIGHT)"/>
+        <property name="leftwardMigration" ref="projectLeftwardDef"/>
+        <property name="rightwardMigration" ref="publicationOfProjectRightwardDef"/>
+    </bean>
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isPublicationOfJournalIssue"/>
+        <property name="rightwardType" value="isJournalIssueOfPublication"/>
+        <property name="description"
+                  value="isJournalIssueOfPublication -> dc.relation.ispartof (RIGHT, on JournalIssue)"/>
+        <property name="rightwardMigration" ref="journalIssueOfPublicationRightwardDef"/>
+    </bean>
+
+    <!-- Dual-direction for testing bidirectional migration. Uses dedicated -->
+    <!-- labels so it does not clash with the leftward-only author type above. -->
+    <bean id="rightwardTestDef" class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="RIGHT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="description"/>
+        <property name="qualifier"><null/></property>
+    </bean>
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isAuthorOfPublicationDual"/>
+        <property name="rightwardType" value="isPublicationOfAuthorDual"/>
+        <property name="description"
+                  value="Dual-direction test type: leftward->dc.contributor.author, rightward->dc.description"/>
+        <property name="leftwardMigration" ref="authorLeftwardDef"/>
+        <property name="rightwardMigration" ref="rightwardTestDef"/>
+    </bean>
+
+    <!-- Rightward-only for testing single-direction rightward migration -->
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isRelatedToProject"/>
+        <property name="rightwardType" value="isProjectRelatedTo"/>
+        <property name="description"
+                  value="Rightward-only test type: project -> dc.relation on right item"/>
+        <property name="rightwardMigration" ref="rightwardRelationDef"/>
+    </bean>
+
+    <bean id="rightwardRelationDef" class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="RIGHT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier"><null/></property>
+    </bean>
+
+    <!-- ============================================================ -->
+    <!-- Shared helper bean for upsert logic                           -->
+    <!-- ============================================================ -->
+
+    <bean id="directionalMetadataMigrator"
+          class="org.dspace.content.migration.DirectionalMetadataMigrator"/>
+
 </beans>

--- a/dspace-api/src/test/java/org/dspace/content/migration/MetadataFieldMoveScriptIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/migration/MetadataFieldMoveScriptIT.java
@@ -1,0 +1,315 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.launcher.ScriptLauncher;
+import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.MetadataFieldBuilder;
+import org.dspace.builder.MetadataSchemaBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataField;
+import org.dspace.content.MetadataSchema;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.MetadataFieldService;
+import org.dspace.content.service.MetadataSchemaService;
+import org.dspace.core.Context;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link MetadataFieldMoveScript}.
+ *
+ * <p>Source/target values are created and read back through short-lived helper contexts so the
+ * shared test context never caches the metadata rows the script mutates on its own context.</p>
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class MetadataFieldMoveScriptIT extends AbstractIntegrationTestWithDatabase {
+
+    private ItemService itemService;
+    private MetadataFieldService metadataFieldService;
+    private MetadataSchemaService metadataSchemaService;
+
+    private Collection collection;
+
+    @Before
+    public void setup() throws Exception {
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        metadataFieldService = ContentServiceFactory.getInstance().getMetadataFieldService();
+        metadataSchemaService = ContentServiceFactory.getInstance().getMetadataSchemaService();
+
+        context.turnOffAuthorisationSystem();
+        Community community = CommunityBuilder.createCommunity(context).withName("Community").build();
+        collection = CollectionBuilder.createCollection(context, community).withName("Collection").build();
+        context.restoreAuthSystemState();
+    }
+
+    /**
+     * Exact (non-regex) move: dc.relation -&gt; dc.relation.project. Values move to the target and the
+     * source field is emptied; value and place are preserved (target was empty).
+     */
+    @Test
+    public void testExactMove() throws Exception {
+        UUID itemId = createItemWithFields("Exact Move", "mvexact.source", "mvexact.target");
+        addValues(itemId, "mvexact", "source", null, "Resource A", "Resource B");
+
+        TestDSpaceRunnableHandler handler = runMove("^mvexact\\.source$", "mvexact.target");
+        assertThat(handler.getErrorMessages(), empty());
+
+        assertThat(read(itemId, "mvexact.source"), empty());
+        List<MetadataValue> moved = read(itemId, "mvexact.target");
+        moved.sort(Comparator.comparingInt(MetadataValue::getPlace));
+        assertThat(moved, hasSize(2));
+        assertEquals("Resource A", moved.get(0).getValue());
+        assertEquals(0, moved.get(0).getPlace());
+        assertEquals("Resource B", moved.get(1).getValue());
+        assertEquals(1, moved.get(1).getPlace());
+    }
+
+    /**
+     * Regex move with a backreference: src.alpha -&gt; dst.alpha via {@code -s '^src\.(.+)$' -t 'dst.$1'}.
+     * Custom schemas are used so the regex only matches the test field.
+     */
+    @Test
+    public void testRegexMove() throws Exception {
+        UUID itemId = createItemWithFields("Regex Move", "mvregsrc.alpha", "mvregdst.alpha");
+        addValues(itemId, "mvregsrc", "alpha", null, "Regex Value");
+
+        TestDSpaceRunnableHandler handler = runMove("^mvregsrc\\.(.+)$", "mvregdst.$1");
+        assertThat(handler.getErrorMessages(), empty());
+
+        assertThat(read(itemId, "mvregsrc.alpha"), empty());
+        List<MetadataValue> moved = read(itemId, "mvregdst.alpha");
+        assertThat(moved, hasSize(1));
+        assertEquals("Regex Value", moved.get(0).getValue());
+    }
+
+    /**
+     * Skip exact duplicates: a source value identical (value+authority+language) to an existing target
+     * value is dropped, leaving a single value on the target.
+     */
+    @Test
+    public void testSkipExactDuplicate() throws Exception {
+        UUID itemId = createItemWithFields("Skip Duplicate", "mvdup.source", "mvdup.target");
+        addValues(itemId, "mvdup", "target", null, "Same Value");
+        addValues(itemId, "mvdup", "source", null, "Same Value");
+
+        TestDSpaceRunnableHandler handler = runMove("^mvdup\\.source$", "mvdup.target");
+        assertThat(handler.getErrorMessages(), empty());
+
+        assertThat(read(itemId, "mvdup.source"), empty());
+        List<MetadataValue> target = read(itemId, "mvdup.target");
+        assertThat("Exact duplicate must not be added again", target, hasSize(1));
+        assertEquals("Same Value", target.get(0).getValue());
+    }
+
+    /**
+     * Append on a populated target: when the target already has values, moved values are appended after
+     * the highest existing place rather than colliding with it.
+     */
+    @Test
+    public void testAppendOnPopulatedTarget() throws Exception {
+        UUID itemId = createItemWithFields("Append", "mvapp.source", "mvapp.target");
+        addValues(itemId, "mvapp", "target", null, "Existing 0", "Existing 1");
+        addValues(itemId, "mvapp", "source", null, "Moved");
+
+        TestDSpaceRunnableHandler handler = runMove("^mvapp\\.source$", "mvapp.target");
+        assertThat(handler.getErrorMessages(), empty());
+
+        assertThat(read(itemId, "mvapp.source"), empty());
+        List<MetadataValue> target = read(itemId, "mvapp.target");
+        target.sort(Comparator.comparingInt(MetadataValue::getPlace));
+        assertThat(target, hasSize(3));
+        assertEquals("Existing 0", target.get(0).getValue());
+        assertEquals("Existing 1", target.get(1).getValue());
+        assertEquals("Moved", target.get(2).getValue());
+        assertThat("Moved value must be appended after the existing maximum place",
+            target.get(2).getPlace(), greaterThan(target.get(1).getPlace()));
+    }
+
+    /**
+     * Missing target field: the run must abort with an error and make no changes.
+     */
+    @Test
+    public void testMissingTargetFails() throws Exception {
+        UUID itemId = createItemWithFields("Missing Target", "mvmiss.foo", null);
+        addValues(itemId, "mvmiss", "foo", null, "Untouched");
+
+        TestDSpaceRunnableHandler handler = runMove("^mvmiss\\.foo$", "ghostschema.bar");
+        assertThat("A missing target must produce an error", handler.getErrorMessages(), not(empty()));
+
+        List<MetadataValue> source = read(itemId, "mvmiss.foo");
+        assertThat("No changes must be made when a target is missing", source, hasSize(1));
+        assertEquals("Untouched", source.get(0).getValue());
+    }
+
+    /**
+     * Collision: two distinct source fields resolving to the same target must abort with no changes.
+     */
+    @Test
+    public void testDuplicateTargetCollisionFails() throws Exception {
+        UUID itemId = createItemWithFields("Collision", "mvcoll.a", "mvcolltgt.merged");
+        context.turnOffAuthorisationSystem();
+        ensureField("mvcoll", "b", null);
+        context.commit();
+        context.restoreAuthSystemState();
+        addValues(itemId, "mvcoll", "a", null, "Value A");
+        addValues(itemId, "mvcoll", "b", null, "Value B");
+
+        TestDSpaceRunnableHandler handler = runMove("^mvcoll\\.(?:a|b)$", "mvcolltgt.merged");
+        assertThat("A target collision must produce an error", handler.getErrorMessages(), not(empty()));
+        assertNotNull("A target collision must raise an exception", handler.getException());
+
+        assertThat(read(itemId, "mvcoll.a"), hasSize(1));
+        assertThat(read(itemId, "mvcoll.b"), hasSize(1));
+        assertThat(read(itemId, "mvcolltgt.merged"), empty());
+    }
+
+    /**
+     * Dry run: resolved pairs and counts are reported but nothing is committed.
+     */
+    @Test
+    public void testDryRunMakesNoChanges() throws Exception {
+        UUID itemId = createItemWithFields("Dry Run", "mvdry.source", "mvdry.target");
+        addValues(itemId, "mvdry", "source", null, "Dry Value");
+
+        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "metadata-field-move", "-s", "^mvdry\\.source$", "-t", "mvdry.target", "-n"
+        };
+        context.uncacheEntities();
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), handler, kernelImpl);
+        assertThat(handler.getErrorMessages(), empty());
+
+        boolean reportedPair = handler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("mvdry.source") && msg.contains("mvdry.target"));
+        assertThat("Dry run should report the resolved field pair", reportedPair, is(true));
+        boolean reportedDryRun = handler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("DRY RUN"));
+        assertThat("Dry run should announce that nothing is committed", reportedDryRun, is(true));
+
+        assertThat(read(itemId, "mvdry.source"), hasSize(1));
+        assertThat(read(itemId, "mvdry.target"), empty());
+    }
+
+    /**
+     * Create an item and ensure the given source/target fields are registered, committing everything so
+     * the script (and the helper contexts) see it.
+     *
+     * @param title       the item title
+     * @param sourceField canonical source field name to register
+     * @param targetField canonical target field name to register, or {@code null} to skip
+     * @return the new item's id
+     */
+    private UUID createItemWithFields(String title, String sourceField, String targetField) throws Exception {
+        context.turnOffAuthorisationSystem();
+        ensureFieldFromCanonical(sourceField);
+        if (targetField != null) {
+            ensureFieldFromCanonical(targetField);
+        }
+        Item item = ItemBuilder.createItem(context, collection).withTitle(title).build();
+        context.commit();
+        context.restoreAuthSystemState();
+        return item.getID();
+    }
+
+    private void ensureFieldFromCanonical(String canonical) throws Exception {
+        String[] parts = canonical.split("\\.");
+        String schema = parts[0];
+        String element = parts[1];
+        String qualifier = parts.length == 3 ? parts[2] : null;
+        ensureSchema(schema);
+        ensureField(schema, element, qualifier);
+    }
+
+    /**
+     * Add stored metadata values to an item using a dedicated context so the shared test context does
+     * not cache them.
+     */
+    private void addValues(UUID itemId, String schema, String element, String qualifier, String... values)
+        throws Exception {
+        try (Context c = new Context()) {
+            c.turnOffAuthorisationSystem();
+            Item item = itemService.find(c, itemId);
+            for (String value : values) {
+                itemService.addMetadata(c, item, schema, element, qualifier, null, value);
+            }
+            itemService.update(c, item);
+            c.commit();
+            // Evict the item and its values so the thread-bound Hibernate session does not keep a
+            // managed reference to rows the script will later move/delete on its own context.
+            for (MetadataValue mv : item.getMetadata()) {
+                c.uncacheEntity(mv);
+            }
+            c.uncacheEntity(item);
+            c.complete();
+        }
+    }
+
+    /**
+     * Read the stored values of a field for an item using a fresh context (sees committed DB state).
+     */
+    private List<MetadataValue> read(UUID itemId, String field) throws Exception {
+        try (Context c = new Context()) {
+            // Clear the thread-bound Hibernate session so a value the script deleted on another context
+            // does not linger as a stale managed reference and break the read with a cascade flush.
+            c.uncacheEntities();
+            Item item = itemService.find(c, itemId);
+            return itemService.getMetadataByMetadataString(item, field);
+        }
+    }
+
+    private TestDSpaceRunnableHandler runMove(String sourceRegex, String targetTemplate) throws Exception {
+        // Detach all setup entities from the thread-bound session so the script (sharing the session)
+        // does not flush a managed item that still references rows it deletes.
+        context.uncacheEntities();
+        TestDSpaceRunnableHandler handler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "metadata-field-move", "-s", sourceRegex, "-t", targetTemplate
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), handler, kernelImpl);
+        return handler;
+    }
+
+    private void ensureSchema(String name) throws Exception {
+        if (metadataSchemaService.find(context, name) == null) {
+            MetadataSchemaBuilder.createMetadataSchema(context, name, "http://dspace.org/mvtest/" + name).build();
+        }
+    }
+
+    private MetadataField ensureField(String schema, String element, String qualifier) throws Exception {
+        String key = schema + "." + element + (qualifier != null ? "." + qualifier : "");
+        MetadataField existing = metadataFieldService.findByString(context, key, '.');
+        if (existing != null) {
+            return existing;
+        }
+        MetadataSchema mdSchema = metadataSchemaService.find(context, schema);
+        return MetadataFieldBuilder.createMetadataField(context, mdSchema, element, qualifier, "test field").build();
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScriptIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScriptIT.java
@@ -11,6 +11,7 @@ import static org.dspace.content.authority.Choices.CF_ACCEPTED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -45,6 +46,7 @@ import org.dspace.core.factory.CoreServiceFactory;
 import org.dspace.core.service.PluginService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -125,6 +127,17 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
 
     }
 
+    /**
+     * Restore default authority configuration after each test so failures
+     * in one test do not leave virtual-metadata/authority settings for the next.
+     */
+    @After
+    public void tearDown() throws Exception {
+        configurationService.setProperty("item.enable-virtual-metadata", savedVirtualMetadata);
+        restoreAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+    }
+
     @Before
     public void setup() {
         choiceAuthorityService.getChoiceAuthoritiesNames(); // initialize the ChoiceAuthorityService
@@ -138,71 +151,32 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
      */
     @Test
     public void testMigrateAuthorRelationshipToAuthority() throws Exception {
-        // Disable authority plugins and enable virtual metadata for relationship creation
-        configurationService.setProperty("item.enable-virtual-metadata", true);
-        configurationService.setProperty(
-            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
-        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
-        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
-        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
-
+        disableAuthorAuthorityConfig();
         clearAllAuthorityCaches();
 
-        context.turnOffAuthorisationSystem();
+        TestScenario scenario = createAuthorScenario();
 
-        // Create entity types
-        EntityType publicationEntityType =
-            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
-        EntityType personEntityType =
-            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
-
-        // Create community and collections
-        parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
-
-        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
-            .withName("Persons")
-            .withEntityType("Person")
-            .build();
-
-        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
-            .withName("Publications")
-            .withEntityType("Publication")
-            .build();
-
-        // Create relationship type: isAuthorOfPublication
-        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
-            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
-                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
-            .withCopyToLeft(false)
-            .withCopyToRight(false)
-            .build();
-
-        // Create person items
-        Item author1 = ItemBuilder.createItem(context, personCollection)
+        Item author1 = ItemBuilder.createItem(context, scenario.personCollection)
             .withTitle("Walter White")
             .build();
 
-        Item author2 = ItemBuilder.createItem(context, personCollection)
+        Item author2 = ItemBuilder.createItem(context, scenario.personCollection)
             .withTitle("Jesse Pinkman")
             .build();
 
-        // Create publication item
-        Item publication = ItemBuilder.createItem(context, publicationCollection)
+        Item publication = ItemBuilder.createItem(context, scenario.publicationCollection)
             .withTitle("Test Publication")
             .withAuthor("Saul Goodman")
             .withAuthor("Jesse Pinkman")
             .build();
 
-        // Create relationships between publication and persons
         RelationshipBuilder.createRelationshipBuilder(
-                context, publication, author1, isAuthorOfPublication, 1, -1)
+                context, publication, author1, scenario.relationshipType, 1, -1)
             .withLeftwardValue("Walter White")
             .build();
 
         RelationshipBuilder.createRelationshipBuilder(
-                context, publication, author2, isAuthorOfPublication, 2, -1)
+                context, publication, author2, scenario.relationshipType, 2, -1)
             .withLeftwardValue("Jesse Pinkman")
             .build();
 
@@ -218,23 +192,12 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
             assertThat("Authority should be null before migration", mv.getAuthority(), nullValue());
         }
 
-        // Disable virtual metadata and restore authority config before running the migration
-        configurationService.setProperty("item.enable-virtual-metadata", false);
-        configurationService.setProperty(
-            "plugin.named.org.dspace.content.authority.ChoiceAuthority", savedAuthorityPlugins);
-        configurationService.setProperty("choices.plugin.dc.contributor.author", savedChoicesPlugin);
-        configurationService.setProperty("choices.presentation.dc.contributor.author", savedChoicesPresentation);
-        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorityControlled);
-
+        enableAuthorAuthorityConfig();
         clearAllAuthorityCaches();
 
-        // Run the migration script
-        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
-        String[] args = new String[] {
+        TestDSpaceRunnableHandler runnableHandler = runMigration(
             "relationship-to-authority-migrate", "-t",
-            String.valueOf(isAuthorOfPublication.getID())
-        };
-        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+            String.valueOf(scenario.relationshipType.getID()));
 
         // Verify no errors
         assertThat("Migration should complete without errors",
@@ -277,7 +240,7 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
 
         // Verify relationships still exist (no -d flag)
         List<Relationship> remaining = relationshipService.findByRelationshipType(
-            context, isAuthorOfPublication);
+            context, scenario.relationshipType);
         assertThat("Relationships should still exist without -d flag", remaining, hasSize(2));
     }
 
@@ -286,83 +249,33 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
      */
     @Test
     public void testMigrateWithDelete() throws Exception {
-        // Disable authority plugins and enable virtual metadata for relationship creation
-        configurationService.setProperty("item.enable-virtual-metadata", true);
-        configurationService.setProperty(
-            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
-        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
-        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
-        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
-
+        disableAuthorAuthorityConfig();
         clearAllAuthorityCaches();
 
-        context.turnOffAuthorisationSystem();
+        TestScenario scenario = createAuthorScenario();
 
-        // Create entity types
-        EntityType publicationEntityType =
-            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
-        EntityType personEntityType =
-            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
-
-        // Create community and collections
-        parentCommunity = CommunityBuilder.createCommunity(context)
-            .withName("Parent Community")
-            .build();
-
-        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
-            .withName("Persons")
-            .withEntityType("Person")
-            .build();
-
-        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
-            .withName("Publications")
-            .withEntityType("Publication")
-            .build();
-
-        // Create relationship type
-        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
-            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
-                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
-            .withCopyToLeft(false)
-            .withCopyToRight(false)
-            .build();
-
-        // Create person item
-        Item author1 = ItemBuilder.createItem(context, personCollection)
+        Item author1 = ItemBuilder.createItem(context, scenario.personCollection)
             .withTitle("Heisenberg")
             .build();
 
-        // Create publication item
-        Item publication = ItemBuilder.createItem(context, publicationCollection)
+        Item publication = ItemBuilder.createItem(context, scenario.publicationCollection)
             .withTitle("Blue Sky Paper")
             .build();
 
-        // Create relationship
         RelationshipBuilder.createRelationshipBuilder(
-                context, publication, author1, isAuthorOfPublication, 0, -1)
+                context, publication, author1, scenario.relationshipType, 0, -1)
             .withLeftwardValue("Heisenberg")
             .build();
 
         context.commit();
         context.restoreAuthSystemState();
 
-        // Disable virtual metadata before running the migration
-        configurationService.setProperty("item.enable-virtual-metadata", false);
-        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
-            new String[] { "org.dspace.content.authority.ItemAuthority = PersonAuthority" });
-        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
-        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
-        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
-
+        enableAuthorAuthorityConfig();
         clearAllAuthorityCaches();
 
-        // Run the migration with -d flag
-        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
-        String[] args = new String[] {
+        TestDSpaceRunnableHandler runnableHandler = runMigration(
             "relationship-to-authority-migrate", "-t",
-            String.valueOf(isAuthorOfPublication.getID()), "-d"
-        };
-        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+            String.valueOf(scenario.relationshipType.getID()), "-d");
 
         // Verify no errors
         assertThat("Migration should complete without errors",
@@ -379,7 +292,7 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
 
         // Verify relationships are deleted
         List<Relationship> remaining = relationshipService.findByRelationshipType(
-            context, isAuthorOfPublication);
+            context, scenario.relationshipType);
         assertThat("Relationships should be deleted with -d flag", remaining, empty());
     }
 
@@ -2056,6 +1969,336 @@ public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegratio
         configurationService.setProperty("choices.plugin.dc.relation.ispartof", savedPlugin);
         configurationService.setProperty("choices.presentation.dc.relation.ispartof", savedPres);
         configurationService.setProperty("authority.controlled.dc.relation.ispartof", savedCtrl);
+    }
+
+    /**
+     * Test that an unknown relationship type id is reported cleanly.
+     */
+    @Test
+    public void testMigrateWithInvalidTypeId() throws Exception {
+        enableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler handler = runMigration(
+            "relationship-to-authority-migrate", "-t", "999999");
+
+        assertThat("Should fail with IllegalArgumentException for unknown type id",
+            handler.getException(), instanceOf(IllegalArgumentException.class));
+        assertThat("Error message should mention missing relationship type",
+            handler.getErrorMessages().stream()
+                .anyMatch(m -> m.contains("not found")), is(true));
+    }
+
+    /**
+     * Test that a relationship type with no registered migration strategy is rejected.
+     */
+    @Test
+    public void testMigrateTypeWithNoStrategy() throws Exception {
+        disableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestScenario scenario = createAuthorScenario();
+
+        Item author = ItemBuilder.createItem(context, scenario.personCollection)
+            .withTitle("Mike Ehrmantraut")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, scenario.publicationCollection)
+            .withTitle("Security Consulting")
+            .build();
+
+        RelationshipType unconfiguredType = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, scenario.publicationEntityType, scenario.personEntityType,
+                "isEditorOfPublication", "isPublicationOfEditor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author, unconfiguredType, 0, -1)
+            .withLeftwardValue("Mike Ehrmantraut")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        enableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler handler = runMigration(
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(unconfiguredType.getID()));
+
+        assertThat("Should fail with IllegalArgumentException for unconfigured type",
+            handler.getException(), instanceOf(IllegalArgumentException.class));
+        assertThat("Error message should mention no migration definition",
+            handler.getErrorMessages().stream()
+                .anyMatch(m -> m.contains("No migration definition")), is(true));
+
+        // Relationships must remain untouched.
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, unconfiguredType);
+        assertThat("Relationships should not be changed", remaining, hasSize(1));
+    }
+
+    /**
+     * Test that combining delete ({@code -d}) and dry-run ({@code -n}) does not
+     * delete relationships.
+     */
+    @Test
+    public void testMigrateDryRunWithDeleteDoesNotDelete() throws Exception {
+        disableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestScenario scenario = createAuthorScenario();
+
+        Item author = ItemBuilder.createItem(context, scenario.personCollection)
+            .withTitle("Hank Schrader")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, scenario.publicationCollection)
+            .withTitle("Minerals")
+            .build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author, scenario.relationshipType, 0, -1)
+            .withLeftwardValue("Hank Schrader")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        enableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler handler = runMigration(
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(scenario.relationshipType.getID()), "-d", "-n");
+
+        assertThat("Dry-run with delete should complete without errors",
+            handler.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("No authority metadata should be added in dry-run", authors, empty());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, scenario.relationshipType);
+        assertThat("Relationships should still exist in dry-run", remaining, hasSize(1));
+    }
+
+    /**
+     * Test that a withdrawn target item is processed without error.
+     */
+    @Test
+    public void testMigrateWithdrawnItem() throws Exception {
+        disableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestScenario scenario = createAuthorScenario();
+
+        Item author = ItemBuilder.createItem(context, scenario.personCollection)
+            .withTitle("Skyler White")
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, scenario.publicationCollection)
+            .withTitle("Beneke Accounts")
+            .build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author, scenario.relationshipType, 0, -1)
+            .withLeftwardValue("Skyler White")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        context.turnOffAuthorisationSystem();
+        itemService.withdraw(context, publication);
+        context.commit();
+        context.restoreAuthSystemState();
+
+        enableAuthorAuthorityConfig();
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler handler = runMigration(
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(scenario.relationshipType.getID()));
+
+        assertThat("Migration should complete without errors for withdrawn item",
+            handler.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 1 author metadata value", authors, hasSize(1));
+        assertEquals("Skyler White", authors.get(0).getValue());
+        assertEquals(author.getID().toString(), authors.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, authors.get(0).getConfidence());
+    }
+
+    /**
+     * Holder for the immutable data created by {@link #createAuthorScenario()}.
+     */
+    private static final class TestScenario {
+        final EntityType publicationEntityType;
+        final EntityType personEntityType;
+        final Collection personCollection;
+        final Collection publicationCollection;
+        final RelationshipType relationshipType;
+
+        TestScenario(EntityType publicationEntityType, EntityType personEntityType,
+                     Collection personCollection, Collection publicationCollection,
+                     RelationshipType relationshipType) {
+            this.publicationEntityType = publicationEntityType;
+            this.personEntityType = personEntityType;
+            this.personCollection = personCollection;
+            this.publicationCollection = publicationCollection;
+            this.relationshipType = relationshipType;
+        }
+    }
+
+    /**
+     * Immutable snapshot of an authority configuration for a single metadata field.
+     */
+    private static final class SavedAuthorityConfig {
+        final String plugin;
+        final String presentation;
+        final String controlled;
+
+        SavedAuthorityConfig(String plugin, String presentation, String controlled) {
+            this.plugin = plugin;
+            this.presentation = presentation;
+            this.controlled = controlled;
+        }
+    }
+
+    /**
+     * Read the current authority configuration for a single metadata field.
+     *
+     * @param pluginProperty the choices.plugin property name
+     * @param presentationProperty the choices.presentation property name
+     * @param controlledProperty the authority.controlled property name
+     * @return the saved configuration snapshot
+     */
+    private SavedAuthorityConfig saveAuthorityConfig(String pluginProperty,
+                                                     String presentationProperty,
+                                                     String controlledProperty) {
+        return new SavedAuthorityConfig(
+            configurationService.getProperty(pluginProperty),
+            configurationService.getProperty(presentationProperty),
+            configurationService.getProperty(controlledProperty));
+    }
+
+    /**
+     * Restore the authority configuration for a single metadata field.
+     *
+     * @param pluginProperty the choices.plugin property name
+     * @param presentationProperty the choices.presentation property name
+     * @param controlledProperty the authority.controlled property name
+     * @param saved the saved configuration snapshot
+     */
+    private void restoreRelationAuthorityConfig(String pluginProperty,
+                                                String presentationProperty,
+                                                String controlledProperty,
+                                                SavedAuthorityConfig saved) {
+        configurationService.setProperty(pluginProperty, saved.plugin);
+        configurationService.setProperty(presentationProperty, saved.presentation);
+        configurationService.setProperty(controlledProperty, saved.controlled);
+    }
+
+    /**
+     * Disable authority plugins for {@code dc.contributor.author} and enable
+     * virtual metadata so relationships can be created without authority
+     * interference.
+     */
+    private void disableAuthorAuthorityConfig() {
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", (String[]) null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+    }
+
+    /**
+     * Restore the {@code dc.contributor.author} authority configuration to
+     * the values captured in {@link #saveConfiguration()}.
+     */
+    private void restoreAuthorAuthorityConfig() {
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", savedAuthorityPlugins);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", savedChoicesPlugin);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", savedChoicesPresentation);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorityControlled);
+    }
+
+    /**
+     * Enable the {@code dc.contributor.author} authority configuration for
+     * migration (PersonAuthority / suggest / true).
+     */
+    private void enableAuthorAuthorityConfig() {
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+            new String[] { "org.dspace.content.authority.ItemAuthority = PersonAuthority" });
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+    }
+
+    /**
+     * Create the common entity types, collections and relationship type used
+     * by the author-migration tests.
+     *
+     * @return the populated test scenario
+     * @throws SQLException if a database error occurs
+     */
+    private TestScenario createAuthorScenario() throws SQLException {
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        Collection personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons")
+            .withEntityType("Person")
+            .build();
+
+        Collection publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications")
+            .withEntityType("Publication")
+            .build();
+
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        return new TestScenario(publicationEntityType, personEntityType,
+            personCollection, publicationCollection, isAuthorOfPublication);
+    }
+
+    /**
+     * Run the migration script with the supplied CLI arguments and return the
+     * captured handler for assertions.
+     *
+     * @param args the script arguments (including the script name)
+     * @return the handler capturing logs, errors and exceptions
+     * @throws Exception if script launch fails
+     */
+    private TestDSpaceRunnableHandler runMigration(String... args) throws Exception {
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+        return runnableHandler;
     }
 
     @SuppressWarnings("rawtypes")

--- a/dspace-api/src/test/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScriptIT.java
+++ b/dspace-api/src/test/java/org/dspace/content/migration/RelationshipToAuthorityMigrationScriptIT.java
@@ -1,0 +1,2079 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.migration;
+
+import static org.dspace.content.authority.Choices.CF_ACCEPTED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.SQLException;
+import java.util.Comparator;
+import java.util.List;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.launcher.ScriptLauncher;
+import org.dspace.app.scripts.handler.impl.TestDSpaceRunnableHandler;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.EntityTypeBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.builder.RelationshipBuilder;
+import org.dspace.builder.RelationshipTypeBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.EntityType;
+import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.Relationship;
+import org.dspace.content.RelationshipType;
+import org.dspace.content.authority.factory.ContentAuthorityServiceFactory;
+import org.dspace.content.authority.service.ChoiceAuthorityService;
+import org.dspace.content.authority.service.MetadataAuthorityService;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.content.service.RelationshipService;
+import org.dspace.core.ReloadableEntity;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.core.service.PluginService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link RelationshipToAuthorityMigrationScript}.
+ *
+ * Tests that the script correctly converts entity relationships into
+ * authority-based metadata values on the publication item.
+ *
+ * @author Adamo Fapohunda (adamo.fapohunda at 4science.com)
+ */
+public class RelationshipToAuthorityMigrationScriptIT extends AbstractIntegrationTestWithDatabase {
+
+    private static ConfigurationService configurationService;
+
+
+    private static PluginService pluginService = CoreServiceFactory
+        .getInstance()
+        .getPluginService();
+
+    private static MetadataAuthorityService metadataAuthorityService = ContentAuthorityServiceFactory
+        .getInstance()
+        .getMetadataAuthorityService();
+
+    private static ChoiceAuthorityService choiceAuthorityService = ContentAuthorityServiceFactory
+        .getInstance()
+        .getChoiceAuthorityService();
+
+    private static String[] savedAuthorityPlugins;
+    private static String savedChoicesPlugin;
+    private static String savedChoicesPresentation;
+    private static String savedAuthorityControlled;
+    private static boolean savedVirtualMetadata;
+
+    private ItemService itemService;
+    private RelationshipService relationshipService;
+
+    private Collection personCollection;
+    private Collection publicationCollection;
+    private Collection projectCollection;
+
+    /**
+     * Save current configuration values before any tests run.
+     */
+    @BeforeClass
+    public static void saveConfiguration() {
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        savedAuthorityPlugins = configurationService.getArrayProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority");
+        savedChoicesPlugin = configurationService.getProperty(
+            "choices.plugin.dc.contributor.author");
+        savedChoicesPresentation = configurationService.getProperty(
+            "choices.presentation.dc.contributor.author");
+        savedAuthorityControlled = configurationService.getProperty(
+            "authority.controlled.dc.contributor.author");
+        savedVirtualMetadata = configurationService.getBooleanProperty(
+            "item.enable-virtual-metadata", false);
+    }
+
+    /**
+     * Restore configuration values after all tests.
+     */
+    @AfterClass
+    public static void restoreConfiguration() throws Exception {
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", savedAuthorityPlugins);
+        configurationService.setProperty(
+            "choices.plugin.dc.contributor.author", savedChoicesPlugin);
+        configurationService.setProperty(
+            "choices.presentation.dc.contributor.author", savedChoicesPresentation);
+        configurationService.setProperty(
+            "authority.controlled.dc.contributor.author", savedAuthorityControlled);
+        configurationService.setProperty(
+            "item.enable-virtual-metadata", savedVirtualMetadata);
+        clearAllAuthorityCaches();
+
+    }
+
+    @Before
+    public void setup() {
+        choiceAuthorityService.getChoiceAuthoritiesNames(); // initialize the ChoiceAuthorityService
+        itemService = ContentServiceFactory.getInstance().getItemService();
+        relationshipService = ContentServiceFactory.getInstance().getRelationshipService();
+    }
+
+    /**
+     * Test that the migration script converts author relationships to
+     * dc.contributor.author metadata with proper authority and place.
+     */
+    @Test
+    public void testMigrateAuthorRelationshipToAuthority() throws Exception {
+        // Disable authority plugins and enable virtual metadata for relationship creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        // Create entity types
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        // Create community and collections
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons")
+            .withEntityType("Person")
+            .build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications")
+            .withEntityType("Publication")
+            .build();
+
+        // Create relationship type: isAuthorOfPublication
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        // Create person items
+        Item author1 = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Walter White")
+            .build();
+
+        Item author2 = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Jesse Pinkman")
+            .build();
+
+        // Create publication item
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Test Publication")
+            .withAuthor("Saul Goodman")
+            .withAuthor("Jesse Pinkman")
+            .build();
+
+        // Create relationships between publication and persons
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author1, isAuthorOfPublication, 1, -1)
+            .withLeftwardValue("Walter White")
+            .build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author2, isAuthorOfPublication, 2, -1)
+            .withLeftwardValue("Jesse Pinkman")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        publication = reload(publication);
+
+        // Verify no authority metadata before migration
+        List<MetadataValue> authorsBefore = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        for (MetadataValue mv : authorsBefore) {
+            assertThat("Authority should be null before migration", mv.getAuthority(), nullValue());
+        }
+
+        // Disable virtual metadata and restore authority config before running the migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", savedAuthorityPlugins);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", savedChoicesPlugin);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", savedChoicesPresentation);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorityControlled);
+
+        clearAllAuthorityCaches();
+
+        // Run the migration script
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isAuthorOfPublication.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        // Verify no errors
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        // Verify success message in info logs
+        boolean foundComplete = runnableHandler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("=== Migration Complete ==="));
+        assertThat("Should contain completion message", foundComplete, is(true));
+
+        // Reload publication and verify metadata
+        publication = reload(publication);
+        List<MetadataValue> authorsAfter = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 3 author metadata values", authorsAfter, hasSize(3));
+
+        // Sort by place to ensure order
+        authorsAfter.sort(Comparator.comparingInt(MetadataValue::getPlace));
+
+        // Verify first author
+        MetadataValue firstAuthor = authorsAfter.get(0);
+        assertEquals("Saul Goodman", firstAuthor.getValue());
+        assertEquals(null, firstAuthor.getAuthority());
+        assertEquals(0, firstAuthor.getPlace());
+
+        // Verify second author
+        MetadataValue secondAuthor = authorsAfter.get(1);
+        assertEquals("Walter White", secondAuthor.getValue());
+        assertEquals(author1.getID().toString(), secondAuthor.getAuthority());
+        assertEquals(CF_ACCEPTED, secondAuthor.getConfidence());
+        assertEquals(1, secondAuthor.getPlace());
+
+        // Verify third author
+
+        MetadataValue thirdAuthor = authorsAfter.get(2);
+        assertEquals("Jesse Pinkman", thirdAuthor.getValue());
+        assertEquals(author2.getID().toString(), thirdAuthor.getAuthority());
+        assertEquals(CF_ACCEPTED, thirdAuthor.getConfidence());
+        assertEquals(2, thirdAuthor.getPlace());
+
+        // Verify relationships still exist (no -d flag)
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, isAuthorOfPublication);
+        assertThat("Relationships should still exist without -d flag", remaining, hasSize(2));
+    }
+
+    /**
+     * Test that the migration script deletes relationships when -d flag is used.
+     */
+    @Test
+    public void testMigrateWithDelete() throws Exception {
+        // Disable authority plugins and enable virtual metadata for relationship creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        // Create entity types
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        // Create community and collections
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons")
+            .withEntityType("Person")
+            .build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications")
+            .withEntityType("Publication")
+            .build();
+
+        // Create relationship type
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        // Create person item
+        Item author1 = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Heisenberg")
+            .build();
+
+        // Create publication item
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Blue Sky Paper")
+            .build();
+
+        // Create relationship
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author1, isAuthorOfPublication, 0, -1)
+            .withLeftwardValue("Heisenberg")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Disable virtual metadata before running the migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+            new String[] { "org.dspace.content.authority.ItemAuthority = PersonAuthority" });
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+
+        clearAllAuthorityCaches();
+
+        // Run the migration with -d flag
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isAuthorOfPublication.getID()), "-d"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        // Verify no errors
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        // Reload and verify metadata was added
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 1 author metadata value", authors, hasSize(1));
+        assertEquals("Heisenberg", authors.get(0).getValue());
+        assertEquals(author1.getID().toString(), authors.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, authors.get(0).getConfidence());
+
+        // Verify relationships are deleted
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, isAuthorOfPublication);
+        assertThat("Relationships should be deleted with -d flag", remaining, empty());
+    }
+
+    /**
+     * Test that dry-run mode does not commit any changes.
+     */
+    @Test
+    public void testMigrateDryRun() throws Exception {
+        // Disable authority plugins and enable virtual metadata for relationship creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        // Create entity types
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        // Create community and collections
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons")
+            .withEntityType("Person")
+            .build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications")
+            .withEntityType("Publication")
+            .build();
+
+        // Create relationship type
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        // Create person item
+        Item author1 = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Gustavo Fring")
+            .build();
+
+        // Create publication item
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Los Pollos Hermanos")
+            .build();
+
+        // Create relationship
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author1, isAuthorOfPublication, 0, -1)
+            .withLeftwardValue("Gustavo Fring")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Disable virtual metadata before running the migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+            new String[] { "org.dspace.content.authority.ItemAuthority = PersonAuthority" });
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        clearAllAuthorityCaches();
+
+        // Run the migration with -n (dry-run) flag
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isAuthorOfPublication.getID()), "-n"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        // Verify no errors
+        assertThat("Dry-run should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        // Verify dry-run message
+        boolean foundDryRun = runnableHandler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("DRY RUN: no changes committed"));
+        assertThat("Should contain dry-run message", foundDryRun, is(true));
+
+        // Reload and verify NO metadata was added (changes were aborted)
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        for (MetadataValue mv : authors) {
+            assertThat("No authority should be set in dry-run", mv.getAuthority(), nullValue());
+        }
+
+        // Verify relationships still exist
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, isAuthorOfPublication);
+        assertThat("Relationships should still exist in dry-run", remaining, hasSize(1));
+    }
+
+    /**
+     * Test that migration falls back to dc.title when leftwardValue is not set.
+     */
+    @Test
+    public void testMigrateWithoutLeftwardValue() throws Exception {
+        // Disable authority plugins and enable virtual metadata for relationship creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        // Create entity types
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        // Create community and collections
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community")
+            .build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons")
+            .withEntityType("Person")
+            .build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications")
+            .withEntityType("Publication")
+            .build();
+
+        // Create relationship type
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        // Create person item with a dc.title but no leftwardValue will be set on relationship
+        Item author1 = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Mike Ehrmantraut")
+            .build();
+
+        // Create publication item
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Half Measures Paper")
+            .build();
+
+        // Create relationship WITHOUT leftwardValue
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author1, isAuthorOfPublication, 0, -1)
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Disable virtual metadata before running the migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("plugin.named.org.dspace.content.authority.ChoiceAuthority",
+            new String[] { "org.dspace.content.authority.ItemAuthority = PersonAuthority" });
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        clearAllAuthorityCaches();
+
+        // Run the migration
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isAuthorOfPublication.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        // Verify no errors
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        // Reload and verify metadata uses dc.title as fallback value
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 1 author metadata value", authors, hasSize(1));
+
+        MetadataValue authorMv = authors.get(0);
+        assertEquals("Mike Ehrmantraut", authorMv.getValue());
+        assertEquals(author1.getID().toString(), authorMv.getAuthority());
+        assertEquals(CF_ACCEPTED, authorMv.getConfidence());
+        assertEquals(0, authorMv.getPlace());
+    }
+
+
+
+    // ============= Project Migration Tests =============
+    // The isProjectOfPublication/isPublicationOfProject type definition maps to
+    // dc.relation.project (leftward, null qualifier). The migration script matches the
+    // definition by the relationship type's leftward/rightward labels, so no
+    // specific database ID is required.
+
+    /**
+     * Test that the migration script converts project relationships to
+     * dc.relation.project metadata with proper authority and place.
+     */
+    @Test
+    public void testMigrateProjectRelationshipToAuthority() throws Exception {
+        // Save current dc.relation.project authority configuration
+        String savedRelationPlugin = configurationService.getProperty("choices.plugin.dc.relation.project");
+        String savedRelationPresentation = configurationService.getProperty("choices.presentation.dc.relation.project");
+        String savedRelationControlled = configurationService.getProperty("authority.controlled.dc.relation.project");
+
+        // Disable dc.relation.project authority for item creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.project", null);
+        configurationService.setProperty("choices.presentation.dc.relation.project", null);
+        configurationService.setProperty("authority.controlled.dc.relation.project", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType isProjectOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Project Alpha").build();
+
+        Item project2 = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Project Beta").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Test Publication").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, isProjectOfPublication, 0, -1)
+            .withLeftwardValue("Project Alpha").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project2, isProjectOfPublication, 1, -1)
+            .withLeftwardValue("Project Beta").build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        publication = reload(publication);
+
+        // Verify no dc.relation.project metadata before migration
+        List<MetadataValue> relationBefore = itemService.getMetadataByMetadataString(
+            publication, "dc.relation.project");
+        assertThat("Should have no dc.relation.project metadata before migration",
+            relationBefore, empty());
+
+        // Set dc.relation.project authority for migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.project", "ProjectAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.project", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.project", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isProjectOfPublication.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> relationAfter = itemService.getMetadataByMetadataString(
+            publication, "dc.relation.project");
+        assertThat("Should have 2 dc.relation.project metadata values", relationAfter, hasSize(2));
+
+        relationAfter.sort(Comparator.comparingInt(MetadataValue::getPlace));
+
+        MetadataValue firstRelation = relationAfter.get(0);
+        assertEquals("Project Alpha", firstRelation.getValue());
+        assertEquals(project.getID().toString(), firstRelation.getAuthority());
+        assertEquals(CF_ACCEPTED, firstRelation.getConfidence());
+        assertEquals(0, firstRelation.getPlace());
+
+        MetadataValue secondRelation = relationAfter.get(1);
+        assertEquals("Project Beta", secondRelation.getValue());
+        assertEquals(project2.getID().toString(), secondRelation.getAuthority());
+        assertEquals(CF_ACCEPTED, secondRelation.getConfidence());
+        assertEquals(1, secondRelation.getPlace());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, isProjectOfPublication);
+        assertThat("Relationships should still exist without -d flag", remaining, hasSize(2));
+
+        // Restore saved dc.relation.project authority configuration
+        configurationService.setProperty("choices.plugin.dc.relation.project", savedRelationPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.project", savedRelationPresentation);
+        configurationService.setProperty("authority.controlled.dc.relation.project", savedRelationControlled);
+    }
+
+    /**
+     * Test that the migration script deletes project relationships when -d flag is used.
+     */
+    @Test
+    public void testMigrateProjectWithDelete() throws Exception {
+        // Save current dc.relation.project authority configuration
+        String savedRelationPlugin = configurationService.getProperty("choices.plugin.dc.relation.project");
+        String savedRelationPresentation = configurationService.getProperty("choices.presentation.dc.relation.project");
+        String savedRelationControlled = configurationService.getProperty("authority.controlled.dc.relation.project");
+
+        // Disable dc.relation.project authority for item creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.project", null);
+        configurationService.setProperty("choices.presentation.dc.relation.project", null);
+        configurationService.setProperty("authority.controlled.dc.relation.project", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType isProjectOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Secret Project").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Confidential Report").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, isProjectOfPublication, 0, -1)
+            .withLeftwardValue("Secret Project").build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Set dc.relation.project authority for migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.project", "ProjectAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.project", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.project", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isProjectOfPublication.getID()), "-d"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            publication, "dc.relation.project");
+        assertThat("Should have 1 dc.relation.project metadata value", relations, hasSize(1));
+        assertEquals("Secret Project", relations.get(0).getValue());
+        assertEquals(project.getID().toString(), relations.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, relations.get(0).getConfidence());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, isProjectOfPublication);
+        assertThat("Relationships should be deleted with -d flag", remaining, empty());
+
+        // Restore saved dc.relation.project authority configuration
+        configurationService.setProperty("choices.plugin.dc.relation.project", savedRelationPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.project", savedRelationPresentation);
+        configurationService.setProperty("authority.controlled.dc.relation.project", savedRelationControlled);
+    }
+
+    /**
+     * Test that dry-run mode does not commit any changes for project migration.
+     */
+    @Test
+    public void testMigrateProjectDryRun() throws Exception {
+        // Save current dc.relation.project authority configuration
+        String savedRelationPlugin = configurationService.getProperty("choices.plugin.dc.relation.project");
+        String savedRelationPresentation = configurationService.getProperty("choices.presentation.dc.relation.project");
+        String savedRelationControlled = configurationService.getProperty("authority.controlled.dc.relation.project");
+
+        // Disable dc.relation.project authority for item creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.project", null);
+        configurationService.setProperty("choices.presentation.dc.relation.project", null);
+        configurationService.setProperty("authority.controlled.dc.relation.project", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType isProjectOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Dry Run Project").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Dry Run Publication").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, isProjectOfPublication, 0, -1)
+            .withLeftwardValue("Dry Run Project").build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Set dc.relation.project authority for migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.project", "ProjectAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.project", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.project", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isProjectOfPublication.getID()), "-n"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Dry-run should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        boolean foundDryRun = runnableHandler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("DRY RUN: no changes committed"));
+        assertThat("Should contain dry-run message", foundDryRun, is(true));
+
+        publication = reload(publication);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            publication, "dc.relation.project");
+        assertThat("Should have no dc.relation.project metadata in dry-run",
+            relations, empty());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(
+            context, isProjectOfPublication);
+        assertThat("Relationships should still exist in dry-run", remaining, hasSize(1));
+
+        // Restore saved dc.relation.project authority configuration
+        configurationService.setProperty("choices.plugin.dc.relation.project", savedRelationPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.project", savedRelationPresentation);
+        configurationService.setProperty("authority.controlled.dc.relation.project", savedRelationControlled);
+    }
+
+    /**
+     * Test that project migration falls back to dc.title when leftwardValue is not set.
+     */
+    @Test
+    public void testMigrateProjectWithoutLeftwardValue() throws Exception {
+        // Save current dc.relation.project authority configuration
+        String savedRelationPlugin = configurationService.getProperty("choices.plugin.dc.relation.project");
+        String savedRelationPresentation = configurationService.getProperty("choices.presentation.dc.relation.project");
+        String savedRelationControlled = configurationService.getProperty("authority.controlled.dc.relation.project");
+
+        // Disable dc.relation.project authority for item creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.project", null);
+        configurationService.setProperty("choices.presentation.dc.relation.project", null);
+        configurationService.setProperty("authority.controlled.dc.relation.project", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType isProjectOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Fallback Project").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Fallback Publication").build();
+
+        // Relationship WITHOUT leftwardValue — should fallback to project's dc.title
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, isProjectOfPublication, 0, -1)
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        // Set dc.relation.project authority for migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.project", "ProjectAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.project", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.project", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isProjectOfPublication.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            publication, "dc.relation.project");
+        assertThat("Should have 1 dc.relation.project metadata value", relations, hasSize(1));
+
+        MetadataValue relationMv = relations.get(0);
+        assertEquals("Fallback Project", relationMv.getValue());
+        assertEquals(project.getID().toString(), relationMv.getAuthority());
+        assertEquals(CF_ACCEPTED, relationMv.getConfidence());
+        assertEquals(0, relationMv.getPlace());
+
+        // Restore saved dc.relation.project authority configuration
+        configurationService.setProperty("choices.plugin.dc.relation.project", savedRelationPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.project", savedRelationPresentation);
+        configurationService.setProperty("authority.controlled.dc.relation.project", savedRelationControlled);
+    }
+
+    // ============= Dual-Direction Migration Tests =============
+    // The isAuthorOfPublicationDual/isPublicationOfAuthorDual type definition is
+    // configured with both leftward (dc.contributor.author on leftItem) and
+    // rightward (dc.description on rightItem) directional definitions. Dedicated
+    // labels are used so this does not clash with the leftward-only author type.
+
+    /**
+     * Test that a dual-direction type definition writes metadata to both
+     * the left and right items in a single migration run.
+     */
+    @Test
+    public void testMigrateDualDirection() throws Exception {
+        // Save authority configs
+        String savedAuthorPlugin = configurationService.getProperty("choices.plugin.dc.contributor.author");
+        String savedAuthorPresentation = configurationService.getProperty("choices.presentation.dc.contributor.author");
+        String savedAuthorControlled = configurationService.getProperty("authority.controlled.dc.contributor.author");
+        String savedDescPlugin = configurationService.getProperty("choices.plugin.dc.description");
+        String savedDescPresentation = configurationService.getProperty("choices.presentation.dc.description");
+        String savedDescControlled = configurationService.getProperty("authority.controlled.dc.description");
+
+        // Disable authority plugins for item creation
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+        configurationService.setProperty("choices.plugin.dc.description", null);
+        configurationService.setProperty("choices.presentation.dc.description", null);
+        configurationService.setProperty("authority.controlled.dc.description", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons").withEntityType("Person").build();
+
+        RelationshipType dualDirectionType = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublicationDual", "isPublicationOfAuthorDual", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item person = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Jane Doe").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Dual Direction Paper").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, person, dualDirectionType, 0, 0)
+            .withLeftwardValue("Jane Doe")
+            .withRightwardValue("Dual Direction Paper")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        publication = reload(publication);
+        person = reload(person);
+
+        // Verify no related metadata before migration
+        List<MetadataValue> authorsBefore = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have no author metadata before migration", authorsBefore, empty());
+        List<MetadataValue> descBefore = itemService.getMetadataByMetadataString(
+            person, "dc.description");
+        assertThat("Should have no description metadata before migration", descBefore, empty());
+
+        // Restore authority configs for migration
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        configurationService.setProperty("choices.plugin.dc.description", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.description", "suggest");
+        configurationService.setProperty("authority.controlled.dc.description", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(dualDirectionType.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        // Verify leftward: dc.contributor.author on publication
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 1 author metadata value on publication", authors, hasSize(1));
+        assertEquals("Jane Doe", authors.get(0).getValue());
+        assertEquals(person.getID().toString(), authors.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, authors.get(0).getConfidence());
+        assertEquals(0, authors.get(0).getPlace());
+
+        // Verify rightward: dc.description on person
+        person = reload(person);
+        List<MetadataValue> descriptions = itemService.getMetadataByMetadataString(
+            person, "dc.description");
+        assertThat("Should have 1 description metadata value on person", descriptions, hasSize(1));
+        assertEquals("Dual Direction Paper", descriptions.get(0).getValue());
+        assertEquals(publication.getID().toString(), descriptions.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, descriptions.get(0).getConfidence());
+        assertEquals(0, descriptions.get(0).getPlace());
+
+        // Restore authority configs
+        configurationService.setProperty("choices.plugin.dc.contributor.author", savedAuthorPlugin);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", savedAuthorPresentation);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorControlled);
+        configurationService.setProperty("choices.plugin.dc.description", savedDescPlugin);
+        configurationService.setProperty("choices.presentation.dc.description", savedDescPresentation);
+        configurationService.setProperty("authority.controlled.dc.description", savedDescControlled);
+    }
+
+    /**
+     * Test that rerunning the migration does not create duplicate metadata
+     * values (place-based upsert idempotency).
+     */
+    @Test
+    public void testMigrateIdempotentUpsert() throws Exception {
+        String savedAuthorPlugin = configurationService.getProperty("choices.plugin.dc.contributor.author");
+        String savedAuthorPresentation = configurationService.getProperty("choices.presentation.dc.contributor.author");
+        String savedAuthorControlled = configurationService.getProperty("authority.controlled.dc.contributor.author");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons").withEntityType("Person").build();
+
+        // Uses the isAuthorOfPublication/isPublicationOfAuthor type (author leftward)
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item author = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Repeat Author").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Repeat Paper").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author, isAuthorOfPublication, 0, -1)
+            .withLeftwardValue("Repeat Author").build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+
+        clearAllAuthorityCaches();
+
+        // First migration run
+        TestDSpaceRunnableHandler handler1 = new TestDSpaceRunnableHandler();
+        String[] args1 = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isAuthorOfPublication.getID())
+        };
+        ScriptLauncher.handleScript(args1, ScriptLauncher.getConfig(kernelImpl), handler1, kernelImpl);
+        assertThat("First migration should complete without errors",
+            handler1.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> afterFirst = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 1 author after first migration", afterFirst, hasSize(1));
+
+        // Second migration run (idempotent)
+        TestDSpaceRunnableHandler handler2 = new TestDSpaceRunnableHandler();
+        String[] args2 = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(isAuthorOfPublication.getID())
+        };
+        ScriptLauncher.handleScript(args2, ScriptLauncher.getConfig(kernelImpl), handler2, kernelImpl);
+        assertThat("Second migration should complete without errors",
+            handler2.getErrorMessages(), empty());
+
+        publication = reload(publication);
+        List<MetadataValue> afterSecond = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should still have exactly 1 author after second migration (no duplicates)",
+            afterSecond, hasSize(1));
+        assertEquals("Repeat Author", afterSecond.get(0).getValue());
+        assertEquals(author.getID().toString(), afterSecond.get(0).getAuthority());
+
+        configurationService.setProperty("choices.plugin.dc.contributor.author", savedAuthorPlugin);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", savedAuthorPresentation);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorControlled);
+    }
+
+    // ============= Rightward-Only Migration Tests =============
+    // The isRelatedToProject/isProjectRelatedTo type definition is configured
+    // with a single rightward directional definition (dc.relation on rightItem).
+
+    /**
+     * Test a rightward-only migration where metadata is written to the
+     * right item using rightwardValue from the relationship.
+     */
+    @Test
+    public void testMigrateRightwardOnly() throws Exception {
+        String savedRelationPlugin = configurationService.getProperty("choices.plugin.dc.relation");
+        String savedRelationPresentation = configurationService.getProperty("choices.presentation.dc.relation");
+        String savedRelationControlled = configurationService.getProperty("authority.controlled.dc.relation");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation", null);
+        configurationService.setProperty("choices.presentation.dc.relation", null);
+        configurationService.setProperty("authority.controlled.dc.relation", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isRelatedToProject", "isProjectRelatedTo", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Source Publication").build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Target Project").build();
+
+        // Relationship: rightwardValue set, leftwardValue empty
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, type, -1, 0)
+            .withRightwardValue("Source Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        publication = reload(publication);
+        project = reload(project);
+
+        // Verify no dc.relation on either item before migration
+        List<MetadataValue> leftRelationsBefore = itemService.getMetadataByMetadataString(
+            publication, "dc.relation");
+        assertThat("Publication should have no dc.relation before migration",
+            leftRelationsBefore, empty());
+        List<MetadataValue> rightRelationsBefore = itemService.getMetadataByMetadataString(
+            project, "dc.relation");
+        assertThat("Project should have no dc.relation before migration",
+            rightRelationsBefore, empty());
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(type.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        // Verify no metadata on leftItem (publication)
+        publication = reload(publication);
+        List<MetadataValue> leftRelations = itemService.getMetadataByMetadataString(
+            publication, "dc.relation");
+        assertThat("Publication should still have no dc.relation (rightward migrates to rightItem)",
+            leftRelations, empty());
+
+        // Verify metadata on rightItem (project)
+        project = reload(project);
+        List<MetadataValue> rightRelations = itemService.getMetadataByMetadataString(
+            project, "dc.relation");
+        assertThat("Project should have 1 dc.relation metadata value", rightRelations, hasSize(1));
+        assertEquals("Source Publication", rightRelations.get(0).getValue());
+        assertEquals(publication.getID().toString(), rightRelations.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, rightRelations.get(0).getConfidence());
+        assertEquals(0, rightRelations.get(0).getPlace());
+
+        configurationService.setProperty("choices.plugin.dc.relation", savedRelationPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation", savedRelationPresentation);
+        configurationService.setProperty("authority.controlled.dc.relation", savedRelationControlled);
+    }
+
+    /**
+     * Test rightward-only migration with dc.title fallback when
+     * rightwardValue is not set.
+     */
+    @Test
+    public void testMigrateRightwardOnlyWithoutValue() throws Exception {
+        String savedRelationPlugin = configurationService.getProperty("choices.plugin.dc.relation");
+        String savedRelationPresentation = configurationService.getProperty("choices.presentation.dc.relation");
+        String savedRelationControlled = configurationService.getProperty("authority.controlled.dc.relation");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation", null);
+        configurationService.setProperty("choices.presentation.dc.relation", null);
+        configurationService.setProperty("authority.controlled.dc.relation", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isRelatedToProject", "isProjectRelatedTo", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Fallback Publication Title").build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Fallback Project").build();
+
+        // Relationship WITHOUT rightwardValue — should fallback to publication's dc.title
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, type, -1, 0)
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t",
+            String.valueOf(type.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        project = reload(project);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            project, "dc.relation");
+        assertThat("Should have 1 dc.relation metadata value", relations, hasSize(1));
+        assertEquals("Fallback Publication Title", relations.get(0).getValue());
+        assertEquals(publication.getID().toString(), relations.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, relations.get(0).getConfidence());
+
+        configurationService.setProperty("choices.plugin.dc.relation", savedRelationPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation", savedRelationPresentation);
+        configurationService.setProperty("authority.controlled.dc.relation", savedRelationControlled);
+    }
+
+    // ============= Migrate-All & Batch-Size Tests =============
+
+    /**
+     * Test that omitting the -t option migrates every relationship type that
+     * has a configured migration definition.
+     */
+    @Test
+    public void testMigrateAllWhenTypeIdOmitted() throws Exception {
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons").withEntityType("Person").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item author = ItemBuilder.createItem(context, personCollection)
+            .withTitle("Migrate All Author").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Migrate All Paper").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author, isAuthorOfPublication, 0, -1)
+            .withLeftwardValue("Migrate All Author").build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        clearAllAuthorityCaches();
+
+        // Run WITHOUT -t : every configured relationship type should be migrated
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] { "relationship-to-authority-migrate" };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+        boolean foundAllMode = runnableHandler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("Mode: ALL configured relationship types"));
+        assertThat("Should run in migrate-all mode", foundAllMode, is(true));
+
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("Should have 1 author metadata value", authors, hasSize(1));
+        assertEquals("Migrate All Author", authors.get(0).getValue());
+        assertEquals(author.getID().toString(), authors.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, authors.get(0).getConfidence());
+
+        configurationService.setProperty("choices.plugin.dc.contributor.author", savedChoicesPlugin);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", savedChoicesPresentation);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorityControlled);
+    }
+
+    /**
+     * Test that the relationship paging batch size can be set with the -b option.
+     */
+    @Test
+    public void testBatchSizeOption() throws Exception {
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty(
+            "plugin.named.org.dspace.content.authority.ChoiceAuthority", null);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", null);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", null);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType personEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Person").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        personCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Persons").withEntityType("Person").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        RelationshipType isAuthorOfPublication = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, personEntityType,
+                "isAuthorOfPublication", "isPublicationOfAuthor", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item author1 = ItemBuilder.createItem(context, personCollection).withTitle("Author One").build();
+        Item author2 = ItemBuilder.createItem(context, personCollection).withTitle("Author Two").build();
+        Item author3 = ItemBuilder.createItem(context, personCollection).withTitle("Author Three").build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Batched Paper").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author1, isAuthorOfPublication, 0, -1).withLeftwardValue("Author One").build();
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author2, isAuthorOfPublication, 1, -1).withLeftwardValue("Author Two").build();
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, author3, isAuthorOfPublication, 2, -1).withLeftwardValue("Author Three").build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.contributor.author", "PersonAuthority");
+        configurationService.setProperty("choices.presentation.dc.contributor.author", "suggest");
+        configurationService.setProperty("authority.controlled.dc.contributor.author", "true");
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(isAuthorOfPublication.getID()), "-b", "1"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+        boolean foundBatch = runnableHandler.getInfoMessages().stream()
+            .anyMatch(msg -> msg.contains("Batch size: 1"));
+        assertThat("Should log the configured batch size of 1", foundBatch, is(true));
+
+        publication = reload(publication);
+        List<MetadataValue> authors = itemService.getMetadataByMetadataString(
+            publication, "dc.contributor.author");
+        assertThat("All 3 authors should be migrated across batches", authors, hasSize(3));
+
+        configurationService.setProperty("choices.plugin.dc.contributor.author", savedChoicesPlugin);
+        configurationService.setProperty("choices.presentation.dc.contributor.author", savedChoicesPresentation);
+        configurationService.setProperty("authority.controlled.dc.contributor.author", savedAuthorityControlled);
+    }
+
+    // ============= Project RIGHTWARD Migration Tests =============
+    // The dual isProjectOfPublication/isPublicationOfProject type also writes
+    // dc.relation.publication on the right (Project) item.
+
+    @Test
+    public void testMigratePublicationOfProjectRightward() throws Exception {
+        String savedPlugin = configurationService.getProperty("choices.plugin.dc.relation.publication");
+        String savedPres = configurationService.getProperty("choices.presentation.dc.relation.publication");
+        String savedCtrl = configurationService.getProperty("authority.controlled.dc.relation.publication");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.publication", null);
+        configurationService.setProperty("choices.presentation.dc.relation.publication", null);
+        configurationService.setProperty("authority.controlled.dc.relation.publication", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Source Publication").build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Target Project").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, type, -1, 0)
+            .withRightwardValue("Source Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.publication", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.publication", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.publication", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(type.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        project = reload(project);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            project, "dc.relation.publication");
+        assertThat("Project should have 1 dc.relation.publication value", relations, hasSize(1));
+        assertEquals("Source Publication", relations.get(0).getValue());
+        assertEquals(publication.getID().toString(), relations.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, relations.get(0).getConfidence());
+        assertEquals(0, relations.get(0).getPlace());
+
+        configurationService.setProperty("choices.plugin.dc.relation.publication", savedPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.publication", savedPres);
+        configurationService.setProperty("authority.controlled.dc.relation.publication", savedCtrl);
+    }
+
+    @Test
+    public void testMigratePublicationOfProjectRightwardWithDelete() throws Exception {
+        String savedPlugin = configurationService.getProperty("choices.plugin.dc.relation.publication");
+        String savedPres = configurationService.getProperty("choices.presentation.dc.relation.publication");
+        String savedCtrl = configurationService.getProperty("authority.controlled.dc.relation.publication");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.publication", null);
+        configurationService.setProperty("choices.presentation.dc.relation.publication", null);
+        configurationService.setProperty("authority.controlled.dc.relation.publication", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Delete Publication").build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("Delete Project").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, type, -1, 0)
+            .withRightwardValue("Delete Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.publication", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.publication", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.publication", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(type.getID()), "-d"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        project = reload(project);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            project, "dc.relation.publication");
+        assertThat("Project should have 1 dc.relation.publication value", relations, hasSize(1));
+        assertEquals(publication.getID().toString(), relations.get(0).getAuthority());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(context, type);
+        assertThat("Relationships should be deleted with -d flag", remaining, empty());
+
+        configurationService.setProperty("choices.plugin.dc.relation.publication", savedPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.publication", savedPres);
+        configurationService.setProperty("authority.controlled.dc.relation.publication", savedCtrl);
+    }
+
+    @Test
+    public void testMigratePublicationOfProjectRightwardDryRun() throws Exception {
+        String savedPlugin = configurationService.getProperty("choices.plugin.dc.relation.publication");
+        String savedPres = configurationService.getProperty("choices.presentation.dc.relation.publication");
+        String savedCtrl = configurationService.getProperty("authority.controlled.dc.relation.publication");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.publication", null);
+        configurationService.setProperty("choices.presentation.dc.relation.publication", null);
+        configurationService.setProperty("authority.controlled.dc.relation.publication", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType projectEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Project").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        projectCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Projects").withEntityType("Project").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, projectEntityType,
+                "isProjectOfPublication", "isPublicationOfProject", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("DryRun Publication").build();
+
+        Item project = ItemBuilder.createItem(context, projectCollection)
+            .withTitle("DryRun Project").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, project, type, -1, 0)
+            .withRightwardValue("DryRun Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.publication", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.publication", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.publication", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(type.getID()), "-n"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Dry-run should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        project = reload(project);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            project, "dc.relation.publication");
+        assertThat("Project should have no dc.relation.publication in dry-run", relations, empty());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(context, type);
+        assertThat("Relationships should still exist in dry-run", remaining, hasSize(1));
+
+        configurationService.setProperty("choices.plugin.dc.relation.publication", savedPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.publication", savedPres);
+        configurationService.setProperty("authority.controlled.dc.relation.publication", savedCtrl);
+    }
+
+    // ============= JournalIssue RIGHTWARD Migration Tests =============
+    // isPublicationOfJournalIssue/isJournalIssueOfPublication (rightward only)
+    // writes dc.relation.ispartof on the right (JournalIssue) item.
+
+    @Test
+    public void testMigrateJournalIssueOfPublicationRightward() throws Exception {
+        String savedPlugin = configurationService.getProperty("choices.plugin.dc.relation.ispartof");
+        String savedPres = configurationService.getProperty("choices.presentation.dc.relation.ispartof");
+        String savedCtrl = configurationService.getProperty("authority.controlled.dc.relation.ispartof");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", null);
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", null);
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType journalIssueEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "JournalIssue").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        Collection journalIssueCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Journal Issues").withEntityType("JournalIssue").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, journalIssueEntityType,
+                "isPublicationOfJournalIssue", "isJournalIssueOfPublication", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Hosted Publication").build();
+
+        Item journalIssue = ItemBuilder.createItem(context, journalIssueCollection)
+            .withTitle("Journal Issue 2026").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, journalIssue, type, -1, 0)
+            .withRightwardValue("Hosted Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(type.getID())
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        journalIssue = reload(journalIssue);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            journalIssue, "dc.relation.ispartof");
+        assertThat("JournalIssue should have 1 dc.relation.ispartof value", relations, hasSize(1));
+        assertEquals("Hosted Publication", relations.get(0).getValue());
+        assertEquals(publication.getID().toString(), relations.get(0).getAuthority());
+        assertEquals(CF_ACCEPTED, relations.get(0).getConfidence());
+        assertEquals(0, relations.get(0).getPlace());
+
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", savedPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", savedPres);
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", savedCtrl);
+    }
+
+    @Test
+    public void testMigrateJournalIssueOfPublicationRightwardWithDelete() throws Exception {
+        String savedPlugin = configurationService.getProperty("choices.plugin.dc.relation.ispartof");
+        String savedPres = configurationService.getProperty("choices.presentation.dc.relation.ispartof");
+        String savedCtrl = configurationService.getProperty("authority.controlled.dc.relation.ispartof");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", null);
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", null);
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType journalIssueEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "JournalIssue").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        Collection journalIssueCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Journal Issues").withEntityType("JournalIssue").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, journalIssueEntityType,
+                "isPublicationOfJournalIssue", "isJournalIssueOfPublication", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("Delete Hosted Publication").build();
+
+        Item journalIssue = ItemBuilder.createItem(context, journalIssueCollection)
+            .withTitle("Delete Journal Issue").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, journalIssue, type, -1, 0)
+            .withRightwardValue("Delete Hosted Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(type.getID()), "-d"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Migration should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        journalIssue = reload(journalIssue);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            journalIssue, "dc.relation.ispartof");
+        assertThat("JournalIssue should have 1 dc.relation.ispartof value", relations, hasSize(1));
+        assertEquals(publication.getID().toString(), relations.get(0).getAuthority());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(context, type);
+        assertThat("Relationships should be deleted with -d flag", remaining, empty());
+
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", savedPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", savedPres);
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", savedCtrl);
+    }
+
+    @Test
+    public void testMigrateJournalIssueOfPublicationRightwardDryRun() throws Exception {
+        String savedPlugin = configurationService.getProperty("choices.plugin.dc.relation.ispartof");
+        String savedPres = configurationService.getProperty("choices.presentation.dc.relation.ispartof");
+        String savedCtrl = configurationService.getProperty("authority.controlled.dc.relation.ispartof");
+
+        configurationService.setProperty("item.enable-virtual-metadata", true);
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", null);
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", null);
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", null);
+
+        clearAllAuthorityCaches();
+
+        context.turnOffAuthorisationSystem();
+
+        EntityType publicationEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "Publication").build();
+        EntityType journalIssueEntityType =
+            EntityTypeBuilder.createEntityTypeBuilder(context, "JournalIssue").build();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+            .withName("Parent Community").build();
+
+        publicationCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Publications").withEntityType("Publication").build();
+
+        Collection journalIssueCollection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("Journal Issues").withEntityType("JournalIssue").build();
+
+        RelationshipType type = RelationshipTypeBuilder
+            .createRelationshipTypeBuilder(context, publicationEntityType, journalIssueEntityType,
+                "isPublicationOfJournalIssue", "isJournalIssueOfPublication", 0, null, 0, null)
+            .withCopyToLeft(false)
+            .withCopyToRight(false)
+            .build();
+
+        Item publication = ItemBuilder.createItem(context, publicationCollection)
+            .withTitle("DryRun Hosted Publication").build();
+
+        Item journalIssue = ItemBuilder.createItem(context, journalIssueCollection)
+            .withTitle("DryRun Journal Issue").build();
+
+        RelationshipBuilder.createRelationshipBuilder(
+                context, publication, journalIssue, type, -1, 0)
+            .withRightwardValue("DryRun Hosted Publication")
+            .build();
+
+        context.commit();
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("item.enable-virtual-metadata", false);
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", "PublicationAuthority");
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", "suggest");
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", "true");
+
+        clearAllAuthorityCaches();
+
+        TestDSpaceRunnableHandler runnableHandler = new TestDSpaceRunnableHandler();
+        String[] args = new String[] {
+            "relationship-to-authority-migrate", "-t", String.valueOf(type.getID()), "-n"
+        };
+        ScriptLauncher.handleScript(args, ScriptLauncher.getConfig(kernelImpl), runnableHandler, kernelImpl);
+
+        assertThat("Dry-run should complete without errors",
+            runnableHandler.getErrorMessages(), empty());
+
+        journalIssue = reload(journalIssue);
+        List<MetadataValue> relations = itemService.getMetadataByMetadataString(
+            journalIssue, "dc.relation.ispartof");
+        assertThat("JournalIssue should have no dc.relation.ispartof in dry-run", relations, empty());
+
+        List<Relationship> remaining = relationshipService.findByRelationshipType(context, type);
+        assertThat("Relationships should still exist in dry-run", remaining, hasSize(1));
+
+        configurationService.setProperty("choices.plugin.dc.relation.ispartof", savedPlugin);
+        configurationService.setProperty("choices.presentation.dc.relation.ispartof", savedPres);
+        configurationService.setProperty("authority.controlled.dc.relation.ispartof", savedCtrl);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private <T extends ReloadableEntity> T reload(T entity) throws SQLException {
+        return context.reloadEntity(entity);
+    }
+
+    /**
+     * Clears all authority-related caches to ensure configuration changes take effect.
+     * CRITICAL: This must be called after any authority configuration changes.
+     */
+    private static void clearAllAuthorityCaches() throws Exception {
+        try {
+            pluginService.clearNamedPluginClasses();  // Can throw SubmissionConfigReaderException
+            choiceAuthorityService.clearCache();
+            metadataAuthorityService.clearCache();  // Critical for authority config reload
+        } catch (Exception e) {
+            throw new Exception("Failed to clear authority caches: " + e.getMessage(), e);
+        }
+    }
+}

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -136,6 +136,14 @@
                   value="org.dspace.content.migration.RelationshipToAuthorityMigrationScript"/>
     </bean>
 
+    <bean id="metadata-field-move"
+          class="org.dspace.content.migration.MetadataFieldMoveCliScriptConfiguration">
+        <property name="description"
+                  value="Move metadata values from a source field (regex) to a target field (template), DB-level"/>
+        <property name="dspaceRunnableClass"
+                  value="org.dspace.content.migration.MetadataFieldMoveScript"/>
+    </bean>
+
     <!-- ============================================================ -->
     <!-- Directional migration definitions                             -->
     <!-- Shareable: one definition can be reused across type configs   -->

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -128,4 +128,84 @@
         <property name="dspaceRunnableClass" value="org.dspace.content.enhancer.script.ItemEnhancerScript"/>
     </bean>
 
+    <bean id="relationship-to-authority-migrate"
+          class="org.dspace.content.migration.RelationshipToAuthorityMigrationCliScriptConfiguration">
+        <property name="description"
+                  value="Migrate relationships to CRIS authority model (config-driven, one type at a time)"/>
+        <property name="dspaceRunnableClass"
+                  value="org.dspace.content.migration.RelationshipToAuthorityMigrationScript"/>
+    </bean>
+
+    <!-- ============================================================ -->
+    <!-- Directional migration definitions                             -->
+    <!-- Shareable: one definition can be reused across type configs   -->
+    <!-- ============================================================ -->
+
+    <bean id="authorLeftwardDef" class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="LEFT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="contributor"/>
+        <property name="qualifier" value="author"/>
+    </bean>
+
+    <bean id="projectLeftwardDef" class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="LEFT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier" value="project"/>
+    </bean>
+
+    <bean id="publicationOfProjectRightwardDef"
+          class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="RIGHT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier" value="publication"/>
+    </bean>
+
+    <bean id="journalIssueOfPublicationRightwardDef"
+          class="org.dspace.content.migration.DirectionalMigrationDefinition">
+        <property name="ownerSide" value="RIGHT"/>
+        <property name="schema" value="dc"/>
+        <property name="element" value="relation"/>
+        <property name="qualifier" value="ispartof"/>
+    </bean>
+
+    <!-- ============================================================ -->
+    <!-- Relationship type migration definitions                       -->
+    <!-- Matched to a relationship type by its leftward/rightward      -->
+    <!-- type labels; compose with leftward and/or rightward directions -->
+    <!-- ============================================================ -->
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isAuthorOfPublication"/>
+        <property name="rightwardType" value="isPublicationOfAuthor"/>
+        <property name="description"
+                  value="isAuthorOfPublication -> dc.contributor.author (Person isAuthorOf Publication)"/>
+        <property name="leftwardMigration" ref="authorLeftwardDef"/>
+    </bean>
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isProjectOfPublication"/>
+        <property name="rightwardType" value="isPublicationOfProject"/>
+        <property name="description"
+                  value="isProjectOfPublication/isPublicationOfProject -> dc.relation.project (LEFT) + dc.relation.publication (RIGHT)"/>
+        <property name="leftwardMigration" ref="projectLeftwardDef"/>
+        <property name="rightwardMigration" ref="publicationOfProjectRightwardDef"/>
+    </bean>
+
+    <bean class="org.dspace.content.migration.RelationshipTypeMigrationDefinition">
+        <property name="leftwardType" value="isPublicationOfJournalIssue"/>
+        <property name="rightwardType" value="isJournalIssueOfPublication"/>
+        <property name="description"
+                  value="isJournalIssueOfPublication -> dc.relation.ispartof (RIGHT, on JournalIssue)"/>
+        <property name="rightwardMigration" ref="journalIssueOfPublicationRightwardDef"/>
+    </bean>
+
+    <!-- ============================================================ -->
+    <!-- Shared helper bean for upsert logic                           -->
+    <!-- ============================================================ -->
+
+    <bean id="directionalMetadataMigrator"
+          class="org.dspace.content.migration.DirectionalMetadataMigrator"/>
 </beans>


### PR DESCRIPTION
## References
* Fixes #11780


## Description

Adds two DSpace admin scripts for bulk data migration: `relationship-to-authority-migrate` converts entity Relationships into authority-based metadata values, and `metadata-field-move` renames stored metadata values across the entire repository using regex-based field matching.

## Instructions for Reviewers

### Features

#### 1. Relationship-to-Authority Migration (`relationship-to-authority-migrate`)

Converts entity relationships into authority-backed metadata. For each relationship, writes a metadata value on the owner item with the related item's UUID as authority and `CF_ACCEPTED` confidence. Optionally deletes the source relationship afterwards (`-d`).

- **Config-driven** — migration definitions are declared as Spring beans in `scripts.xml`, mapping relationship type labels (leftward/rightward) to directional definitions (owner side + target metadata field)
- **Label-based matching** — type definitions are matched by leftward/rightward labels, not database IDs, making configs portable across environments
- **Directional support** — each relationship type can migrate leftward (metadata on left item), rightward (metadata on right item), or both
- **Place-based upsert** — writes at the relationship's `place`; if the slot is occupied, updates in place (idempotent re-runs)
- **Value derivation** — uses a configured directional value, or falls back to the related item's `dc.title`
- **Stored metadata only** — reads/writes persistent metadata, never virtual (relationship-based) metadata
- Full integration test suite (12 tests)

#### 2. Metadata Field Move (`metadata-field-move`)

Bulk renames stored metadata values across the entire repository using regex source matching and template-based target resolution.

- **Regex-based mapping** — `-s` source regex matched against registered field canonical names (`schema.element[.qualifier]`); `-t` target template with `$1`, `$2`, ... backreference support
- **Skip exact duplicates** — values matching existing target values (same text/authority/language) are dropped via bulk delete, not duplicated
- **Place-append logic** — if target field is empty, preserves original `place`; if target already has values, appends after max existing place
- **Validation (fail-fast)** — aborts if any resolved target field is not registered, or if two sources map to the same target
- **Stable keyset pagination** — processes by object id in configurable batches (default 1000), committing per batch
- **Bypasses event/indexing pipeline** — direct `metadatavalue` updates for speed; prints reindex reminder at completion
- Full integration test suite (7 tests)

### Relationship type configurations

The following relationship types are configured in `dspace/config/spring/api/scripts.xml`:

| Relationship (leftward → rightward) | Target metadata | Direction | Notes |
|--------------------------------------|----------------|-----------|-------|
| `isAuthorOfPublication` / `isPublicationOfAuthor` | `dc.contributor.author` | Leftward (Publication ← Person) | ✅ Used in ItemView |
| `isProjectOfPublication` / `isPublicationOfProject` | `dc.relation.project` | Leftward (Publication ← Project) | ✅ Used in ItemView |
| | `dc.relation.publication` | Rightward (Project → Publication) | ✅ Used in ItemView |
| `isPublicationOfJournalIssue` / `isJournalIssueOfPublication` | `dc.relation.ispartof` | Leftward (Publication ← JournalIssue) | ✅ Used in ItemView |

### Usage examples

**Relationship-to-authority migration:**

```bash
# Migrate ALL configured relationship types
dspace relationship-to-authority-migrate

# Preview ALL configured types (no changes committed)
dspace relationship-to-authority-migrate -n

# Migrate a single relationship type by ID, keep the relationships
dspace relationship-to-authority-migrate -t 1

# Migrate a single type and delete the source relationships
dspace relationship-to-authority-migrate -t 1 -d

# Use a custom batch size
dspace relationship-to-authority-migrate -b 500
```

**Metadata field move:**

```bash
# Move dc.relation to dc.relation.project
dspace metadata-field-move -s '^dc\\.relation$' -t 'dc.relation.project'

# Move all cris.* fields to dspace.* (same element/qualifier)
dspace metadata-field-move -s '^cris\\.(.+)$' -t 'dspace.$1'

# Preview before applying
dspace metadata-field-move -s '^cris\\.(.+)$' -t 'dspace.$1' -n

# Use a custom batch size
dspace metadata-field-move -s '^dc\\.relation$' -t 'dc.relation.project' -b 500
```

After a real metadata-field-move run, always reindex:
```bash
dspace index-discovery -b
```

### Testing

```bash
# Relationship-to-authority migration tests
mvn -pl dspace-api verify -DskipIntegrationTests=false \
  -Dit.test=RelationshipToAuthorityMigrationIT -DfailIfNoTests=false

# Metadata field move tests
mvn test -Dtest=org.dspace.content.migration.MetadataFieldMoveScriptIT -DskipUnitTests=false
```


## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
