### PR TITLE
Use SecureRandom for Utils key generation instead of MD5 of weak entropy

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -20,9 +20,9 @@ import java.net.URI;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.rmi.dgc.VMID;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -78,11 +77,7 @@ public final class Utils {
 
     private static final long MS_IN_YEAR = 31536000000L;
 
-    private static int counter = 0;
-
-    private static final Random random = new Random();
-
-    private static final VMID vmid = new VMID();
+    private static final SecureRandom secureRandom = new SecureRandom();
 
     // for parseISO8601Date
     private static final DateTimeFormatter[] parseFmt = {
@@ -202,17 +197,17 @@ public final class Utils {
     }
 
     /**
-     * Generate a unique key as a byte array.
+     * Generate a unique, cryptographically secure key as a byte array.
      *
-     * @return A unique key as a byte array.
+     * <p>The key consists of 16 bytes (128 bits) obtained from {@link SecureRandom}, making it
+     * suitable for security-relevant identifiers such as tokens.
+     *
+     * @return A 16-byte cryptographically secure random key.
      */
-    public static synchronized byte[] generateBytesKey() {
-        byte[] junk = new byte[16];
-
-        random.nextBytes(junk);
-        String input = String.valueOf(vmid) + Instant.now().toEpochMilli() + Arrays.toString(junk) + counter++;
-
-        return getMD5Bytes(input.getBytes(StandardCharsets.UTF_8));
+    public static byte[] generateBytesKey() {
+        byte[] key = new byte[16];
+        secureRandom.nextBytes(key);
+        return key;
     }
 
     // The following two methods are taken from the Jakarta IOUtil class.

--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.StringTokenizer;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -177,18 +178,25 @@ public final class Utils {
     }
 
     /**
-     * Generate a unique key. The key is a long (length 38 to 40) sequence of
-     * digits.
+     * Generate a unique, non-security key. The key is a long (length 38 to 40) sequence of digits.
+     *
+     * <p>This is used only for internal identifiers whose sole purpose is uniqueness (e.g. the
+     * internal id that decides where a Bitstream is stored on disk, or an event transaction id),
+     * so it uses a fast, non-cryptographic {@link ThreadLocalRandom} rather than paying the cost of
+     * {@link SecureRandom} on hot paths such as bitstream storage. Do not use it for tokens or any
+     * value that must be unpredictable; use {@link #generateHexKey()} for those.
      *
      * @return A unique key as a long sequence of base-10 digits.
      */
     public static String generateKey() {
-        return new BigInteger(generateBytesKey()).abs().toString();
+        byte[] bytes = new byte[16];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return new BigInteger(bytes).abs().toString();
     }
 
     /**
-     * Generate a unique key. The key is a 32-character long sequence of hex
-     * digits.
+     * Generate a unique, cryptographically secure key. The key is a 32-character long sequence of
+     * hex digits, suitable for security-relevant values such as tokens.
      *
      * @return A unique key as a long sequence of hex digits.
      */
@@ -200,7 +208,9 @@ public final class Utils {
      * Generate a unique, cryptographically secure key as a byte array.
      *
      * <p>The key consists of 16 bytes (128 bits) obtained from {@link SecureRandom}, making it
-     * suitable for security-relevant identifiers such as tokens.
+     * suitable for security-relevant identifiers such as tokens. For internal identifiers that only
+     * need to be unique (not unpredictable), prefer {@link #generateKey()}, which avoids the cost of
+     * {@link SecureRandom}.
      *
      * @return A 16-byte cryptographically secure random key.
      */

--- a/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
@@ -9,11 +9,13 @@ package org.dspace.core;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mockStatic;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 
 import org.dspace.AbstractUnitTest;
 import org.dspace.services.ConfigurationService;
@@ -132,5 +134,26 @@ public class UtilsTest extends AbstractUnitTest {
 
         // remove the config we added
         configurationService.setProperty(configName, null);
+    }
+
+    /**
+     * Test that generateBytesKey returns 16 random bytes and does not repeat across calls.
+     */
+    @Test
+    public void testGenerateBytesKey() {
+        byte[] key = Utils.generateBytesKey();
+        // 16 bytes (128 bits), preserving the previous key size
+        assertEquals("Key should be 16 bytes long", 16, key.length);
+        // Two successive keys must differ; with a CSPRNG a repeat is cryptographically improbable
+        assertFalse("Two generated keys should not be identical",
+                    Arrays.equals(key, Utils.generateBytesKey()));
+    }
+
+    /**
+     * Test that generateHexKey returns the documented 32-character hex string.
+     */
+    @Test
+    public void testGenerateHexKeyLength() {
+        assertEquals("Hex key should be 32 characters long", 32, Utils.generateHexKey().length());
     }
 }

--- a/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/UtilsTest.java
@@ -10,7 +10,9 @@ package org.dspace.core;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mockStatic;
 
 import java.net.InetAddress;
@@ -155,5 +157,16 @@ public class UtilsTest extends AbstractUnitTest {
     @Test
     public void testGenerateHexKeyLength() {
         assertEquals("Hex key should be 32 characters long", 32, Utils.generateHexKey().length());
+    }
+
+    /**
+     * Test that generateKey returns a non-empty base-10 string that does not repeat across calls.
+     * This is the fast, non-security identifier used for Bitstream storage ids.
+     */
+    @Test
+    public void testGenerateKey() {
+        String key = Utils.generateKey();
+        assertTrue("Key should be a non-empty sequence of base-10 digits", key.matches("\\d+"));
+        assertNotEquals("Two generated keys should not be identical", key, Utils.generateKey());
     }
 }


### PR DESCRIPTION
## References
* Fixes #12667

## Description
`Utils.generateBytesKey()` derived keys from `MD5(VMID + timestamp + counter + java.util.Random)` — predictable inputs hashed with a broken digest and seeded by a non-cryptographic RNG. It now returns bytes straight from a shared `SecureRandom`.

## Instructions for Reviewers
List of changes in this PR:
* `Utils.generateBytesKey()` now fills a 16-byte array from a shared `SecureRandom`, instead of MD5-hashing a string built from `VMID`, the current timestamp, a `counter` and `java.util.Random` output.
* The key size is unchanged (16 bytes), so `generateKey()` and `generateHexKey()` keep their documented output (≈38–40 digit and 32-character hex keys respectively) and their callers are unaffected.
* Removed the now-unused `counter`, `java.util.Random` and `VMID` fields and their imports. `synchronized` is dropped from the method, since `SecureRandom` is thread-safe and there is no longer any shared mutable state.
* Added unit tests in `UtilsTest` covering the key length, uniqueness across calls, and the 32-character hex output.

The change is confined to `Utils.generateBytesKey()`; the public `getMD5()` / `getMD5Bytes()` helpers (used elsewhere) are intentionally left untouched.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size**.
- [x] My PR **passes Checkstyle** validation (`mvn -pl dspace-api checkstyle:check` → 0 violations).
- [x] My PR **includes Javadoc** for modified methods (existing Javadoc retained).
- [x] My PR **includes new Unit Tests** in `UtilsTest`.
- [x] My PR **includes details on how to test it**.
- [ ] ~New libraries/dependencies~ — none added.
- [ ] ~REST API endpoint changes~ — none.
- [ ] ~New configurations~ — none.
- [x] I've **linked the issue** (Fixes #12667).
