### PR TITLE
Harden Crossref deposit response parsing to protect against corrupt/unsecured responses from Crossref API

### DIFF
--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefClient.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefClient.java
@@ -19,6 +19,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.identifier.doi.DOIIdentifierException;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -151,7 +152,7 @@ public class CrossRefClient {
         switch (statusCode) {
             case (200): {
                 try {
-                    SAXBuilder builder = new SAXBuilder();
+                    SAXBuilder builder = XMLUtils.getSAXBuilder();
                     Document doc = builder.build(new StringReader(content));
                     XPathExpression<Object> xpath = XPathFactory.instance().compile(
                             "/doi_batch_diagnostic/record_diagnostic[@status = 'Failure']", Filters.fpassthrough(),

--- a/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/CrossRefClientTest.java
+++ b/dspace-api/src/test/java/org/dspace/identifier/doi/crossref/CrossRefClientTest.java
@@ -88,6 +88,37 @@ public class CrossRefClientTest {
     }
 
     @Test
+    public void sendDepositRequest_200withDoctypeAndExternalEntity_doesNotResolveEntity() throws Exception {
+        // The deposit endpoint response must be parsed without resolving DOCTYPE / external entities.
+        // A SYSTEM entity pointing at a sentinel must never be fetched, and a DOCTYPE must be refused
+        // rather than expanded into the document. Before the fix the bare SAXBuilder resolved the
+        // entity (file read / outbound request); after the fix the hardened builder refuses the DOCTYPE.
+        MockWebServer sentinel = new MockWebServer();
+        sentinel.start();
+        sentinel.enqueue(new MockResponse().setResponseCode(200).setBody("PWNED"));
+        String sentinelUrl = sentinel.url("/xxe-callback").toString();
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                         + "<!DOCTYPE doi_batch_diagnostic [\n"
+                         + "  <!ENTITY xxe SYSTEM \"" + sentinelUrl + "\">\n"
+                         + "]>\n"
+                         + "<doi_batch_diagnostic status=\"completed\">\n"
+                         + "  <record_diagnostic status=\"Success\">&xxe;</record_diagnostic>\n"
+                         + "</doi_batch_diagnostic>"));
+
+        // The DOCTYPE is refused by the hardened parser, surfacing as a BAD_ANSWER parse failure.
+        assertThatExceptionOfType(DOIIdentifierException.class)
+                .isThrownBy(() -> client.sendDepositRequest("metadata"))
+                .matches(ex -> ex.getCode() == DOIIdentifierException.BAD_ANSWER);
+
+        // The SYSTEM entity must not have been dereferenced.
+        assertThat(sentinel.getRequestCount()).isEqualTo(0);
+        sentinel.shutdown();
+    }
+
+    @Test
     public void sendDepositRequest_200withFailureMessage_throwsDOIIdentifierExceptionWithBadRequest() throws Exception {
         server.enqueue(new MockResponse()
                        .setResponseCode(200)


### PR DESCRIPTION
## References
* Related to #9061 and #11962

## Description

_This issue was discovered/reported by @tonghuaroot.  This patch was also developed entirely by @tonghuaroot and submitted to Committers privately.  This PR is submitted on their behalf._

In DSpace 10.0, we added the ability to support DOI registration via CrossRef in #11962.

However, in the new `CrossRefClient`, we overlooked that the **response** from the CrossRef API was not being validated/secured properly.  So, if the CrossRef API was ever compromised, then it would be possible to potentially open DSpace to XXE style attacks.

This small PR patches the issue by using our new `XMLUtils.getSAXBuilder()` which provides a secured copy of `SAXBuilder` that will protect against potential XXEs coming via the CrossRef API response.  This PR also includes a test which validates that protection against XXE style attacks now exists for this `CrossRefClient`.

Thanks again to @tonghuaroot for reporting this issue and providing a fix.

## Instructions for Reviewers

* Review code and tests
* If possible, verify no change of behavior with CrossRef DOI Registration process. 

## Credit

Reported by @tonghuaroot.  Code fix in this PR is by @tonghuaroot 