### PR TITLE
Application hardening (especially of OAI-PMH) by securing all usage of `TransformerFactory`

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemArchive.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemupdate/ItemArchive.java
@@ -27,7 +27,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.LocalSchemaFilenameFilter;
@@ -133,7 +132,7 @@ public class ItemArchive {
     protected Transformer getTransformer()
         throws TransformerConfigurationException {
         if (transformer == null) {
-            transformer = TransformerFactory.newInstance().newTransformer();
+            transformer = XMLUtils.getTransformerFactory().newTransformer();
         }
         return transformer;
     }

--- a/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
@@ -9,16 +9,25 @@ package org.dspace.app.util;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jdom2.input.SAXBuilder;
@@ -365,5 +374,141 @@ public class XMLUtils {
         }
     }
 
+    /**
+     * Initialize and return the javax TransformerFactory with some basic security
+     * applied to avoid XXE attacks and other unwanted content inclusion
+     * @return transformer factory to generate new transformers
+     * @throws TransformerConfigurationException
+     */
+    public static TransformerFactory getTransformerFactory() throws TransformerConfigurationException {
+        TransformerFactory factory = TransformerFactory.newInstance();
 
+        // Process XML securely
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        // No external DTDs or Stylesheets
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+
+        return factory;
+    }
+
+    /**
+     * Initialize and return the javax TransformerFactory with less security applied.  This is intended only for
+     * internal or configuration use where external stylesheets and other dangerous features are purposefully
+     * included, but are only allowed from specific paths, e.g. ${dspace.dir}/config or some other path specified
+     * by the java caller.
+     * <p>
+     * If no allowedPaths are passed, then all external stylesheets are rejected.
+     * @param allowedBasePaths path(s) where all stylesheets should be located. Only these path will be "trusted"
+     *                         for externally referenced stylesheets.
+     * @return TransformerFactory that allows references to external stylesheets but only for the given base Paths.
+     * @throws TransformerConfigurationException
+     */
+    public static TransformerFactory getTrustedTransformerFactory(String... allowedBasePaths)
+        throws TransformerConfigurationException {
+        // Initialize a default trusted TransformerFactory by specifying "null" as the factoryClassName
+        return getTrustedTransformerFactory(null, allowedBasePaths);
+    }
+
+    /**
+     * Initialize and return the javax TransformerFactory with less security applied.  This is intended only for
+     * internal or configuration use where external stylesheets and other dangerous features are purposefully
+     * included, but are only allowed from specific paths, e.g. ${dspace.dir}/config or some other path specified
+     * by the java caller.
+     * <p>
+     * If no allowedPaths are passed, then all external stylesheets are rejected.
+     * @param factoryClassName optional factory class to use to initialize TransformerFactory. If `null` a default
+     *                         TransformerFactory will be initialized
+     * @param allowedBasePaths path(s) where all stylesheets should be located. Only these path will be "trusted"
+     *                         for externally referenced stylesheets.
+     * @return TransformerFactory that allows references to external stylesheets but only for the given base Paths.
+     * @throws TransformerConfigurationException
+     */
+    public static TransformerFactory getTrustedTransformerFactory(String factoryClassName, String... allowedBasePaths)
+        throws TransformerConfigurationException {
+        // If not null, use the passed in factoryClassName. Otherwise, initialize a default TransformerFactory
+        TransformerFactory factory = factoryClassName != null ?
+            TransformerFactory.newInstance(factoryClassName, null) : TransformerFactory.newInstance();
+
+        // Process XML securely
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        // No external DTDs
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+
+        // NOTE: We cannot disable XMLConstants.ACCESS_EXTERNAL_STYLESHEETS because OAI-PMH references some external
+        // stylesheets during XOAI transformations. Therefore, we set a custom URIResolver to ensure all external
+        // stylesheets come from trusted directories.
+        factory.setURIResolver(new PathRestrictedURIResolver(allowedBasePaths));
+
+        return factory;
+    }
+
+
+    /**
+     * This URIResolver accepts one or more path strings in its
+     * constructor and throws a TransformerException if the entity systemID
+     * is not within the allowed path (or a subdirectory).
+     * If no parameters are passed, then this effectively disallows
+     * any external entity resolution.
+     */
+    public static class PathRestrictedURIResolver implements URIResolver {
+
+        private final List<String> allowedBasePaths;
+
+        public PathRestrictedURIResolver(String... allowedBasePaths) {
+            this.allowedBasePaths = Arrays.asList(allowedBasePaths);
+        }
+
+        @Override
+        public Source resolve(String href, String base) throws TransformerException {
+            final URI uri;
+            // Base path is optional, as the "href" might already be an absolute path
+            if (base == null || base.isEmpty()) {
+                uri = URI.create(href);
+            } else {
+                uri = URI.create(base).resolve(href);
+            }
+
+            // Only allow for "file" scheme or empty scheme
+            String scheme = uri.getScheme();
+            if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
+                throw new TransformerException("External resources not allowed: " + uri +
+                                           ". Only local file paths are permitted.");
+            }
+
+            Path resolvedPath;
+            try {
+                // Resolve to an absolute path
+                resolvedPath = Paths.get(uri).toAbsolutePath().normalize();
+            } catch (Exception e) {
+                throw new TransformerException("Invalid path: " + uri, e);
+            }
+
+            boolean isAllowed = false;
+            for (String basePath : allowedBasePaths) {
+                Path allowedPath = Paths.get(basePath).toAbsolutePath().normalize();
+                if (resolvedPath.startsWith(allowedPath)) {
+                    isAllowed = true;
+                    break;
+                }
+            }
+
+            if (!isAllowed) {
+                throw new TransformerException("Access denied to path: " + resolvedPath);
+            }
+
+            File file = resolvedPath.toFile();
+            if (!file.exists() || !file.canRead()) {
+                throw new TransformerException("File not found or not readable: " + resolvedPath);
+            }
+
+            try {
+                return new StreamSource(new FileInputStream(file));
+            } catch (FileNotFoundException e) {
+                throw new TransformerException("Unable to stream file at: " + resolvedPath);
+            }
+        }
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/authority/util/XMLUtils.java
+++ b/dspace-api/src/main/java/org/dspace/authority/util/XMLUtils.java
@@ -7,24 +7,17 @@
  */
 package org.dspace.authority.util;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.logging.log4j.Logger;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 /**
  * @author Antoine Snyers (antoine at atmire.com)
@@ -134,24 +127,5 @@ public class XMLUtils {
                 //                lastNode.drop();
             }
         };
-    }
-
-    public static Document convertStreamToXML(InputStream is) {
-        Document result = null;
-        if (is != null) {
-            DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
-            try {
-                DocumentBuilder builder = domFactory.newDocumentBuilder();
-                result = builder.parse(is);
-            } catch (ParserConfigurationException e) {
-                log.error("Error", e);
-            } catch (SAXException e) {
-                log.error("Error", e);
-            } catch (IOException e) {
-                log.error("Error", e);
-            }
-        }
-        return result;
-
     }
 }

--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/XSLTCrosswalk.java
@@ -20,6 +20,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.core.SelfNamedPlugin;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
@@ -175,7 +176,7 @@ public abstract class XSLTCrosswalk extends SelfNamedPlugin {
                 Source transformSource
                     = new StreamSource(new FileInputStream(transformFile));
                 TransformerFactory transformerFactory
-                    = TransformerFactory.newInstance();
+                    = XMLUtils.getTransformerFactory();
                 transformer = transformerFactory.newTransformer(transformSource);
                 transformLastModified = transformFile.lastModified();
             } catch (TransformerConfigurationException | FileNotFoundException e) {

--- a/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
@@ -20,13 +20,13 @@ import java.util.Map;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
@@ -119,7 +119,7 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
         jurisdiction = configurationService.getProperty("cc.license.jurisdiction", "");
 
         try {
-            templates = TransformerFactory.newInstance().newTemplates(
+            templates = XMLUtils.getTransformerFactory().newTemplates(
                     new StreamSource(CreativeCommonsServiceImpl.class
                                              .getResourceAsStream("CreativeCommons.xsl")));
         } catch (TransformerConfigurationException e) {

--- a/dspace-api/src/main/java/org/dspace/license/LicenseCleanup.java
+++ b/dspace-api/src/main/java/org/dspace/license/LicenseCleanup.java
@@ -23,11 +23,11 @@ import java.util.Properties;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
@@ -57,7 +57,7 @@ public class LicenseCleanup {
 
     static {
         try {
-            templates = TransformerFactory.newInstance().newTemplates(
+            templates = XMLUtils.getTransformerFactory().newTemplates(
                 new StreamSource(CreativeCommonsServiceImpl.class
                                      .getResourceAsStream("LicenseCleanup.xsl")));
         } catch (TransformerConfigurationException e) {

--- a/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/migration/SubmissionFormsMigration.java
@@ -25,6 +25,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.utils.DSpace;
@@ -95,7 +96,7 @@ public class SubmissionFormsMigration extends DSpaceRunnable<SubmissionFormsMigr
         Result result = new StreamResult(new File(outputPath));
 
         // Create an instance of TransformerFactory
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        TransformerFactory transformerFactory = XMLUtils.getTransformerFactory();
 
         Transformer trans;
         try {

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <!-- This is the path to the root [dspace-src] directory. -->
         <root.basedir>${basedir}/..</root.basedir>
-        <xoai.version>3.4.1</xoai.version>
+        <xoai.version>3.4.2</xoai.version>
     </properties>
 
     <build>

--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -39,6 +39,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
 import org.dspace.xoai.services.api.cache.XOAICacheService;
@@ -101,7 +102,7 @@ public class DSpaceOAIDataProvider {
                 String styleSheetPath = manager.getStyleSheet();
                 Resource styleSheetResource = resourceLoader.getResource("classpath:" + styleSheetPath);
                 htmlTransformerSource = styleSheetResource.getContentAsByteArray();
-                htmlTransformerFactory = TransformerFactory.newInstance();
+                htmlTransformerFactory = XMLUtils.getTransformerFactory();
                 // run for potential exceptions only as a sanity check on the XSLT:
                 htmlTransformerFactory.newTransformer(
                         new StreamSource(new ByteArrayInputStream(htmlTransformerSource)));

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/resources/DSpaceResourceResolver.java
@@ -18,20 +18,25 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 
 import com.lyncode.xoai.dataprovider.services.api.ResourceResolver;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
 public class DSpaceResourceResolver implements ResourceResolver {
-    // Requires usage of Saxon as OAI-PMH uses some XSLT 2 functions
-    private static final TransformerFactory transformerFactory = TransformerFactory
-            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
-
     private final String basePath;
+    private final String crosswalksPath;
 
     public DSpaceResourceResolver() {
         ConfigurationService configurationService
                 = DSpaceServicesFactory.getInstance().getConfigurationService();
+        // base path for resolving XSLT templates
         basePath = configurationService.getProperty("oai.config.dir");
+        // additional path for crosswalks which may be used by XSLT templates
+        crosswalksPath = configurationService.getProperty("dspace.dir")
+            + File.separator
+            + "config"
+            + File.separator
+            + "crosswalks";
     }
 
     @Override
@@ -48,6 +53,13 @@ public class DSpaceResourceResolver implements ResourceResolver {
         // XSLT-files (like <xsl:import href="utils.xsl"/>)
         String systemId = basePath + "/" + path;
         mySrc.setSystemId(systemId);
+
+        // Requires usage of Saxon as OAI-PMH uses some XSLT 2 functions. Only trust stylesheets stored under
+        // the given path(s).
+        TransformerFactory transformerFactory =
+            XMLUtils.getTrustedTransformerFactory("net.sf.saxon.TransformerFactoryImpl",
+                                                  new String[] {basePath, crosswalksPath});
+
         return transformerFactory.newTemplates(mySrc);
     }
 }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/PipelineTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/integration/xoai/PipelineTest.java
@@ -19,16 +19,16 @@ import javax.xml.transform.stream.StreamSource;
 
 import com.lyncode.xoai.util.XSLPipeline;
 import org.apache.commons.io.IOUtils;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.xoai.tests.support.XmlMatcherBuilder;
 import org.junit.Test;
 
 public class PipelineTest {
-    private static TransformerFactory factory = TransformerFactory.newInstance();
-
     @Test
     public void pipelineTest() throws Exception {
         InputStream input = PipelineTest.class.getClassLoader().getResourceAsStream("item.xml");
         InputStream xslt = PipelineTest.class.getClassLoader().getResourceAsStream("oai_dc.xsl");
+        TransformerFactory factory = XMLUtils.getTransformerFactory();
         String output = IOUtils.toString(new XSLPipeline(input, true)
                                              .apply(factory.newTemplates(new StreamSource(xslt)))
                                              .getTransformed(), Charset.defaultCharset());

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/stylesheets/AbstractXSLTest.java
@@ -17,12 +17,9 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.IOUtils;
+import org.dspace.app.util.XMLUtils;
 
 public abstract class AbstractXSLTest {
-    // Requires usage of Saxon as OAI-PMH uses some XSLT 2 functions
-    private static final TransformerFactory factory = TransformerFactory
-            .newInstance("net.sf.saxon.TransformerFactoryImpl", null);
-
     protected TransformBuilder apply(String xslLocation) throws Exception {
         return new TransformBuilder(xslLocation);
     }
@@ -44,8 +41,16 @@ public abstract class AbstractXSLTest {
         private final Transformer transformer;
 
         public TransformBuilder(String xslLocation) throws Exception {
+            File inputFile = new File("../dspace/config/crosswalks/oai/metadataFormats", xslLocation);
+            String inputFileDir = inputFile.toPath().normalize().getParent().toString();
+
+            // Requires usage of Saxon as OAI-PMH uses some XSLT 2 functions. Only trust stylesheets stored under
+            // the same directory as the given XSL.
+            TransformerFactory factory = XMLUtils.getTrustedTransformerFactory("net.sf.saxon.TransformerFactoryImpl",
+                                                                               new String[] {inputFileDir});
+
             this.transformer = factory.newTransformer(
-                new StreamSource(new File("../dspace/config/crosswalks/oai/metadataFormats", xslLocation)));
+                new StreamSource(inputFile));
         }
 
         public String to(InputStream input) throws Exception {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/OpenSearchController.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -28,6 +27,7 @@ import org.dspace.app.rest.parameter.SearchFilter;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.app.rest.utils.RestDiscoverQueryBuilder;
 import org.dspace.app.rest.utils.ScopeResolver;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.app.util.factory.UtilServiceFactory;
 import org.dspace.app.util.service.OpenSearchService;
 import org.dspace.core.Context;
@@ -232,7 +232,7 @@ public class OpenSearchController {
                     (int) qResults.getTotalSearchResults(), qResults.getStart(),
                     qResults.getMaxResults(), container, dsoResults);
             try {
-                Transformer xf = TransformerFactory.newInstance().newTransformer();
+                Transformer xf = XMLUtils.getTransformerFactory().newTransformer();
                 response.setContentType(openSearchService.getContentType(format));
                 response.addHeader(CONTENT_DISPOSITION, CONTENT_DISPOSITION_INLINE);
                 xf.transform(new DOMSource(resultsDoc),


### PR DESCRIPTION
## Description

This PR updates our existing `XMLUtils` class to add secure methods related to `TransformerFactory` initialization, to protect against XML-based attacks such as XXE.  In DSpace, `TransformerFactory` is only ever used for internal processing of XML content. But, securing the initialization helps to protect against potential future security issues.

Specifically, `TransformerFactory` is used in the following places:
* OAI-PMH metadata format transformations (from internal DIM to the format requested via OAI-PMH)
* Tools related to Creative Commons import of RDF (when RDF is fetched from the CC API)
* XSLT metadata crosswalks which are configured in `dspace.cfg` via `crosswalk.submission.*.stylesheet` or `crosswalks.dissemination.*.stylesheet` when importing/exporting AIPs or similar packages.
* In OpenSearch to format the results
* A few command-line tools, namely the `./dspace submission-forms-migrate` script used to transform pre-7.x `input-forms.xml` and `item-submission.xml` into the new `submission-forms.xml` and `item-submission.xml`

None of these are under direct control of users, but it's still best to protect all usage of TransformerFactory to avoid any future XXE-style attacks wherever it is used.

This PR also includes a few minor code cleanup fixes to `XMLUtils`:
* ~~Fixes a small bug in `XMLUtils` where a path-restricted builder was created but not used. See 49fb3cf93e476e2d6180944f30695aa62458a05a~~ -> This was moved to a separate PR as it requires additional fixes. See #12709
* Removes an unused `XMLUtils.convertStreamtoXML()` method as it was not well secured and no longer used. See 1fb061a8029f0ca86f6e52ed30668b0d252aa2f9

**NOTE:** This PR depends on upgrading to XOAI version 3.4.2, which includes an update to Saxon 12. See https://github.com/DSpace/xoai/pull/132

## Instructions for Reviewers
* Review Code
* Test that OAI-PMH still works properly, especially the HTML-based interface (which uses XSLT)
* Test CC License RDF import (optional, as support for RDF storage of CC licenses is being removed in #12424)
* Test export of AIPs or export of data to DataCite / Crossref (as these all use XSLT crosswalks)
* Test OpenSearch is still responding properly
* Test usage of `./dspace submission-forms-migrate` script

## Credit
This flaw in our `TransformerFactory` code was pointed out by @ik0z.