### PR TITLE
Exclude apache5-client from AWS SDK s3 to fix dependency convergence (#12690)

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -730,6 +730,14 @@
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>apache-client</artifactId>
               </exclusion>
+              <!-- Exclude apache5-client (Apache HttpClient 5): added transitively by the AWS SDK
+                   from v2.46.x onward. DSpace uses the CRT based client (S3AsyncClient.crtBuilder()),
+                   so this client is unused, and it drags in conflicting httpcore5 versions that break
+                   dependency convergence. See https://github.com/DSpace/DSpace/issues/12690 -->
+              <exclusion>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>apache5-client</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
## References

Fixes #12690

Unblocks the Dependabot `amazon-s3` group bump on this branch (#12576).

## Description

The grouped Dependabot `amazon-s3` bumps that raise the AWS SDK from `2.43.2` to `2.46.3` fail CI on every maintained branch. The `Run Unit Tests` job aborts during the build at the `maven-enforcer-plugin` `DependencyConvergence` rule, before any test runs:

```
[ERROR] Dependency convergence error for org.apache.httpcomponents.core5:httpcore5:jar:5.4
```

From AWS SDK v2.46.x onward, `software.amazon.awssdk:s3` pulls in a new transitive artifact, `software.amazon.awssdk:apache5-client` (the Apache HttpClient 5 based sync client), which brings in conflicting `httpcore5` versions (`5.4` and `5.4.2`).

DSpace does not use that client. `S3BitStoreService` builds its client with `S3AsyncClient.crtBuilder()` (the AWS CRT based client, backed by the explicit `aws-crt` dependency), and the pom already excludes the other AWS HTTP clients (`apache-client`, `netty-nio-client`) for the same reason. This PR simply extends that exclusion list to `apache5-client`.

The exclusion is a no-op at the current `2.43.2` (which does not depend on `apache5-client`), so it lands ahead of the version bump. Once merged, the Dependabot bump rebases cleanly and passes CI.

## Instructions for Reviewers

Verified locally that with `s3` temporarily set to `2.46.3`:

- `mvn -pl dspace-api dependency:tree` no longer contains any `httpcore5` or `apache5-client` artifact.
- `mvn -pl dspace-api validate` (which runs the `enforce-versions` rule) reports `BUILD SUCCESS`.

The committed change keeps `s3` at the current `2.43.2`; only the exclusion is added.

## Checklist

- [x] My PR is small in size (e.g. less than 100 lines of code, not including tests), or I have provided reasons as to why that's not possible.
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. (n/a, build configuration change)
- [x] My PR passes all tests and includes new/updated tests if applicable.
- [x] My PR does not introduce new dependencies (it removes an unused transitive one).
