### PR TITLE
Fix OpenSearch base URL and remove unused configs

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1725,14 +1725,10 @@ webui.feed.item.author = dc.contributor.author
 # so even if Syndication Feeds are not enabled, they must be configured
 # enable open search
 websvc.opensearch.enable = true
-# context for html request URLs - change only for non-standard servlet mapping
-websvc.opensearch.uicontext = search
-# context for xml request URLs - change only for non-standard servlet mapping
-websvc.opensearch.svccontext = opensearch/search
+# base context for request URLs - change only for non-standard servlet mapping
+websvc.opensearch.svccontext = opensearch
 # present autodiscovery link in every page head
 websvc.opensearch.autolink = true
-# number of hours to retain results before recalculating
-websvc.opensearch.validity = 48
 # short name used in browsers for search service
 # should be 16 or fewer characters
 websvc.opensearch.shortname = DSpace


### PR DESCRIPTION
## References
* Requires Angular PR https://github.com/DSpace/dspace-angular/pull/5862

## Description
OpenSearch service URLs in DSpace 7.0 - 10.0 are broken, because they are prefixed with the full `opensearch/search` path instead of just `opensearch/`. This PR along with the related PR ensure that correct service and search URLs are constructed.

## Instructions for Reviewers

**Note to reviewers re: failing integration tests** - these failures are due to the fact that the main branch of angular does not append `/search` to the base URL when constructing the search links. Once https://github.com/DSpace/dspace-angular/pull/5862 is merged, these tests should pass.

**Changes**:
* Update default cnfiguration so that `websvc.opensearch.svccontent` is "opensearch" (to match the base OpenSearch Controller mapping rather than the search method specifically).
    * The frontend is expected to append "search" or "service" when constructing routes in `rss.component.ts` (see related PR linked at the top of the description).
* Removed several unused configuration properties that date back to pre-7.0 usage:  `websvc.opensearch.uicontext`,  `websvc.opensearch.validity`

**To Test**:
1. With default `websvc.opensearch.*` configuration values, note the broken link generated in existing code by inspecting the homepage (or search / collection pages) and looking for the OpenSearch service link, e.g:
```
<link href="http://localhost:8080/server/opensearch/search/service" type="application/atom+xml" rel="search" title="Dspace">
```

You can also see that in existing code, the syndication feed links do work as expected. e.g:
```
<link href="http://localhost:8080/server/opensearch/search?format=atom&amp;sort=dc.date.accessioned&amp;sort_direction=DESC&amp;query=*&amp;rpp=10" type="application/atom+xml" rel="alternate" title="Sitewide Atom feed">
````

2. Apply this and the related Angular PR https://github.com/DSpace/dspace-angular/pull/5862
3. Perform the same test as in step 1: you should now see a working service link, and the search/syndication links should continue to work correctly.

## Checklist
- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.