### PR TITLE
Fix bug in `XMLUtils.getTrustedDocumentBuilder()` where path-restricted builder was not returned.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/RegistryImporter.java
+++ b/dspace-api/src/main/java/org/dspace/administer/RegistryImporter.java
@@ -49,11 +49,17 @@ public class RegistryImporter {
      */
     public static Document loadXML(String filename)
         throws IOException, ParserConfigurationException, SAXException {
-        // This XML builder will *not* disable external entities as XML
-        // registries are considered trusted content
-        DocumentBuilder builder = XMLUtils.getTrustedDocumentBuilder();
 
-        Document document = builder.parse(new File(filename));
+        File inputFile = new File(filename);
+        String inputFileDir = inputFile.toPath().normalize().getParent().toString();
+
+        // This XML builder will *not* disable external entities as XML
+        // registries are considered trusted content. However, it will
+        // restrict them to be within the directory that the
+        // current input form XML file exists (or a sub-directory)
+        DocumentBuilder builder = XMLUtils.getTrustedDocumentBuilder(inputFileDir);
+
+        Document document = builder.parse(inputFile);
 
         return document;
     }

--- a/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
+++ b/dspace-api/src/main/java/org/dspace/administer/RegistryLoader.java
@@ -266,11 +266,17 @@ public class RegistryLoader {
      */
     private static Document loadXML(String filename) throws IOException,
         ParserConfigurationException, SAXException {
-        // This XML builder will *not* disable external entities as XML
-        // registries are considered trusted content
-        DocumentBuilder builder = XMLUtils.getTrustedDocumentBuilder();
 
-        return builder.parse(new File(filename));
+        File inputFile = new File(filename);
+        String inputFileDir = inputFile.toPath().normalize().getParent().toString();
+
+        // This XML builder will *not* disable external entities as XML
+        // registries are considered trusted content. However, it will
+        // restrict them to be within the directory that the
+        // current input form XML file exists (or a sub-directory)
+        DocumentBuilder builder = XMLUtils.getTrustedDocumentBuilder(inputFileDir);
+
+        return builder.parse(inputFile);
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/util/InitializeEntities.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/InitializeEntities.java
@@ -160,9 +160,13 @@ public class InitializeEntities {
     private void parseXMLToRelations(Context context, String fileLocation) throws AuthorizeException {
         try {
             File fXmlFile = new File(fileLocation);
+            String inputFileDir = fXmlFile.toPath().normalize().getParent().toString();
+
             // This XML builder will allow external entities, so the relationship types XML should
-            // be considered trusted by administrators
-            DocumentBuilder dBuilder = XMLUtils.getTrustedDocumentBuilder();
+            // be considered trusted by administrators. However, it will
+            // restrict them to be within the directory that the
+            // current input form XML file exists (or a sub-directory)
+            DocumentBuilder dBuilder = XMLUtils.getTrustedDocumentBuilder(inputFileDir);
             Document doc = dBuilder.parse(fXmlFile);
 
             doc.getDocumentElement().normalize();

--- a/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
@@ -242,7 +242,7 @@ public class XMLUtils {
         factory.setIgnoringElementContentWhitespace(true);
         DocumentBuilder builder = factory.newDocumentBuilder();
         builder.setEntityResolver(new PathRestrictedEntityResolver(allowedPaths));
-        return factory.newDocumentBuilder();
+        return builder;
     }
 
     /**


### PR DESCRIPTION
## References
* Related to #11030

## Description
Fixes a small bug in `XMLUtils.getTrustedDocumentBuilder()`, where a path-restricted builder was initialized but was not returned.  This patches a small bug in #11030.  

The patch will ensure that all code using this method is now fully protected against XXE style attacks.  That said, this is not a security issue because this method is only used to parse internal DSpace XML configurations (namely related to initializing entities, registry and metadata, as well as submission forms).  It is never used for user-based data.

## Instructions for Reviewers
* Review Code
* Test areas where `XMLUtils.getTrustedDocumentBuilder()` is used.  This includes:
   * Initialization of empty database via both the `RegistryImporter` and `MetadataImporter`. (NOTE: These are also tested via our automated tests, as both of these importers run during initial tests to prepopulate the database)
   * `DCInputsReader` and `SubmissionConfigReader` - most easily tested via the submission process, as this loads the submission forms.
   * `InitializeEntities` - most easily tested by running the `[dspace]/bin/dspace initialize-entities -f [dspace]/config/entities/relationship-types.xml` script on an empty database.
   * `StructBuilder` - most easily tested by running `[dspace]/bin/dspace structure-builder` to import or export a community/collection hierarchy

## Credit
This flaw in `XMLUtils.getTrustedDocumentBuilder()` code was pointed out by @ik0z.