### PR TITLE
Fixes audit logs when modifying or moving existing values

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -1027,7 +1027,17 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
      */
     protected void moveSingleMetadataValue(Context context, T dso, int place, MetadataValue rr) {
         //just move the metadata
+        boolean placeChanged = rr.getPlace() != place;
+        if (placeChanged) {
+            dso.addMetadataEventDetails(new MetadataEvent(rr, MetadataEvent.REMOVE));
+        }
+
         rr.setPlace(place);
+
+        if (placeChanged) {
+            dso.addMetadataEventDetails(new MetadataEvent(rr, MetadataEvent.ADD));
+            dso.setMetadataModified();
+        }
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/ItemServiceImpl.java
@@ -1965,7 +1965,7 @@ public class ItemServiceImpl extends DSpaceObjectServiceImpl<Item> implements It
         }
 
         // Update the MetadataValue object with the new place setting
-        rr.setPlace(place);
+        super.moveSingleMetadataValue(context, dso, place, rr);
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -54,7 +54,11 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
         MetadataValueRest metadataValueToReplace = metadataPatchUtils.extractMetadataValueFromOperation(operation);
         // Property of md being altered
         String propertyOfMd = metadataPatchUtils.extractPropertyOfMdFromPath(partsOfPath);
-        replace(context, resource, dsoService, metadataField, metadataValueToReplace, indexInPath, propertyOfMd);
+        String newValueMdAttribute = metadataPatchUtils.extractNewValueOfMd(operation);
+        replace(
+            context, resource, dsoService, metadataField, metadataValueToReplace, indexInPath,
+            propertyOfMd, newValueMdAttribute
+        );
         return resource;
     }
 
@@ -77,13 +81,15 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
      * @param metadataValue     value of md element
      * @param index             possible index of md being replaced
      * @param propertyOfMd      possible property of md being replaced
+     * @param newPropertyValue  value for the possible property of md being replaced (when propertyOfMd != null)
      */
     private void replace(Context context,
                          R dso, DSpaceObjectService<R> dsoService,
                          MetadataField metadataField,
                          MetadataValueRest metadataValue,
                          String index,
-                         String propertyOfMd
+                         String propertyOfMd,
+                         String newPropertyValue
     ) {
         if (metadataField == null) {
             // Case 1 - replace entire set of metadata
@@ -92,8 +98,10 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
             // Case 2 - replace all metadata for existing key
             this.replaceMetadataFieldMetadata(context, dso, dsoService, metadataField, metadataValue);
         } else {
-            // Case 3 and 4 - replace single existing metadata value or single property
-            this.replaceMetadataValue(context, dso, dsoService, metadataField, metadataValue, index, propertyOfMd);
+            // Case 3 and 4 - replace single existing metadata
+            this.replaceMetadataValue(
+                context, dso, dsoService, metadataField, metadataValue, index, propertyOfMd, newPropertyValue
+            );
         }
     }
 
@@ -147,6 +155,7 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
      * @param metadataValue     new value of md element
      * @param index             index of md being replaced
      * @param propertyOfMd      property of md being replaced
+     * @param newPropertyValue  new value for the property being replaced
      */
     private void replaceMetadataValue(Context context,
                                       R dso,
@@ -154,7 +163,8 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                                       MetadataField metadataField,
                                       MetadataValueRest metadataValue,
                                       String index,
-                                      @Nullable String propertyOfMd
+                                      @Nullable String propertyOfMd,
+                                      @Nullable String newPropertyValue
     ) {
         try {
             List<MetadataValue> metadataValues = dsoService.getMetadata(
@@ -175,7 +185,8 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
                     existingMdv,
                     metadataValue,
                     indexInt,
-                    propertyOfMd
+                    propertyOfMd,
+                    newPropertyValue
                 );
             } else {
                 throw new UnprocessableEntityException("There is no metadata of this type at that index");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/patch/operation/DSpaceObjectMetadataReplaceOperation.java
@@ -10,11 +10,12 @@ package org.dspace.app.rest.repository.patch.operation;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.dspace.app.audit.MetadataEvent;
+import jakarta.annotation.Nullable;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.MetadataValueRest;
 import org.dspace.app.rest.model.patch.Operation;
+import org.dspace.app.rest.utils.MetadataReplaceUtils;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
@@ -45,7 +46,7 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
 
     @Override
     public R perform(Context context, R resource, Operation operation) throws SQLException {
-        DSpaceObjectService dsoService = ContentServiceFactory.getInstance().getDSpaceObjectService(resource);
+        DSpaceObjectService<R> dsoService = ContentServiceFactory.getInstance().getDSpaceObjectService(resource);
         MetadataField metadataField = metadataPatchUtils.getMetadataField(context, operation);
         String[] partsOfPath = operation.getPath().split("/");
         // Index of md being patched
@@ -53,21 +54,22 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
         MetadataValueRest metadataValueToReplace = metadataPatchUtils.extractMetadataValueFromOperation(operation);
         // Property of md being altered
         String propertyOfMd = metadataPatchUtils.extractPropertyOfMdFromPath(partsOfPath);
-        String newValueMdAttribute = metadataPatchUtils.extractNewValueOfMd(operation);
-
-        replace(context, resource, dsoService, metadataField, metadataValueToReplace, indexInPath, propertyOfMd,
-                newValueMdAttribute);
+        replace(context, resource, dsoService, metadataField, metadataValueToReplace, indexInPath, propertyOfMd);
         return resource;
     }
 
     /**
      * Replaces metadata in the dso; 4 cases:
-     *      * - If we replace everything: clears all metadata
-     *      * - If we replace for a single field: clearMetadata on the field & add the new ones
-     *      * - A single existing metadata value:
-     *      * Retrieve the metadatavalue object & make alterations directly on this object
-     *      * - A single existing metadata property:
-     *      * Retrieve the metadatavalue object & make alterations directly on this object
+     * <ol>
+     *     <li> - If we replace everything: clears all metadata </li>
+     *     <li> - If we replace for a single field: clearMetadata on the field & add the new ones </li>
+     *     <li> - A single existing metadata value:
+     *     Retrieve the metadatavalue object & make alterations directly on this object
+     *     </li>
+     *     <li> - A single existing metadata property:
+     *     Retrieve the metadatavalue object & make alterations directly on this object
+     *     </li>
+     * </ol>
      * @param context           context patch is being performed in
      * @param dso               dso being patched
      * @param dsoService        service doing the patch in db
@@ -75,28 +77,24 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
      * @param metadataValue     value of md element
      * @param index             possible index of md being replaced
      * @param propertyOfMd      possible property of md being replaced
-     * @param valueMdProperty   possible new value of property of md being replaced
      */
-    private void replace(Context context, DSpaceObject dso, DSpaceObjectService dsoService, MetadataField metadataField,
-                         MetadataValueRest metadataValue, String index, String propertyOfMd, String valueMdProperty) {
-        // replace entire set of metadata
+    private void replace(Context context,
+                         R dso, DSpaceObjectService<R> dsoService,
+                         MetadataField metadataField,
+                         MetadataValueRest metadataValue,
+                         String index,
+                         String propertyOfMd
+    ) {
         if (metadataField == null) {
+            // Case 1 - replace entire set of metadata
             this.replaceAllMetadata(context, dso, dsoService);
-            return;
-        }
-
-        // replace all metadata for existing key
-        if (index == null) {
+        } else if (index == null) {
+            // Case 2 - replace all metadata for existing key
             this.replaceMetadataFieldMetadata(context, dso, dsoService, metadataField, metadataValue);
-            return;
+        } else {
+            // Case 3 and 4 - replace single existing metadata value or single property
+            this.replaceMetadataValue(context, dso, dsoService, metadataField, metadataValue, index, propertyOfMd);
         }
-        // replace single existing metadata value
-        if (propertyOfMd == null) {
-            this.replaceSingleMetadataValue(dso, dsoService, metadataField, metadataValue, index);
-            return;
-        }
-        // replace single property of exiting metadata value
-        this.replaceSinglePropertyOfMdValue(dso, dsoService, metadataField, index, propertyOfMd, valueMdProperty);
     }
 
     /**
@@ -105,7 +103,7 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
      * @param dso               dso being patched
      * @param dsoService        service doing the patch in db
      */
-    private void replaceAllMetadata(Context context, DSpaceObject dso, DSpaceObjectService dsoService) {
+    private void replaceAllMetadata(Context context, R dso, DSpaceObjectService<R> dsoService) {
         try {
             dsoService.clearMetadata(context, dso, Item.ANY, Item.ANY, Item.ANY, Item.ANY);
         } catch (SQLException e) {
@@ -122,8 +120,12 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
      * @param metadataField     md field being patched
      * @param metadataValue     value of md element
      */
-    private void replaceMetadataFieldMetadata(Context context, DSpaceObject dso, DSpaceObjectService dsoService,
-                                              MetadataField metadataField, MetadataValueRest metadataValue) {
+    private void replaceMetadataFieldMetadata(Context context,
+                                              R dso,
+                                              DSpaceObjectService<R> dsoService,
+                                              MetadataField metadataField,
+                                              MetadataValueRest metadataValue
+    ) {
         try {
             dsoService.clearMetadata(context, dso, metadataField.getMetadataSchema().getName(),
                     metadataField.getElement(), metadataField.getQualifier(), Item.ANY);
@@ -137,88 +139,57 @@ public class DSpaceObjectMetadataReplaceOperation<R extends DSpaceObject> extend
     }
 
     /**
-     * Replaces metadata value of a single metadataValue object
-     *      Retrieve the metadatavalue object & make alerations directly on this object
+     * Replaces metadata value of a single metadataValue object or a single property of the object.
+     * Retrieve the metadatavalue object & make alerations directly on this object
      * @param dso               dso being patched
      * @param dsoService        service doing the patch in db
      * @param metadataField     md field being patched
      * @param metadataValue     new value of md element
      * @param index             index of md being replaced
+     * @param propertyOfMd      property of md being replaced
      */
-    // replace single existing metadata value
-    private void replaceSingleMetadataValue(DSpaceObject dso, DSpaceObjectService dsoService,
-                                            MetadataField metadataField, MetadataValueRest metadataValue,
-                                            String index) {
+    private void replaceMetadataValue(Context context,
+                                      R dso,
+                                      DSpaceObjectService<R> dsoService,
+                                      MetadataField metadataField,
+                                      MetadataValueRest metadataValue,
+                                      String index,
+                                      @Nullable String propertyOfMd
+    ) {
         try {
-            List<MetadataValue> metadataValues = dsoService.getMetadata(dso,
-                    metadataField.getMetadataSchema().getName(), metadataField.getElement(),
-                    metadataField.getQualifier(), Item.ANY);
+            List<MetadataValue> metadataValues = dsoService.getMetadata(
+                dso,
+                metadataField.getMetadataSchema().getName(),
+                metadataField.getElement(),
+                metadataField.getQualifier(),
+                Item.ANY
+            );
             int indexInt = Integer.parseInt(index);
-            if (indexInt >= 0 && metadataValues.size() > indexInt
-                    && metadataValues.get(indexInt) != null) {
-                // Alter this existing md
+            if (indexInt >= 0 && metadataValues.size() > indexInt && metadataValues.get(indexInt) != null) {
                 MetadataValue existingMdv = metadataValues.get(indexInt);
-                existingMdv.setAuthority(metadataValue.getAuthority());
-                existingMdv.setConfidence(metadataValue.getConfidence());
-                existingMdv.setLanguage(metadataValue.getLanguage());
-                existingMdv.setValue(metadataValue.getValue());
-                dso.addMetadataEventDetails(new MetadataEvent(existingMdv, MetadataEvent.MODIFY));
-                dsoService.setMetadataModified(dso);
-                existingMdv.setSecurityLevel(metadataValue.getSecurityLevel());
+                MetadataReplaceUtils.replaceValue(
+                    context,
+                    dsoService,
+                    dso,
+                    metadataField.toString(),
+                    existingMdv,
+                    metadataValue,
+                    indexInt,
+                    propertyOfMd
+                );
             } else {
                 throw new UnprocessableEntityException("There is no metadata of this type at that index");
             }
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("This index (" + index + ") is not valid number.", e);
-        }
-    }
-
-    /**
-     * Replaces single property of a specific mdValue object
-     * @param dso               dso being patched
-     * @param dsoService        service doing the patch in db
-     * @param metadataField     md field being patched
-     * @param index             index of md being replaced
-     * @param propertyOfMd      property of md being replaced
-     * @param valueMdProperty   new value of property of md being replaced
-     */
-    private void replaceSinglePropertyOfMdValue(DSpaceObject dso, DSpaceObjectService dsoService,
-                                                MetadataField metadataField,
-                                                String index, String propertyOfMd, String valueMdProperty) {
-        try {
-            List<MetadataValue> metadataValues = dsoService.getMetadata(dso,
-                    metadataField.getMetadataSchema().getName(), metadataField.getElement(),
-                    metadataField.getQualifier(), Item.ANY);
-            int indexInt = Integer.parseInt(index);
-            if (indexInt >= 0 && metadataValues.size() > indexInt && metadataValues.get(indexInt) != null) {
-                // Alter only asked propertyOfMd
-                MetadataValue existingMdv = metadataValues.get(indexInt);
-                if (propertyOfMd.equals("authority")) {
-                    existingMdv.setAuthority(valueMdProperty);
-                }
-                if (propertyOfMd.equals("confidence")) {
-                    existingMdv.setConfidence(Integer.valueOf(valueMdProperty));
-                }
-                if (propertyOfMd.equals("language")) {
-                    existingMdv.setLanguage(valueMdProperty);
-                }
-                if (propertyOfMd.equals("value")) {
-                    existingMdv.setValue(valueMdProperty);
-                }
-                dso.addMetadataEventDetails(new MetadataEvent(existingMdv, MetadataEvent.MODIFY));
-                dsoService.setMetadataModified(dso);
-            } else {
-                throw new UnprocessableEntityException("There is no metadata of this type at that index");
-            }
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Not all numbers are valid numbers. " +
-                    "(Index and confidence should be nr)", e);
+        } catch (SQLException e) {
+            throw new RuntimeException("SQL error trying to replace metadata", e);
         }
     }
 
     @Override
     public boolean supports(Object objectToMatch, Operation operation) {
-        return (operation.getPath().startsWith(metadataPatchUtils.OPERATION_METADATA_PATH)
+        return (operation.getPath().startsWith(DSpaceObjectMetadataPatchUtils.OPERATION_METADATA_PATH)
                 && operation.getOp().trim().equalsIgnoreCase(OPERATION_REPLACE)
                 && objectToMatch instanceof DSpaceObject);
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/MetadataValueReplacePatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/MetadataValueReplacePatchOperation.java
@@ -14,11 +14,11 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import org.dspace.app.rest.model.MetadataValueRest;
+import org.dspace.app.rest.utils.MetadataReplaceUtils;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.MetadataValue;
 import org.dspace.content.service.DSpaceObjectService;
 import org.dspace.core.Context;
-import org.dspace.core.Utils;
 
 /**
  * Submission "replace" common PATCH operation.
@@ -38,25 +38,36 @@ public abstract class MetadataValueReplacePatchOperation<DSO extends DSpaceObjec
         return MetadataValueRest.class;
     }
 
-    protected void replaceValue(Context context, DSO source, String target, List<MetadataValue> list,
-                                MetadataValueRest object, int index)
-        throws SQLException {
-        String[] metadata = Utils.tokenize(target);
-        if (object.getSecurityLevel() != null) {
-            getDSpaceObjectService().replaceSecuredMetadata(context, source, metadata[0], metadata[1], metadata[2],
-                    object.getLanguage(), object.getValue(), object.getAuthority(),
-                    object.getConfidence(), index, object.getSecurityLevel());
-        } else {
-            getDSpaceObjectService().replaceMetadata(context, source, metadata[0], metadata[1], metadata[2],
-                    object.getLanguage(), object.getValue(), object.getAuthority(),
-                    object.getConfidence(), index);
-        }
-
+    /**
+     * Replaces values of an existing metadata value.
+     * @param context DSpace context.
+     * @param dso DSO that will have metadata modified.
+     * @param mdField Qualified name of the metadata field to modify.
+     * @param existingMdvs Current metadata values of {@code dso} for the field {@code mdField}.
+     * @param newMdv New values for the metadata value being modified.
+     * @param mdvIndex Index of the metadata value in {@code existingMdvs} to modify.
+     * @throws SQLException
+     */
+    protected void replaceValue(Context context,
+                                DSO dso,
+                                String mdField,
+                                List<MetadataValue> existingMdvs,
+                                MetadataValueRest newMdv,
+                                int mdvIndex
+    ) throws SQLException {
+        MetadataValue existingMdv = existingMdvs.get(mdvIndex);
+        DSpaceObjectService<DSO> dsoService = getDSpaceObjectService();
+        MetadataReplaceUtils.replaceValue(context, dsoService, dso, mdField, existingMdv, newMdv, mdvIndex);
     }
 
-    protected void setDeclaredField(Context context, DSO source, Object value, String metadata, String namedField,
-                                    List<MetadataValue> metadataByMetadataString, int index)
-        throws IllegalAccessException, SQLException {
+    protected void setDeclaredField(Context context,
+                                    DSO source,
+                                    Object value,
+                                    String metadata,
+                                    String namedField,
+                                    List<MetadataValue> metadataByMetadataString,
+                                    int index
+    ) throws IllegalAccessException, SQLException {
         // check field
         String raw = (String) value;
         for (Field field : MetadataValueRest.class.getDeclaredFields()) {
@@ -92,7 +103,6 @@ public abstract class MetadataValueReplacePatchOperation<DSO extends DSpaceObjec
             }
         }
     }
-
 
     protected abstract DSpaceObjectService<DSO> getDSpaceObjectService();
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
@@ -1,3 +1,10 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
 package org.dspace.app.rest.utils;
 
 import java.sql.SQLException;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
@@ -55,7 +55,7 @@ public class MetadataReplaceUtils {
         String language = propertyOfMd == null || "language".equals(propertyOfMd)
             ? newMdv.getLanguage()
             : existingMdv.getLanguage();
-        final var value = propertyOfMd == null || "value".equals(propertyOfMd)
+        String value = propertyOfMd == null || "value".equals(propertyOfMd)
             ? newMdv.getValue()
             : existingMdv.getValue();
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
@@ -1,0 +1,90 @@
+package org.dspace.app.rest.utils;
+
+import java.sql.SQLException;
+
+import jakarta.annotation.Nullable;
+import org.dspace.app.rest.model.MetadataValueRest;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.MetadataValue;
+import org.dspace.content.service.DSpaceObjectService;
+import org.dspace.core.Context;
+import org.dspace.core.Utils;
+
+/**
+ * Utility class for replace operations performed on metadata.
+ * <br><br>
+ * Will use DSpaceObjectService#replaceMetadata in order to always register 2 audit logs of type MODIFY_METADATA, one
+ * of type ADD and other of type REMOVE.
+ */
+public class MetadataReplaceUtils {
+    /**
+     * Replaces information in a metadata value.
+     * @param context DSpace context.
+     * @param dsoService Service of the DSO type having the metadata modified.
+     * @param dso DSO of the metadata being modifid.
+     * @param mdField Qualified name of the metadata field being modified.
+     * @param existingMdv Current metadata value that will be modified.
+     * @param newMdv REST object representing the modified version of the metadata.
+     * @param index Place of the metadata value being modified.
+     * @param propertyOfMd Name of the metadata value property to modify. All properties if null.
+     * @param <DSO> Type of the DSO having the metadata modified.
+     * @throws SQLException
+     */
+    public static <DSO extends DSpaceObject> void replaceValue(
+        Context context,
+        DSpaceObjectService<DSO> dsoService,
+        DSO dso,
+        String mdField,
+        MetadataValue existingMdv,
+        MetadataValueRest newMdv,
+        int index,
+        @Nullable String propertyOfMd
+    ) throws SQLException {
+        String[] metadata = Utils.tokenize(mdField);
+
+        // Gets the value of each property.
+        // Keeps the old one when just a single property is being modified (when 'propertyOfMd' is not null).
+        String authority = propertyOfMd == null || "authority".equals(propertyOfMd)
+            ? newMdv.getAuthority()
+            : existingMdv.getAuthority();
+        int confidence = propertyOfMd == null || "confidence".equals(propertyOfMd)
+            ? newMdv.getConfidence()
+            : existingMdv.getConfidence();
+        String language = propertyOfMd == null || "language".equals(propertyOfMd)
+            ? newMdv.getLanguage()
+            : existingMdv.getLanguage();
+        final var value = propertyOfMd == null || "value".equals(propertyOfMd)
+            ? newMdv.getValue()
+            : existingMdv.getValue();
+
+        if (newMdv.getSecurityLevel() == null) {
+            dsoService.replaceMetadata(
+                context, dso,
+                metadata[0], metadata[1], metadata[2],
+                language, value, authority, confidence, index
+            );
+        } else {
+            dsoService.replaceSecuredMetadata(
+                context, dso,
+                metadata[0], metadata[1], metadata[2],
+                language, value, authority, confidence, index, newMdv.getSecurityLevel()
+            );
+        }
+    }
+
+    /**
+     * Replaces information in a metadata value.
+     * @see MetadataReplaceUtils#replaceValue(Context, DSpaceObjectService, DSpaceObject, String, MetadataValue, MetadataValueRest, int, String) Same as this method, with propertyOfMd null.
+     */
+    public static <DSO extends DSpaceObject> void replaceValue(
+        Context context,
+        DSpaceObjectService<DSO> dsoService,
+        DSO dso,
+        String mdField,
+        MetadataValue existingMdv,
+        MetadataValueRest newMdv,
+        int index
+    ) throws SQLException {
+        replaceValue(context, dsoService, dso, mdField, existingMdv, newMdv, index, null);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
@@ -17,18 +17,20 @@ import org.dspace.core.Utils;
  * of type ADD and other of type REMOVE.
  */
 public class MetadataReplaceUtils {
+    private MetadataReplaceUtils() {}
+
     /**
-     * Replaces information in a metadata value.
+     * Replaces a(all) property(ies) in a metadata value.
      * @param context DSpace context.
      * @param dsoService Service of the DSO type having the metadata modified.
-     * @param dso DSO of the metadata being modifid.
+     * @param dso DSO of the metadata being modified.
      * @param mdField Qualified name of the metadata field being modified.
      * @param existingMdv Current metadata value that will be modified.
      * @param newMdv REST object representing the modified version of the metadata.
-     * @param index Place of the metadata value being modified.
+     * @param index Place of the metadata value being modified in {@code existingMdv}.
      * @param propertyOfMd Name of the metadata value property to modify. All properties if null.
      * @param <DSO> Type of the DSO having the metadata modified.
-     * @throws SQLException
+     * @throws SQLException If replacement fails.
      */
     public static <DSO extends DSpaceObject> void replaceValue(
         Context context,
@@ -73,8 +75,16 @@ public class MetadataReplaceUtils {
     }
 
     /**
-     * Replaces information in a metadata value.
-     * @see MetadataReplaceUtils#replaceValue(Context, DSpaceObjectService, DSpaceObject, String, MetadataValue, MetadataValueRest, int, String) Same as this method, with propertyOfMd null.
+     * Replaces all properties in a metadata value.
+     * @param context DSpace context.
+     * @param dsoService Service of the DSO type having the metadata modified.
+     * @param dso DSO of the metadata being modified.
+     * @param mdField Qualified name of the metadata field being modified.
+     * @param existingMdv Current metadata value that will be modified.
+     * @param newMdv REST object representing the modified version of the metadata.
+     * @param index Place of the metadata value being modified in {@code existingMdv}.
+     * @param <DSO> Type of the DSO having the metadata modified.
+     * @throws SQLException If replacement fails.
      */
     public static <DSO extends DSpaceObject> void replaceValue(
         Context context,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/MetadataReplaceUtils.java
@@ -36,6 +36,7 @@ public class MetadataReplaceUtils {
      * @param newMdv REST object representing the modified version of the metadata.
      * @param index Place of the metadata value being modified in {@code existingMdv}.
      * @param propertyOfMd Name of the metadata value property to modify. All properties if null.
+     * @param newPropertyValue Value of the specific property to modify. Only meaningful if propertyOfMd != null.
      * @param <DSO> Type of the DSO having the metadata modified.
      * @throws SQLException If replacement fails.
      */
@@ -47,24 +48,29 @@ public class MetadataReplaceUtils {
         MetadataValue existingMdv,
         MetadataValueRest newMdv,
         int index,
-        @Nullable String propertyOfMd
+        @Nullable String propertyOfMd,
+        @Nullable String newPropertyValue
     ) throws SQLException {
         String[] metadata = Utils.tokenize(mdField);
 
         // Gets the value of each property.
         // Keeps the old one when just a single property is being modified (when 'propertyOfMd' is not null).
-        String authority = propertyOfMd == null || "authority".equals(propertyOfMd)
+        String authority = propertyOfMd == null
             ? newMdv.getAuthority()
-            : existingMdv.getAuthority();
-        int confidence = propertyOfMd == null || "confidence".equals(propertyOfMd)
+            : ("authority".equals(propertyOfMd) ? newPropertyValue : existingMdv.getAuthority());
+        int confidence = propertyOfMd == null
             ? newMdv.getConfidence()
-            : existingMdv.getConfidence();
-        String language = propertyOfMd == null || "language".equals(propertyOfMd)
+            : (
+            "confidence".equals(propertyOfMd) && newPropertyValue != null
+            ? Integer.parseInt(newPropertyValue)
+            : existingMdv.getConfidence()
+        );
+        String language = propertyOfMd == null
             ? newMdv.getLanguage()
-            : existingMdv.getLanguage();
-        String value = propertyOfMd == null || "value".equals(propertyOfMd)
+            : ("language".equals(propertyOfMd) ? newPropertyValue : existingMdv.getLanguage());
+        String value = propertyOfMd == null
             ? newMdv.getValue()
-            : existingMdv.getValue();
+            : ("value".equals(propertyOfMd) ? newPropertyValue : existingMdv.getValue());
 
         if (newMdv.getSecurityLevel() == null) {
             dsoService.replaceMetadata(
@@ -102,6 +108,6 @@ public class MetadataReplaceUtils {
         MetadataValueRest newMdv,
         int index
     ) throws SQLException {
-        replaceValue(context, dsoService, dso, mdField, existingMdv, newMdv, index, null);
+        replaceValue(context, dsoService, dso, mdField, existingMdv, newMdv, index, null, null);
     }
 }


### PR DESCRIPTION
## References
* Proposal to fix #12686

## Description
Changes the metadata patch operations to use a utility class that will ensure that appropriated audit logs are created for the operation.

## Instructions for Reviewers
This PR will change:
- Creates a new utility class `MetadataReplaceUtils`, that will be used to replace metadata properties and register the appropriated audit logs. I opted for this new class because I could not manage to inject the existing class `DSpaceObjectMetadataPatchUtils` in `MetadataValueReplacePatchOperation`.
- Changes the patch operations in `DSpaceObjectMetadataReplaceOperation` and `MetadataValueReplacePatchOperation` to use this new utility class
- Also made a small fix in in `DSpaceObjectServiceImpl#moveSingleMetadataValue` to register the audit logs when a metadata *place* changes

As stated in the issue #12686, with this PR when a metadata value of an archived item is changed either by the *Edit* or *Administer > Metadata* menus, the correct audit logs are created.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
