### PR TITLE
Guard DCInputAuthority.getMatches/getBestMatch against a locale with no value-pairs (fixes #12723)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/DCInputAuthority.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/DCInputAuthority.java
@@ -158,7 +158,7 @@ public class DCInputAuthority extends SelfNamedPlugin implements ChoiceAuthority
         int dflt = -1;
         int found = 0;
         List<Choice> v = new ArrayList<Choice>();
-        for (int i = 0; i < valuesLocale.length; ++i) {
+        for (int i = 0; valuesLocale != null && i < valuesLocale.length; ++i) {
             // In a DCInputAuthority context, a user will want to query the labels, not the values
             if (query == null || Strings.CI.contains(labelsLocale[i], query)) {
                 if (found >= start && v.size() < limit) {
@@ -180,7 +180,7 @@ public class DCInputAuthority extends SelfNamedPlugin implements ChoiceAuthority
         Locale currentLocale = I18nUtil.getSupportedLocale(locale);
         String[] valuesLocale = values.get(currentLocale.getLanguage());
         String[] labelsLocale = labels.get(currentLocale.getLanguage());
-        for (int i = 0; i < valuesLocale.length; ++i) {
+        for (int i = 0; valuesLocale != null && i < valuesLocale.length; ++i) {
             if (text.equalsIgnoreCase(valuesLocale[i])) {
                 Choice[] v = new Choice[1];
                 v[0] = new Choice(String.valueOf(i), valuesLocale[i], labelsLocale[i]);

--- a/dspace-api/src/test/java/org/dspace/content/authority/DCInputAuthorityTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/authority/DCInputAuthorityTest.java
@@ -1,0 +1,54 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.authority;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import org.dspace.AbstractUnitTest;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DCInputAuthority}.
+ */
+public class DCInputAuthorityTest extends AbstractUnitTest {
+
+    /**
+     * When the authority has no value-pairs configured for the requested locale's
+     * language, {@link DCInputAuthority#getBestMatch(String, String)} and
+     * {@link DCInputAuthority#getMatches(String, int, int, String)} must return an
+     * empty result instead of throwing a {@link NullPointerException}.
+     */
+    @Test
+    public void noValuePairsForLocaleReturnsEmptyResult() throws Exception {
+        DCInputAuthority authority = new DCInputAuthority();
+        // Pre-populate the (empty) value/label maps so the once-only init() is a
+        // no-op and lookups for any locale return null, reproducing a locale that
+        // has no configured value-pairs.
+        setField(authority, "values", new HashMap<String, String[]>());
+        setField(authority, "labels", new HashMap<String, String[]>());
+
+        Choices bestMatch = authority.getBestMatch("anything", "en");
+        assertNotNull(bestMatch);
+        assertEquals(Choices.CF_NOTFOUND, bestMatch.confidence);
+        assertEquals(0, bestMatch.values.length);
+
+        Choices matches = authority.getMatches("anything", 0, 10, "en");
+        assertNotNull(matches);
+        assertEquals(0, matches.values.length);
+    }
+
+    private void setField(Object target, String name, Object value) throws Exception {
+        Field field = DCInputAuthority.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## References
Fixes #12723

## Description
`DCInputAuthority.getMatches(...)` and `DCInputAuthority.getBestMatch(...)` look up the value array for the current locale's language and iterate it without a null check:

```java
String[] valuesLocale = values.get(currentLocale.getLanguage());
...
for (int i = 0; i < valuesLocale.length; ++i) {   // NPE when valuesLocale == null
```

When the authority has no value-pairs configured for that language, `values.get(...)` returns `null` and the loop throws a `NullPointerException`. The sibling `getLabel(...)` in the same class already guards against this (`for (int i = 0; valuesLocale != null && i < valuesLocale.length; i++)`), so the class was internally inconsistent.

These methods are reachable from the REST vocabulary endpoint (`VocabularyEntryLinkRepository.filter` calls `ChoiceAuthority.getBestMatch` / `getMatches`), so a client querying a `DCInputAuthority`-backed vocabulary under a locale whose language has no configured value-pairs hits the NPE.

This PR adds the same `valuesLocale != null` guard to both loops, so the methods return an empty result instead of throwing.

## Instructions for Reviewers
The fix mirrors the existing null-safe handling in `getLabel(...)` within the same class.

A unit test (`DCInputAuthorityTest`) reproduces the scenario: it puts the authority into a state where the value/label maps contain no entry for the requested locale, then asserts that `getBestMatch` and `getMatches` return an empty result rather than throwing. Without the fix, both calls throw a `NullPointerException`.

To run the test:

```
mvn install -DskipTests
mvn test -pl dspace-api -Dtest=DCInputAuthorityTest -DskipUnitTests=false
```

## Checklist
- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests).
- [x] My PR passes Checkstyle validation using `mvn checkstyle:check`.
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_.
- [x] My PR includes new or updated unit/integration tests for the bug fix.
- [x] If my PR includes new libraries/dependencies, I've made sure their licenses align with the DSpace BSD License.
- [x] If my PR modifies the REST API, I've linked to the REST Contract page (or open PR) related to this change.
