### PR TITLE
141984: Refactor discovery.xml with shared parent beans and reusable …

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -446,8 +446,14 @@
         </property>
     </bean>
 
-    <bean id="defaultRelationshipsConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
-        <!--Which sidebar facets are to be displayed-->
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this defaultRelationshipsConfiguration config.
+         Inherited unchanged: searchSortConfiguration, recentSubmissionConfiguration, moreLikeThisConfiguration,
+         tagCloudFacetConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration, which additionally highlights
+         organization.legalName / person.givenName / person.familyName (see PR notes). -->
+    <bean id="defaultRelationshipsConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="defaultConfiguration">
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration: no searchFilterAccessStatus) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterAuthor" />
@@ -457,9 +463,8 @@
                 <ref bean="searchFilterEntityType"/>
             </list>
         </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page
+            (overrides defaultConfiguration: no searchFilterHasGeospatialMetadata / searchFilterAccessStatus / searchFilterGeospatialPoint) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
@@ -477,116 +482,27 @@
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides defaultConfiguration: NOT filtered on latestVersion = true, for relationship-safe queries) -->
         <property name="defaultFilterQueries">
             <list>
-                <!--Only find items, communities and collections-->
-                <!-- NOTE: NOT filtered on latestVersion = true -->
                 <value>search.resourcetype:Item OR search.resourcetype:Collection OR search.resourcetype:Community</value>
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dspace.entity.type"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="person.identifier.jobtitle"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="project.identifier.name"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <!-- By default, full text snippets are disabled, as snippets of embargoed/restricted bitstreams
-                             may appear in search results when the Item is public. See DS-3498
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="project.identifier.status"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="orgunit.identifier.name"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="orgunit.identifier.description"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        -->
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="moreLikeThisConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
-                <property name="similarityMetadataFields">
-                    <list>
-                        <value>dc.title</value>
-                        <value>dc.contributor.author</value>
-                        <value>dc.creator</value>
-                        <value>dc.subject</value>
-                    </list>
-                </property>
-                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
-                <property name="minTermFrequency" value="5"/>
-                <!--The maximum number of related items displayed-->
-                <property name="max" value="3"/>
-                <!--The minimum word length below which words will be ignored-->
-                <property name="minWordLength" value="5"/>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
     <!--The configuration settings for discovery of withdrawn and indiscoverable items (admin only)-->
-    <bean id="unDiscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this unDiscoverableItems config.
+         Inherited unchanged: searchSortConfiguration, recentSubmissionConfiguration, moreLikeThisConfiguration,
+         tagCloudFacetConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration, which additionally highlights
+         organization.legalName / person.givenName / person.familyName (see PR notes). -->
+    <bean id="unDiscoverableItems" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="undiscoverable"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration: no searchFilterAccessStatus) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterAuthor" />
@@ -596,9 +512,8 @@
                 <ref bean="searchFilterEntityType"/>
             </list>
         </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page
+            (overrides defaultConfiguration: no searchFilterHasGeospatialMetadata / searchFilterAccessStatus / searchFilterGeospatialPoint) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
@@ -616,21 +531,9 @@
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides defaultConfiguration: only withdrawn/undiscoverable items) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items-->
@@ -639,234 +542,48 @@
                 <value>withdrawn:true OR discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dspace.entity.type"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="person.identifier.jobtitle"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="project.identifier.name"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <!-- By default, full text snippets are disabled, as snippets of embargoed/restricted bitstreams
-                             may appear in search results when the Item is public. See DS-3498
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="project.identifier.status"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="orgunit.identifier.name"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="orgunit.identifier.description"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        -->
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="moreLikeThisConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
-                <property name="similarityMetadataFields">
-                    <list>
-                        <value>dc.title</value>
-                        <value>dc.contributor.author</value>
-                        <value>dc.creator</value>
-                        <value>dc.subject</value>
-                    </list>
-                </property>
-                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
-                <property name="minTermFrequency" value="5"/>
-                <!--The maximum number of related items displayed-->
-                <property name="max" value="3"/>
-                <!--The minimum word length below which words will be ignored-->
-                <property name="minWordLength" value="5"/>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <!--The configuration settings for discovery of withdrawn and undiscoverable items (admin only) and regular items-->
-    <bean id="administrativeView" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!--The configuration settings for discovery of withdrawn and undiscoverable items (admin only) and regular items.
+        Uses defaultConfiguration's properties, unless overridden below for this administrativeView config.
+        Inherited unchanged: searchSortConfiguration, recentSubmissionConfiguration, moreLikeThisConfiguration,
+        tagCloudFacetConfiguration, defaultRpp, spellCheckEnabled.
+        NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration (3 extra highlight fields) and,
+        via merge="true", also gains defaultConfiguration's access-status and geospatial facets/filters that were
+        previously absent from the admin view (see PR notes). -->
+    <bean id="administrativeView" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="administrativeView"/>
         <property name="indexAlways" value="true"/>
+        <!-- Uses defaultConfiguration's sidebarFacets + extra admin-only facets specific to this administrativeView config -->
         <property name="sidebarFacets">
-            <list>
+            <list merge="true">
                 <ref bean="searchFilterDiscoverable" />
                 <ref bean="searchFilterWithdrawn" />
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
-                <ref bean="searchFilterEntityType"/>
                 <ref bean="searchFilterNotifyRelation" />
                 <ref bean="searchFilterNotifyEndorsement" />
                 <ref bean="searchFilterNotifyReview" />
             </list>
         </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
+        <!-- Uses defaultConfiguration's searchFilters + extra admin-only filters specific to this administrativeView config -->
         <property name="searchFilters">
-            <list>
+            <list merge="true">
                 <ref bean="searchFilterDiscoverable" />
                 <ref bean="searchFilterWithdrawn" />
-                <ref bean="searchFilterTitle" />
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
-                <ref bean="searchFilterFileNameInOriginalBundle" />
-                <ref bean="searchFilterFileDescriptionInOriginalBundle" />
-                <ref bean="searchFilterEntityType"/>
-                <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
-                <ref bean="searchFilterIsProjectOfPublicationRelation"/>
-                <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
-                <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
-                <ref bean="searchFilterIsJournalOfPublicationRelation"/>
                 <ref bean="searchFilterNotifyRelation" />
                 <ref bean="searchFilterNotifyEndorsement" />
                 <ref bean="searchFilterNotifyReview" />
             </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
         </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides defaultConfiguration: admin view also shows withdrawn/undiscoverable items) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items-->
                 <value>search.resourcetype:Item AND latestVersion:true</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dspace.entity.type"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="person.identifier.jobtitle"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="project.identifier.name"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <!-- By default, full text snippets are disabled, as snippets of embargoed/restricted bitstreams
-                             may appear in search results when the Item is public. See DS-3498
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="project.identifier.status"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="orgunit.identifier.name"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="orgunit.identifier.description"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        -->
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <property name="moreLikeThisConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryMoreLikeThisConfiguration">
-                <property name="similarityMetadataFields">
-                    <list>
-                        <value>dc.title</value>
-                        <value>dc.contributor.author</value>
-                        <value>dc.creator</value>
-                        <value>dc.subject</value>
-                    </list>
-                </property>
-                <!--The minimum number of matching terms across the metadata fields above before an item is found as related -->
-                <property name="minTermFrequency" value="5"/>
-                <!--The maximum number of related items displayed-->
-                <property name="max" value="3"/>
-                <!--The minimum word length below which words will be ignored-->
-                <property name="minWordLength" value="5"/>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
 
@@ -946,27 +663,13 @@
         <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <!--The supervised workspace configuration settings for discovery -->
+    <!--The supervised workspace configuration settings for discovery.
+        Uses workspaceConfiguration's properties (sidebarFacets, searchFilters, hitHighlightingConfiguration,
+        defaultRpp, spellCheckEnabled), unless overridden below for this supervisedWorkspace config -->
     <bean id="supervisedWorkspaceConfiguration"
           class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="workspaceConfiguration">
         <property name="id" value="supervisedWorkspace" />
-        <!--Which sidebar facets are to be displayed -->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page -->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-            </list>
-        </property>
         <!--The sort filters for the discovery search-->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
@@ -989,54 +692,27 @@
                 <value>search.resourcetype:WorkspaceItem AND supervised:true</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="fulltext"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
     <!--The other workspace configuration settings for discovery.
         "Other workspace" shows workspace items that the current user can view and potentially edit
         because they are linked as authors or owners via dspace.object.owner metadata authority.
-        This enables collaborative editing where co-authors can see each other's in-progress work. -->
+        This enables collaborative editing where co-authors can see each other's in-progress work.
+        Uses workspaceConfiguration's properties (hitHighlightingConfiguration, defaultRpp, spellCheckEnabled),
+        unless overridden below for this otherWorkspace config -->
     <bean id="otherWorkspaceConfiguration"
           class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="workspaceConfiguration">
         <property name="id" value="otherWorkspace" />
-        <!--Which sidebar facets are to be displayed -->
+        <!--Which sidebar facets are to be displayed (overrides workspaceConfiguration: no searchFilterObjectNamedType) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page -->
+        <!--The search filters which can be used on the discovery search page
+            (overrides workspaceConfiguration: no searchFilterObjectNamedType, adds searchFilterEntityType) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterType" />
@@ -1066,63 +742,30 @@
                 <value>search.resourcetype:WorkspaceItem</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="fulltext"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
 
-    <!--The workflow configuration settings for discovery -->
+    <!--The workflow configuration settings for discovery.
+        Uses workspaceConfiguration's properties (hitHighlightingConfiguration, defaultRpp, spellCheckEnabled),
+        unless overridden below for this workflow config -->
     <bean id="workflowConfiguration"
         class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-        scope="prototype">
+        scope="prototype" parent="workspaceConfiguration">
         <property name="id" value="workflow" />
-        <!--Which sidebar facets are to be displayed -->
+        <!-- Uses workspaceConfiguration's sidebarFacets + searchFilterSubmitter specific to this workflow config -->
         <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
+            <list merge="true">
                 <ref bean="searchFilterSubmitter" />
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page -->
+        <!-- Uses workspaceConfiguration's searchFilters + searchFilterSubmitter specific to this workflow config -->
         <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
+            <list merge="true">
                 <ref bean="searchFilterSubmitter" />
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search
+            (overrides workspaceConfiguration: no defaultSortField) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -1143,62 +786,17 @@
                 <value>search.resourcetype:PoolTask OR search.resourcetype:ClaimedTask</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="fulltext"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <!--The workflowAdmin configuration settings for discovery -->
+    <!--The workflowAdmin configuration settings for discovery.
+        Uses workflowConfiguration's properties (sidebarFacets and searchFilters incl. searchFilterSubmitter,
+        hitHighlightingConfiguration, defaultRpp, spellCheckEnabled), unless overridden below for this workflowAdmin config -->
     <bean id="workflowAdminConfiguration"
         class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-        scope="prototype">
+        scope="prototype" parent="workflowConfiguration">
         <property name="id" value="workflowAdmin" />
-        <!--Which sidebar facets are to be displayed -->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterSubmitter" />
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page -->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterSubmitter" />
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search
+            (overrides workflowConfiguration: no sortLastModified) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -1217,63 +815,29 @@
                 <value>search.resourcetype:XmlWorkflowItem</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="fulltext"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!--The supervision configuration settings for discovery.
+        Uses workflowConfiguration's properties (hitHighlightingConfiguration, defaultRpp, spellCheckEnabled),
+        unless overridden below for this supervision config -->
     <bean id="supervisionConfiguration"
           class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="workflowConfiguration">
         <property name="id" value="supervision" />
-        <!--Which sidebar facets are to be displayed -->
+        <!-- Uses workflowConfiguration's sidebarFacets (incl. searchFilterSubmitter) + searchFilterSupervision specific to this supervision config -->
         <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterSubmitter" />
+            <list merge="true">
                 <ref bean="searchFilterSupervision" />
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page -->
+        <!-- Uses workflowConfiguration's searchFilters (incl. searchFilterSubmitter) + searchFilterSupervision specific to this supervision config -->
         <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterObjectNamedType" />
-                <ref bean="searchFilterType" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterSubmitter" />
+            <list merge="true">
                 <ref bean="searchFilterSupervision" />
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search
+            (overrides workflowConfiguration: no sortLastModified) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -1292,36 +856,6 @@
                 <value>search.resourcetype:WorkspaceItem OR search.resourcetype:XmlWorkflowItem</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10" />
-        <property name="hitHighlightingConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightingConfiguration">
-                <property name="metadataFields">
-                    <list>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.title"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.contributor.author"/>
-                            <property name="snippets" value="5"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="dc.description.abstract"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                        <bean class="org.dspace.discovery.configuration.DiscoveryHitHighlightFieldConfiguration">
-                            <property name="field" value="fulltext"/>
-                            <property name="maxSize" value="250"/>
-                            <property name="snippets" value="2"/>
-                        </bean>
-                    </list>
-                </property>
-            </bean>
-        </property>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
     <!-- Inverse Relations -->
@@ -1533,10 +1067,15 @@
     </bean>
 
 
-    <bean id="publication" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this publication config.
+         Inherited unchanged: searchSortConfiguration, recentSubmissionConfiguration, tagCloudFacetConfiguration,
+         defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
+    <bean id="publication" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="publication"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration: no searchFilterAccessStatus) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterAuthor" />
@@ -1546,9 +1085,8 @@
                 <ref bean="searchFilterEntityType"/>
             </list>
         </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page
+            (overrides defaultConfiguration: no geospatial/access-status filters; adds Publication relation filters) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
@@ -1566,19 +1104,6 @@
                 <ref bean="searchFilterIsJournalOfPublicationRelation"/>
                 <ref bean="searchFilterIsDatasetOfPublicationRelation"/>
             </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
         </property>
         <!--Any default filter queries, these filter queries will be used for all
             queries done by discovery for this configuration -->
@@ -1589,70 +1114,16 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="publicationRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Same as the "publication" configuration, but does NOT filter out older versions of items.
+         Uses publication's properties, unless overridden below for this publicationRelationships config -->
+    <bean id="publicationRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="publication">
         <property name="id" value="publicationRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
-                <ref bean="searchFilterEntityType"/>
-            </list>
-        </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterTitle" />
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
-                <ref bean="searchFilterFileNameInOriginalBundle" />
-                <ref bean="searchFilterFileDescriptionInOriginalBundle" />
-                <ref bean="searchFilterEntityType"/>
-                <ref bean="searchFilterIsAuthorOfPublicationRelation"/>
-                <ref bean="searchFilterIsProjectOfPublicationRelation"/>
-                <ref bean="searchFilterIsOrgUnitOfPublicationRelation"/>
-                <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
-                <ref bean="searchFilterIsJournalOfPublicationRelation"/>
-                <ref bean="searchFilterIsDatasetOfPublicationRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides publication: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -1661,37 +1132,17 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="dataset" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
-        <property name="id" value="publication"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
-                <ref bean="searchFilterEntityType"/>
-            </list>
-        </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
+    <!-- Same structure as the "publication" configuration, but for the Dataset entity type.
+         Uses publication's properties, unless overridden below for this dataset config.
+         NOTE: the "id" property is intentionally inherited from publication (value "publication") to preserve
+         current behavior. This appears to be a pre-existing copy/paste in upstream main (the "dataset"
+         configuration reports id "publication"); preserved here to keep this refactor behavior-neutral (see PR notes). -->
+    <bean id="dataset" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="publication">
+        <!--The search filters which can be used on the discovery search page
+            (overrides publication: Dataset relation filters instead of Publication ones) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
@@ -1708,19 +1159,6 @@
                 <ref bean="searchFilterIsPublicationOfDatasetRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
             queries done by discovery for this configuration -->
         <property name="defaultFilterQueries">
@@ -1730,37 +1168,16 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="datasetRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Same as the "dataset" configuration, but does NOT filter out older versions of items.
+         Uses dataset's properties, unless overridden below for this datasetRelationships config.
+         NOTE: the "id" property value "publicationRelationships" is preserved from upstream main (see PR notes). -->
+    <bean id="datasetRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="dataset">
         <property name="id" value="publicationRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterAuthor" />
-                <ref bean="searchFilterSubject" />
-                <ref bean="searchFilterIssued" />
-                <ref bean="searchFilterContentInOriginalBundle"/>
-                <ref bean="searchFilterEntityType"/>
-            </list>
-        </property>
-        <!-- Set TagCloud configuration per discovery configuration -->
-        <property name="tagCloudFacetConfiguration" ref="defaultTagCloudFacetConfiguration"/>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page
+            (overrides dataset: searchFilterIsDatasetOfPublicationRelation instead of searchFilterIsPublicationOfDatasetRelation) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle" />
@@ -1777,21 +1194,9 @@
                 <ref bean="searchFilterIsDatasetOfPublicationRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle" />
-                        <ref bean="sortDateIssued" />
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides dataset: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -1800,25 +1205,20 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned" />
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="person" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this person config.
+         Inherited unchanged: defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
+    <bean id="person" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="person"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: person has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which person does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterJobtitle"/>
@@ -1826,7 +1226,7 @@
                 <ref bean="searchFilterBirthdate"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterFamilyName"/>
@@ -1840,7 +1240,7 @@
                 <ref bean="searchFilterIsDatasetOfAuthorRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -1863,8 +1263,7 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
+        <!--The configuration for the recent submissions (overrides defaultConfiguration: max=5) -->
         <property name="recentSubmissionConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
                 <property name="metadataSortField" value="dc.date.accessioned"/>
@@ -1873,52 +1272,16 @@
                 <property name="useAsHomePage" value="false"/>
             </bean>
         </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="personRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Same as the "person" configuration, but does NOT filter out older versions of items.
+         Uses person's properties, unless overridden below for this personRelationships config -->
+    <bean id="personRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="person">
         <property name="id" value="personRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterJobtitle"/>
-                <ref bean="searchFilterKnowsLanguage"/>
-                <ref bean="searchFilterBirthdate"/>
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterFamilyName"/>
-                <ref bean="searchFilterGivenName"/>
-                <ref bean="searchFilterJobtitle"/>
-                <ref bean="searchFilterKnowsLanguage"/>
-                <ref bean="searchFilterBirthdate"/>
-                <ref bean="searchFilterIsOrgUnitOfPersonRelation"/>
-                <ref bean="searchFilterIsProjectOfPersonRelation"/>
-                <ref bean="searchFilterIsPublicationOfAuthorRelation"/>
-                <ref bean="searchFilterIsDatasetOfAuthorRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortFamilyName"/>
-                        <ref bean="sortGivenName"/>
-                        <ref bean="sortBirthDate"/>
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides person: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -1927,31 +1290,23 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="5"/>
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="project" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this project config.
+         Inherited unchanged: defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration, moreLikeThisConfiguration and
+         tagCloudFacetConfiguration (subject tag cloud; project's searchFilters include searchFilterSubject) (see PR notes). -->
+    <bean id="project" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="project"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterSubject"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterSubject"/>
@@ -1962,7 +1317,7 @@
                 <ref bean="searchFilterIsDatasetOfProjectRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -1982,8 +1337,7 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
+        <!--The configuration for the recent submissions (overrides defaultConfiguration: max=5) -->
         <property name="recentSubmissionConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
                 <property name="metadataSortField" value="dc.date.accessioned"/>
@@ -1992,44 +1346,16 @@
                 <property name="useAsHomePage" value="false"/>
             </bean>
         </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <bean id="projectRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">
+    <!-- Same as the "project" configuration, but does NOT filter out older versions of items.
+         Uses project's properties, unless overridden below for this projectRelationships config -->
+    <bean id="projectRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
+          scope="prototype" parent="project">
         <property name="id" value="projectRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterSubject"/>
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterSubject"/>
-                <ref bean="searchFilterIdentifier"/>
-                <ref bean="searchFilterIsOrgUnitOfProjectRelation"/>
-                <ref bean="searchFilterIsPersonOfProjectRelation"/>
-                <ref bean="searchFilterIsPublicationOfProjectRelation"/>
-                <ref bean="searchFilterIsDatasetOfProjectRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides project: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -2038,26 +1364,20 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="5"/>
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this orgUnit config.
+         Inherited unchanged: recentSubmissionConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
     <bean id="orgUnit" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="orgUnit"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: orgUnit has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which orgUnit does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterOrganizationAddressCountry"/>
@@ -2065,7 +1385,7 @@
                 <ref bean="searchFilterOrganizationFoundingDate"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterOrganizationLegalName"/>
@@ -2078,7 +1398,7 @@
                 <ref bean="searchFilterIsDatasetOfOrgUnitRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2102,64 +1422,16 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Same as the "orgUnit" configuration, but does NOT filter out older versions of items.
+         Uses orgUnit's properties, unless overridden below for this orgUnitRelationships config -->
     <bean id="orgUnitRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="orgUnit">
         <property name="id" value="orgUnitRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterOrganizationAddressCountry"/>
-                <ref bean="searchFilterOrganizationAddressLocality"/>
-                <ref bean="searchFilterOrganizationFoundingDate"/>
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterOrganizationLegalName"/>
-                <ref bean="searchFilterOrganizationAddressCountry"/>
-                <ref bean="searchFilterOrganizationAddressLocality"/>
-                <ref bean="searchFilterOrganizationFoundingDate"/>
-                <ref bean="searchFilterIsPersonOfOrgUnitRelation"/>
-                <ref bean="searchFilterIsProjectOfOrgUnitRelation"/>
-                <ref bean="searchFilterIsPublicationOfOrgUnitRelation"/>
-                <ref bean="searchFilterIsDatasetOfOrgUnitRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortOrganizationLegalName"/>
-                        <ref bean="sortOrganizationAddressCountry"/>
-                        <ref bean="sortOrganizationAddressLocality"/>
-                        <ref bean="sortOrganizationFoundingDate"/>
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides orgUnit: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -2168,34 +1440,27 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this journalIssue config.
+         Inherited unchanged: recentSubmissionConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
     <bean id="journalIssue" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="journalIssue"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: journalIssue has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which journalIssue does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterCreativeWorkKeywords"/>
                 <ref bean="searchFilterCreativeWorkDatePublished"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle"/>
@@ -2205,7 +1470,7 @@
                 <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2228,59 +1493,16 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Same as the "journalIssue" configuration, but does NOT filter out older versions of items.
+         Uses journalIssue's properties, unless overridden below for this journalIssueRelationships config -->
     <bean id="journalIssueRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="journalIssue">
         <property name="id" value="journalIssueRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterCreativeWorkKeywords"/>
-                <ref bean="searchFilterCreativeWorkDatePublished"/>
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterTitle"/>
-                <ref bean="searchFilterPublicationIssueNumber"/>
-                <ref bean="searchFilterCreativeWorkKeywords"/>
-                <ref bean="searchFilterCreativeWorkDatePublished"/>
-                <ref bean="searchFilterIsPublicationOfJournalIssueRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortPublicationIssueNumber"/>
-                        <ref bean="sortTitle"/>
-                        <ref bean="sortCreativeWorkDatePublished"/>
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides journalIssue: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -2289,33 +1511,26 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this journalVolume config.
+         Inherited unchanged: recentSubmissionConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
     <bean id="journalVolume" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="journalVolume"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: journalVolume has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which journalVolume does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterCreativeWorkDatePublished"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle"/>
@@ -2325,7 +1540,7 @@
                 <ref bean="searchFilterIsJournalVolumeRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2348,58 +1563,16 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Same as the "journalVolume" configuration, but does NOT filter out older versions of items.
+         Uses journalVolume's properties, unless overridden below for this journalVolumeRelationships config -->
     <bean id="journalVolumeRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="journalVolume">
         <property name="id" value="journalVolumeRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterCreativeWorkDatePublished"/>
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterTitle"/>
-                <ref bean="searchFilterPublicationVolumeNumber"/>
-                <ref bean="searchFilterCreativeWorkDatePublished"/>
-                <ref bean="searchFilterIsIssueOfJournalVolumeRelation"/>
-                <ref bean="searchFilterIsJournalVolumeRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortPublicationVolumeNumber"/>
-                        <ref bean="sortTitle"/>
-                        <ref bean="sortCreativeWorkDatePublished"/>
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides journalVolume: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -2408,40 +1581,33 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
-    <!-- Geospatial configuration -->
+    <!-- Geospatial configuration.
+         Uses defaultConfiguration's properties, unless overridden below for this geospatial config.
+         Inherited unchanged: recentSubmissionConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
     <bean id="geospatialConfiguration" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="geospatial"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: geospatial has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which geospatial does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterGeospatialPoint"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterGeospatialPoint"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2461,34 +1627,27 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this journal config.
+         Inherited unchanged: recentSubmissionConfiguration, defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration and moreLikeThisConfiguration (see PR notes). -->
     <bean id="journal" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="journal"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: journal has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which journal does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterCreativeWorkPublisher"/>
                 <ref bean="searchFilterCreativeWorkEditor"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterTitle"/>
@@ -2498,7 +1657,7 @@
                 <ref bean="searchFilterIsVolumeOfJournalRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2520,58 +1679,16 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Same as the "journal" configuration, but does NOT filter out older versions of items.
+         Uses journal's properties, unless overridden below for this journalRelationships config -->
     <bean id="journalRelationships" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="journal">
         <property name="id" value="journalRelationships"/>
-        <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
-        <property name="sidebarFacets">
-            <list>
-                <ref bean="searchFilterCreativeWorkPublisher"/>
-                <ref bean="searchFilterCreativeWorkEditor"/>
-            </list>
-        </property>
-        <!--The search filters which can be used on the discovery search page-->
-        <property name="searchFilters">
-            <list>
-                <ref bean="searchFilterTitle"/>
-                <ref bean="searchFilterCreativeWorkPublisher"/>
-                <ref bean="searchFilterCreativeWorkEditor"/>
-                <ref bean="searchFilterIsIssueOfJournalVolumeRelation"/>
-                <ref bean="searchFilterIsVolumeOfJournalRelation"/>
-            </list>
-        </property>
-        <!--The sort filters for the discovery search-->
-        <property name="searchSortConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
-                <property name="sortFields">
-                    <list>
-                        <ref bean="sortScore" />
-                        <ref bean="sortTitle"/>
-                        <ref bean="sortCreativeWorkDatePublished"/>
-                        <ref bean="sortDateAccessioned"/>
-                    </list>
-                </property>
-            </bean>
-        </property>
         <!--Any default filter queries, these filter queries will be used for all
-            queries done by discovery for this configuration -->
+            queries done by discovery for this configuration
+            (overrides journal: NOT filtered on latestVersion = true) -->
         <property name="defaultFilterQueries">
             <list>
                 <!--Only find items, communities and collections-->
@@ -2580,27 +1697,21 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--The configuration for the recent submissions-->
-        <property name="recentSubmissionConfiguration">
-            <bean class="org.dspace.discovery.configuration.DiscoveryRecentSubmissionsConfiguration">
-                <property name="metadataSortField" value="dc.date.accessioned"/>
-                <property name="type" value="date"/>
-                <property name="max" value="20"/>
-                <!-- If enabled the collection home page will not display metadata but show a pageable list of recent submissions -->
-                <property name="useAsHomePage" value="false"/>
-            </bean>
-        </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Uses defaultConfiguration's properties, unless overridden below for this personOrOrgunit config.
+         Inherited unchanged: defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration, moreLikeThisConfiguration and
+         recentSubmissionConfiguration (personOrOrgunit previously defined none of these) (see PR notes). -->
     <bean id="personOrOrgunit" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="personOrOrgunit"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: personOrOrgunit has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which personOrOrgunit does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterOrganizationAddressCountry"/>
@@ -2608,7 +1719,7 @@
                 <ref bean="searchFilterEntityType"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterEntityType"/>
@@ -2627,7 +1738,7 @@
                 <ref bean="searchFilterIsPublicationOfAuthorRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2654,18 +1765,22 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
+    <!-- Openaire4 guidelines - search for an OrgUnit that has a specific dc.type=FundingOrganization.
+         Uses defaultConfiguration's properties, unless overridden below for this openaireFundingAgency config.
+         Inherited unchanged: defaultRpp, spellCheckEnabled.
+         NOTE: now inherits defaultConfiguration's hitHighlightingConfiguration, moreLikeThisConfiguration and
+         recentSubmissionConfiguration (openaireFundingAgency previously defined none of these) (see PR notes). -->
     <bean id="openaireFundingAgency" class="org.dspace.discovery.configuration.DiscoveryConfiguration"
-          scope="prototype">
+          scope="prototype" parent="defaultConfiguration">
         <property name="id" value="fundingAgency"/>
         <property name="indexAlways" value="true"/>
-        <!--Which sidebar facets are to be displayed-->
+        <!-- Override: openaireFundingAgency has no tagCloud (defaultConfiguration's tagCloud needs searchFilterSubject, which it does not use) -->
+        <property name="tagCloudFacetConfiguration">
+            <bean class="org.dspace.discovery.configuration.TagCloudFacetConfiguration"/>
+        </property>
+        <!--Which sidebar facets are to be displayed (overrides defaultConfiguration) -->
         <property name="sidebarFacets">
             <list>
                 <ref bean="searchFilterOrganizationAddressCountry"/>
@@ -2673,7 +1788,7 @@
                 <ref bean="searchFilterOrganizationFoundingDate"/>
             </list>
         </property>
-        <!--The search filters which can be used on the discovery search page-->
+        <!--The search filters which can be used on the discovery search page (overrides defaultConfiguration) -->
         <property name="searchFilters">
             <list>
                 <ref bean="searchFilterOrganizationLegalName"/>
@@ -2686,7 +1801,7 @@
                 <ref bean="searchFilterIsProjectOfFundingAgencyRelation"/>
             </list>
         </property>
-        <!--The sort filters for the discovery search-->
+        <!--The sort filters for the discovery search (overrides defaultConfiguration) -->
         <property name="searchSortConfiguration">
             <bean class="org.dspace.discovery.configuration.DiscoverySortConfiguration">
                 <property name="sortFields">
@@ -2710,10 +1825,6 @@
                 <value>-withdrawn:true AND -discoverable:false</value>
             </list>
         </property>
-        <!--Default result per page  -->
-        <property name="defaultRpp" value="10"/>
-        <!-- When true a "did you mean" example will be displayed, value can be true or false -->
-        <property name="spellCheckEnabled" value="true"/>
     </bean>
 
     <bean id="eperson_claims" class="org.dspace.discovery.configuration.DiscoveryConfiguration" scope="prototype">


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #12729

## Description
Refactors `dspace/config/spring/api/discovery.xml` to remove duplicated `DiscoveryConfiguration` definitions by using Spring parent beans (`parent="X"`) and reusable lists (`<list merge="true">`).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Introduced `parent="defaultConfiguration"` for entity configs (`publication`, `person`, `project`, `orgUnit`, `journal*`, `personOrOrgunit`, `openaireFundingAgency`, `geospatialConfiguration`) and for `defaultRelationshipsConfiguration`, `unDiscoverableItems`, and `administrativeView`; each child bean now declares only properties that genuinely differ from its parent on `main`.
* Introduced `parent="publication"` for `dataset` (overrides only relation `searchFilters` and `defaultFilterQueries` for `entityType_keyword:Dataset`).
* Introduced `parent="<base entity>"` for all `*Relationships` beans (`publicationRelationships`, `datasetRelationships`, `personRelationships`, etc.), overriding only `id`, `defaultFilterQueries`, and any relation-specific filter differences.
* Chained the workspace/workflow/supervision family off `workspaceConfiguration` (`supervisedWorkspaceConfiguration`, `otherWorkspaceConfiguration`, `workflowConfiguration`, `workflowAdminConfiguration`, `supervisionConfiguration`).
* Used `<list merge="true">` where a config is "parent list plus extras": `administrativeView` (admin/Notify facets), `workflowConfiguration` (`searchFilterSubmitter`), `supervisionConfiguration` (`searchFilterSupervision`).
* Overrode `tagCloudFacetConfiguration` with an empty bean for entity configs whose `searchFilters` do not include `searchFilterSubject`, so inherited tag clouds do not fail `DiscoveryConfiguration.afterPropertiesSet()` validation.
* Added inline comments per refactored bean documenting inherited vs overridden properties.
* Left standalone (unchanged): `eperson_claims`, CRIS `DiscoveryRelatedItemConfiguration` beans, `ldnMessageEntityBaseConfig` / existing NOTIFY hierarchy, and base beans `defaultConfiguration` / `workspaceConfiguration`.

**Intentional behavior changes (documented for review):**
* **Entity configs** (`publication`, `dataset`, `person`, `project`, `orgUnit`, `journal*`, `personOrOrgunit`, `openaireFundingAgency`, `geospatialConfiguration`, and their `*Relationships` children) now inherit `defaultConfiguration`'s `hitHighlightingConfiguration` and `moreLikeThisConfiguration` where they previously had none.
* **`personOrOrgunit` and `openaireFundingAgency`** additionally inherit default's `recentSubmissionConfiguration` (max=20).
* **`project`** inherits default's subject tag cloud (valid: `searchFilterSubject` is already in its filters).
* **`defaultRelationshipsConfiguration` and `unDiscoverableItems`** inherit default's richer hit-highlight fields (`organization.legalName`, `person.givenName`, `person.familyName`).
* **`administrativeView`** (and therefore `NOTIFY.incoming.involvedItems` / `NOTIFY.outgoing.involvedItems`, which extend it) now inherits default's access-status and geospatial facets/filters via `merge="true"`, plus default's extra hit-highlight fields. Facet/filter ordering changes slightly (inherited entries first, then admin-specific).

**Include guidance for how to test or review your PR.**

1. **Spring context load** — start DSpace (or run any `./dspace` command that loads the kernel) and confirm the application starts without `BeanCreationException` from `DiscoveryConfiguration.afterPropertiesSet()`.
2. **Discovery search smoke test** — browse/search as an anonymous user and verify default discovery facets, filters, and sort options behave as before.
3. **Entity-type views** — if CRIS/entity types are enabled, open discovery for `Publication`, `Dataset`, `Person`, `Project`, etc. and confirm entity-specific facets/filters and results still look correct.
4. **Admin view** — as an admin, open the administrative discovery view and confirm admin-only facets (Discoverable, Withdrawn, Notify*) appear; note the intentional addition of access-status and geospatial filters inherited from default.
5. **Workspace / workflow** — submit or workflow-test an item and confirm workspace/workflow/supervision discovery views still list the expected items and filters.
6. **Optional reindex** — run `./dspace index-discovery -b` after deploy; no schema or index field changes are expected, but a full reindex confirms indexing still completes cleanly.


## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide). _(No Java changes.)_
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. _(N/A — no Java changes.)_
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). _(No Java changes; existing tests should be unaffected. Config-only refactor.)_
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. _(N/A.)_
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. _(N/A.)_
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue). _(Fixes [#12729](https://github.com/DSpace/DSpace/issues/12729).)_
