### PR TITLE
Restrict feedback submission to authenticated users by default

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSendFeedbackFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSendFeedbackFeature.java
@@ -38,7 +38,15 @@ public class CanSendFeedbackFeature implements AuthorizationFeature {
     @SuppressWarnings("rawtypes")
     public boolean isAuthorized(Context context, BaseObjectRest object) throws SQLException {
         String recipientEmail = configurationService.getProperty("feedback.recipient");
-        return StringUtils.isNotBlank(recipientEmail);
+        if (StringUtils.isBlank(recipientEmail)) {
+            return false;
+        }
+        // When anonymous submission is disabled, only authenticated users can send feedback
+        if (context.getCurrentUser() == null
+                && !configurationService.getBooleanProperty("feedback.allow-anonymous", false)) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSendFeedbackFeature.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/authorization/impl/CanSendFeedbackFeature.java
@@ -20,13 +20,14 @@ import org.springframework.stereotype.Component;
 
 /**
  * The send feedback feature. It can be used to verify if the parameter that contain
- * recipient e-mail is configured.
+ * recipient e-mail is configured and if the current user is authorized to send feedback.
  * 
  * @author Mykhaylo Boychuk (mykhaylo.boychuk at 4science.com)
  */
 @Component
 @AuthorizationFeatureDocumentation(name = CanSendFeedbackFeature.NAME,
-    description = "It can be used to verify if the parameter that contain recipient e-mail is configured.")
+    description = "It can be used to verify if the parameter that contain recipient e-mail is configured"
+        + " and if the current user is authorized to send feedback.")
 public class CanSendFeedbackFeature implements AuthorizationFeature {
 
     public static final String NAME = "canSendFeedback";

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/FeedbackRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/FeedbackRestRepository.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.exception.DSpaceFeedbackNotFoundException;
+import org.dspace.app.rest.exception.RESTAuthorizationException;
 import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.FeedbackRest;
@@ -62,6 +63,14 @@ public class FeedbackRestRepository extends DSpaceRestRepository<FeedbackRest, I
     protected FeedbackRest createAndReturn(Context context) throws AuthorizeException, SQLException {
         HttpServletRequest req = getRequestService().getCurrentRequest().getHttpServletRequest();
         FeedbackRest feedbackRest = null;
+
+        // By default feedback submission is restricted to authenticated users. Anonymous submission
+        // can be re-enabled via the "feedback.allow-anonymous" configuration property. This is checked
+        // here (rather than in @PreAuthorize) because it depends on runtime configuration.
+        if (context.getCurrentUser() == null
+                && !configurationService.getBooleanProperty("feedback.allow-anonymous", false)) {
+            throw new RESTAuthorizationException("Submitting feedback requires an authenticated user");
+        }
 
         String recipientEmail = configurationService.getProperty("feedback.recipient");
         if (StringUtils.isBlank(recipientEmail)) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/FeedbackRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/FeedbackRestRepositoryIT.java
@@ -130,4 +130,55 @@ public class FeedbackRestRepositoryIT extends AbstractControllerIntegrationTest 
         }
     }
 
+    @Test
+    public void sendFeedbackUnauthenticatedByDefaultTest() throws Exception {
+        configurationService.setProperty("feedback.recipient", "recipient.email@test.com");
+        // feedback.allow-anonymous defaults to false, so anonymous users cannot submit feedback
+        FeedbackService originFeedbackService = feedbackRestRepository.getFeedbackService();
+        try {
+            FeedbackService feedbackServiceMock = mock(FeedbackServiceImpl.class);
+            feedbackRestRepository.setFeedbackService(feedbackServiceMock);
+
+            FeedbackRest feedbackRest = new FeedbackRest();
+            feedbackRest.setEmail("misha.boychuk@test.com");
+            feedbackRest.setMessage("My feedback!");
+
+            getClient().perform(post("/api/tools/feedbacks")
+                       .content(mapper.writeValueAsBytes(feedbackRest))
+                       .contentType(contentType))
+                       .andExpect(status().isUnauthorized());
+
+            verifyNoMoreInteractions(feedbackServiceMock);
+        } finally {
+            feedbackRestRepository.setFeedbackService(originFeedbackService);
+        }
+    }
+
+    @Test
+    public void sendFeedbackAnonymousAllowedTest() throws Exception {
+        configurationService.setProperty("feedback.recipient", "recipient.email@test.com");
+        configurationService.setProperty("feedback.allow-anonymous", true);
+        FeedbackService originFeedbackService = feedbackRestRepository.getFeedbackService();
+        try {
+            FeedbackService feedbackServiceMock = mock(FeedbackServiceImpl.class);
+            feedbackRestRepository.setFeedbackService(feedbackServiceMock);
+
+            FeedbackRest feedbackRest = new FeedbackRest();
+            feedbackRest.setEmail("misha.boychuk@test.com");
+            feedbackRest.setMessage("My feedback!");
+
+            getClient().perform(post("/api/tools/feedbacks")
+                       .content(mapper.writeValueAsBytes(feedbackRest))
+                       .contentType(contentType))
+                       .andExpect(status().isCreated());
+
+            verify(feedbackServiceMock).sendEmail(isNotNull(), isNotNull(), eq("recipient.email@test.com"),
+                    eq("misha.boychuk@test.com"), eq("My feedback!"), isNull());
+            verifyNoMoreInteractions(feedbackServiceMock);
+        } finally {
+            feedbackRestRepository.setFeedbackService(originFeedbackService);
+            configurationService.setProperty("feedback.allow-anonymous", false);
+        }
+    }
+
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanSendFeedbackFeatureIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/authorization/CanSendFeedbackFeatureIT.java
@@ -76,10 +76,9 @@ public class CanSendFeedbackFeatureIT extends AbstractControllerIntegrationTest 
                                .andExpect(jsonPath("$", Matchers.is(
                                           AuthorizationMatcher.matchAuthorization(authEPersonSite))));
 
+        // anonymous users cannot send feedback by default (feedback.allow-anonymous defaults to false)
         getClient().perform(get("/api/authz/authorizations/" + authAnonymousSite.getID()))
-                   .andExpect(status().isOk())
-                   .andExpect(jsonPath("$", Matchers.is(
-                              AuthorizationMatcher.matchAuthorization(authAnonymousSite))));
+                   .andExpect(status().isNotFound());
     }
 
     @Test
@@ -105,6 +104,26 @@ public class CanSendFeedbackFeatureIT extends AbstractControllerIntegrationTest 
 
         getClient().perform(get("/api/authz/authorizations/" + authAnonymousSite.getID()))
                    .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void canSendFeedbackFeatureAnonymousAllowedTest() throws Exception {
+        configurationService.setProperty("feedback.recipient", "myemail@test.com");
+        configurationService.setProperty("feedback.allow-anonymous", true);
+        try {
+            Site site = siteService.findSite(context);
+            SiteRest siteRest = siteConverter.convert(site, DefaultProjection.DEFAULT);
+
+            // when anonymous submission is enabled, anonymous users are allowed to send feedback
+            Authorization authAnonymousSite = new Authorization(null, canSendFeedbackFeature, siteRest);
+
+            getClient().perform(get("/api/authz/authorizations/" + authAnonymousSite.getID()))
+                       .andExpect(status().isOk())
+                       .andExpect(jsonPath("$", Matchers.is(
+                                  AuthorizationMatcher.matchAuthorization(authAnonymousSite))));
+        } finally {
+            configurationService.setProperty("feedback.allow-anonymous", false);
+        }
     }
 
 }

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -168,6 +168,10 @@ mail.from.address = dspace-noreply@myu.edu
 # if this property is empty or commented out, feedback form is disabled
 feedback.recipient = dspace-help@myu.edu
 
+# Whether anonymous (unauthenticated) users are allowed to submit the feedback form.
+# Defaults to false, which means only authenticated users may submit feedback.
+feedback.allow-anonymous = false
+
 # General site administration (Webmaster) e-mail
 # System notifications/reports and other sysadmin emails are sent to this address
 mail.admin = dspace-help@myu.edu


### PR DESCRIPTION
﻿## References

Fixes #12671

## Description

Restricts the feedback submission endpoint (`POST /api/tools/feedbacks`) to authenticated users by default, with a new `feedback.allow-anonymous` configuration property to optionally restore anonymous submission.

## Instructions for Reviewers

List of changes in this PR:
* `FeedbackRestRepository#createAndReturn` now rejects anonymous submissions with `401 Unauthorized` unless `feedback.allow-anonymous = true`. The check is done in-method (mirroring e.g. `ResourcePolicyRestRepository`) because it depends on runtime configuration and therefore cannot live in `@PreAuthorize`.
* `CanSendFeedbackFeature` returns `false` for anonymous users when anonymous submission is disabled, so the UI stays consistent with the endpoint.
* Added the `feedback.allow-anonymous` property (default `false`) to `dspace.cfg`, alongside `feedback.recipient`.
* Added/updated integration tests in `FeedbackRestRepositoryIT` and `CanSendFeedbackFeatureIT` covering both the default (restricted) and anonymous-allowed modes.

How to test:
* With defaults, an anonymous `POST /api/tools/feedbacks` returns `401`; an authenticated submission works as before.
* Set `feedback.allow-anonymous = true` and the anonymous submission succeeds again.

A matching Angular UI change (restricting the feedback form for anonymous users) will be linked to this same issue.

## Checklist

- [x] My PR is created against the `main` branch of code.
- [x] My PR is small in size.
- [x] My PR passes Checkstyle validation.
- [x] My PR includes Javadoc where applicable (no new public API; the behavioral change is documented inline).
- [x] My PR includes new/updated integration tests.
- [x] My PR includes details on how to test it.
- [x] My PR includes basic technical documentation for the new `feedback.allow-anonymous` configuration.
- [ ] A separate REST Contract PR documenting the endpoint behavior change will be opened and linked.
- [x] My PR is linked to the issue it fixes (#12671).
