### PR TITLE
Fix JSON export and import in solr-core-management tool

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImport.java
@@ -430,9 +430,33 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
         log.debug("Thread '{}' writing to file: {}", currentThread.getName(), filename);
         long writeStart = System.currentTimeMillis();
 
-        try (InputStream inputStream = response.body();
-             FileOutputStream outputStream = new FileOutputStream(filePath.toFile())) {
-            inputStream.transferTo(outputStream);
+        if (format.equals("json")) {
+            try (InputStream inputStream = response.body()) {
+                JsonNode root = jsonMapper.readTree(inputStream);
+                JsonNode docs = root.path("response").path("docs");
+                if (docs.isArray()) {
+                    for (JsonNode doc : docs) {
+                        if (doc.isObject()) {
+                            com.fasterxml.jackson.databind.node.ObjectNode objectNode =
+                                    (com.fasterxml.jackson.databind.node.ObjectNode) doc;
+                            objectNode.remove("_version_");
+                            objectNode.remove("_root_");
+                        }
+                    }
+                    try (FileOutputStream outputStream = new FileOutputStream(filePath.toFile())) {
+                        jsonMapper.writeValue(outputStream, docs);
+                    }
+                } else {
+                    try (FileOutputStream outputStream = new FileOutputStream(filePath.toFile())) {
+                        jsonMapper.writeValue(outputStream, root);
+                    }
+                }
+            }
+        } else {
+            try (InputStream inputStream = response.body();
+                 FileOutputStream outputStream = new FileOutputStream(filePath.toFile())) {
+                inputStream.transferTo(outputStream);
+            }
         }
 
         long writeTime = System.currentTimeMillis() - writeStart;
@@ -537,25 +561,67 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
         String url = baseUrl + "/update";
         String contentType = format.equals("csv") ? "application/csv" : "application/json";
 
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(Duration.ofMinutes(10))
-                .header("Content-Type", contentType)
-                .POST(HttpRequest.BodyPublishers.ofFile(file.toPath()))
-                .build();
+        Path pathToSend = file.toPath();
+        boolean isTempFile = false;
 
-        long uploadStart = System.currentTimeMillis();
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-        long uploadTime = System.currentTimeMillis() - uploadStart;
-
-        if (response.statusCode() != 200) {
-            throw new RuntimeException("SOLR import failed for file " + file.getName() +
-                    " with status: " + response.statusCode() + " - " + response.body());
+        if (format.equals("json")) {
+            try {
+                JsonNode root = jsonMapper.readTree(file);
+                JsonNode docs = root;
+                if (root.isObject() && root.has("response") && root.get("response").has("docs")) {
+                    docs = root.get("response").get("docs");
+                }
+                if (docs.isArray()) {
+                    for (JsonNode doc : docs) {
+                        if (doc.isObject()) {
+                            com.fasterxml.jackson.databind.node.ObjectNode objectNode =
+                                    (com.fasterxml.jackson.databind.node.ObjectNode) doc;
+                            objectNode.remove("_version_");
+                            objectNode.remove("_root_");
+                        }
+                    }
+                    Path tempFile = Files.createTempFile("solr_import_", ".json");
+                    try (FileOutputStream outputStream = new FileOutputStream(tempFile.toFile())) {
+                        jsonMapper.writeValue(outputStream, docs);
+                    }
+                    pathToSend = tempFile;
+                    isTempFile = true;
+                }
+            } catch (Exception e) {
+                log.warn("Failed to preprocess JSON file {}, posting raw file instead: {}",
+                        file.getName(), e.getMessage());
+            }
         }
 
-        long totalTime = System.currentTimeMillis() - fileStart;
-        handler.logInfo("Thread '" + currentThread.getName() + "' completed import of '" + file.getName() +
-                        "' in " + totalTime + " ms (upload: " + uploadTime + "ms)");
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofMinutes(10))
+                    .header("Content-Type", contentType)
+                    .POST(HttpRequest.BodyPublishers.ofFile(pathToSend))
+                    .build();
+
+            long uploadStart = System.currentTimeMillis();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            long uploadTime = System.currentTimeMillis() - uploadStart;
+
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("SOLR import failed for file " + file.getName() +
+                        " with status: " + response.statusCode() + " - " + response.body());
+            }
+
+            long totalTime = System.currentTimeMillis() - fileStart;
+            handler.logInfo("Thread '" + currentThread.getName() + "' completed import of '" + file.getName() +
+                            "' in " + totalTime + " ms (upload: " + uploadTime + "ms)");
+        } finally {
+            if (isTempFile) {
+                try {
+                    Files.deleteIfExists(pathToSend);
+                } catch (Exception e) {
+                    log.warn("Failed to delete temp file: {}", pathToSend, e);
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## References
* Fixes #12684

## Description
This change fixes the JSON export and import functionalities in the `solr-core-management` command. It extracts and cleans the documents array from the Solr JSON response, removing internal metadata fields like `_version_` and `_root_` before performing updates.

## Instructions for Reviewers
List of changes in this PR:
* **Export Preprocessing**: Modifies the JSON export to parse the raw Solr response, extract the `response.docs` list, clean out internal fields (`_version_`, `_root_`), and write them to the export file as a clean JSON array.
* **Import Preprocessing & Cleanups**: Updates the JSON import to accept both clean JSON document arrays and wrapped Solr responses. It strips out internal fields before POSTing to the `/update` endpoint to prevent conflicts.
* **Temp File Management**: Cleaned JSON updates are processed via a temporary JSON file, which is posted to Solr and then cleaned up in a `finally` block.
* **Fallback Handler**: Includes a fallback to posting the raw file directly if JSON parsing or preprocessing fails.

### Testing / Review Steps:
1. Export a small Solr core in JSON format:
   ```bash
   [dspace]/bin/dspace solr-core-management -c audit -m export -f json -d /tmp/auditexport/
   ```
2. Verify that the generated `.json` files contain clean arrays of documents (e.g. `[ { "id": "..." } ]`) instead of wrapped search responses (e.g. `{"responseHeader":..., "response":{"docs":[...]}}`).
3. Import the directory back:
   ```bash
   [dspace]/bin/dspace solr-core-management -c audit -m import -f json -d /tmp/auditexport/
   ```
4. Verify that the import succeeds without `400 - Unknown command 'responseHeader'` errors.
5. (Optional) Attempt to import an older exported JSON file that contains a wrapped Solr response, verifying that it is preprocessed and imported successfully.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (less than 1,000 lines of code).
- [x] My PR **passes Checkstyle** validation based on the Code Style Guide.
- [x] My PR **includes Javadoc** for all new (or modified) public methods and classes.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests**.
- [x] My PR **includes details on how to test it**.
- [ ] If my PR includes new libraries/dependencies, I've made sure their licenses align with the DSpace BSD License. *(N/A - no new dependencies)*
- [ ] If my PR modifies REST API endpoints, I've opened a separate REST Contract PR related to this change. *(N/A - CLI/REST Script internal behavior only)*
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. *(N/A - no new configurations)*
- [x] If my PR fixes an issue ticket, I've linked them together.