### PR TITLE
[GitHub Actions] Don't run tests or docker build if the only changes are to markdown files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,23 @@
 name: Build
 
 # Run this Build for all pushes / PRs to current branch
-on: [push, pull_request]
+on:
+  push:
+    # Don't run if PR is only updating static documentation
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
+  pull_request:
+    # Don't run if PR is only updating static documentation
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -17,8 +17,11 @@ on:
       - 'dspace-**'
     # Don't run if PR is only updating static documentation
     paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
       - '**/*.md'
-      - '**/*.txt'
   schedule:
     - cron: "37 0 * * 1"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,21 @@ on:
       - 'dspace-**'
     tags:
       - 'dspace-**'
+    # Don't run if PR is only updating static documentation
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
   pull_request:
+    # Don't run if PR is only updating static documentation
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - 'LICENSES_THIRD_PARTY'
+      - 'NOTICE'
+      - '**/*.md'
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)


### PR DESCRIPTION
## References

* Frontend version of this PR is at https://github.com/DSpace/dspace-angular/pull/5966

## Description

This small PR updates our GitHub actions to **skip running** any tests (both Unit and Integration) or Docker builds when a PR or commit **only includes changes to Markdown files** (`*.md`).

The reason for this PR is to streamline our ability to update Markdown files without triggering CI, e.g. with #12739

**Known Side Effect:**  

While this will ensure that we don't unnecessarily run tests/builds, disabling these checks will mean that PRs which only modify Markdown (`*.md`) will **never receive a green checkmark from GitHub checks** (as some checks will never complete).  

You can see an example of this "side effect" in #12739, which doesn't have a green checkmark as the `CodeQL` task is flagged as `Expected -- Waiting for status to be reported`.  In this situation, `CodeQL` will **never run** for PRs which only modify Markdown as it already has `paths-ignore` rules in `codescan.yml`, see https://github.com/DSpace/DSpace/blob/main/.github/workflows/codescan.yml#L20

(Personally, I'm OK with this side effect as it seems minor, but I wanted to make sure others agree.)

## Instructions for Reviewers
* Review the changes & verify that you are aware of the side effects listed above.


If approved, this should be ported to `DSpace/dspace-angular`, as it should similarly ignore PRs that only include changes to Markdown files.