### PR TITLE
Report actual target directory in batch import unzip error log (#11954)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -1977,9 +1977,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
 
         File tempdir = new File(destinationDir);
         if (!tempdir.isDirectory()) {
-            logError("'" + configurationService.getProperty("org.dspace.app.batchitemimport.work.dir") +
-                          "' as defined by the key 'org.dspace.app.batchitemimport.work.dir' in dspace.cfg " +
-                          "is not a valid directory");
+            logError("'" + destinationDir + "' is not a valid directory");
         }
 
         if (!tempdir.exists() && !tempdir.mkdirs()) {


### PR DESCRIPTION
## References
* Fixes #11954

## Description
In `ItemImportServiceImpl.unzip(File, String)`, when the target directory is invalid the error log printed the value of the `org.dspace.app.batchitemimport.work.dir` config property rather than the directory actually being used. This PR logs the real `destinationDir` instead.

## Instructions for Reviewers
List of changes in this PR:
* In `unzip(File zipfile, String destDir)`, the "is not a valid directory" error now reports the actual `destinationDir` that was validated (i.e. the passed-in `destDir`, or the configured work dir when `destDir` is `null`).
* Removed the hard-coded reference to the `org.dspace.app.batchitemimport.work.dir` key from that message, since it is inaccurate when a caller supplies its own `destDir` — e.g. `processUIImport`, which passes its own `dataDir`. This was the misleading behavior described in the issue.

How to review:
* See `dspace-api/.../itemimport/ItemImportServiceImpl.java`, method `unzip(File, String)`.
* Previously a UI batch import (ZIP) that hit an invalid working folder logged the config default path regardless of the folder actually passed; now the logged path matches the directory in use.

Note: this is a log-message correctness fix with no change to control flow or behavior, so no functional unit test is included. Happy to add a log-capture test if reviewers would prefer one.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size**.
- [x] My PR **passes Checkstyle** validation based on the Code Style Guide.
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_ (no public API changed).
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** (logging-only change; see note above).
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies, licenses align (none added).
- [x] If my PR modifies REST API endpoints, a REST Contract PR is opened (N/A).
- [x] If my PR includes new configurations, technical documentation is provided (none added).
- [x] If my PR fixes an issue ticket, I've linked them together.