### PR TITLE
LDAP: Allow authentication via email address in addition to ID field

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -465,7 +465,8 @@ public class LDAPAuthentication implements AuthenticationMethod {
             ldap_surname_field = configurationService.getProperty("authentication-ldap.surname_field");
             ldap_phone_field = configurationService.getProperty("authentication-ldap.phone_field");
             ldap_group_field = configurationService.getProperty("authentication-ldap.login.groupmap.attribute");
-            includeMailFilter = configurationService.getBooleanProperty("authentication-ldap.include_mail_filter", false);
+            includeMailFilter =
+                configurationService.getBooleanProperty("authentication-ldap.include_mail_filter", false);
             useTLS = configurationService.getBooleanProperty("authentication-ldap.starttls", false);
 
             setupSpringLdap(configurationService);

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -500,7 +500,9 @@ public class LDAPAuthentication implements AuthenticationMethod {
             try {
                 Filter filter;
                 if (includeMailFilter) {
-                    filter = new OrFilter().or(new EqualsFilter(ldap_id_field, netid)).or(new EqualsFilter(ldap_email_field, netid));
+                    filter = new OrFilter().or(
+                        new EqualsFilter(ldap_id_field, netid)).or(new EqualsFilter(ldap_email_field, netid)
+                    );
                 } else {
                     filter = new EqualsFilter(ldap_id_field, netid);
                 }

--- a/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/LDAPAuthentication.java
@@ -39,6 +39,8 @@ import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.ldap.filter.EqualsFilter;
+import org.springframework.ldap.filter.Filter;
+import org.springframework.ldap.filter.OrFilter;
 import org.springframework.ldap.filter.PresentFilter;
 import org.springframework.ldap.query.LdapQueryBuilder;
 import org.springframework.ldap.support.LdapNameBuilder;
@@ -325,7 +327,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
                             log.info(LogHelper.getHeader(context,
                                                           "type=ldap-login", "type=ldap_but_already_email"));
                             context.turnOffAuthorisationSystem();
-                            setEpersonAttributes(context, eperson, ldap, Optional.of(netid), email);
+                            setEpersonAttributes(context, eperson, ldap, Optional.of(ldap.uid), email);
                             ePersonService.update(context, eperson);
                             context.dispatchEvents();
                             context.restoreAuthSystemState();
@@ -342,7 +344,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
                                 try {
                                     context.turnOffAuthorisationSystem();
                                     eperson = ePersonService.create(context);
-                                    setEpersonAttributes(context, eperson, ldap, Optional.of(netid), email);
+                                    setEpersonAttributes(context, eperson, ldap, Optional.of(ldap.uid), email);
                                     eperson.setCanLogIn(true);
                                     authenticationService.initEPerson(context, request, eperson);
                                     ePersonService.update(context, eperson);
@@ -424,6 +426,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
 
         private Logger log = null;
 
+        protected String uid = null;
         protected String ldapEmail = null;
         protected String ldapGivenName = null;
         protected String ldapSurname = null;
@@ -443,6 +446,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
         final String ldap_surname_field;
         final String ldap_phone_field;
         final String ldap_group_field;
+        private boolean includeMailFilter;
         final boolean useTLS;
 
         private LdapTemplate ldapTemplate;
@@ -461,6 +465,7 @@ public class LDAPAuthentication implements AuthenticationMethod {
             ldap_surname_field = configurationService.getProperty("authentication-ldap.surname_field");
             ldap_phone_field = configurationService.getProperty("authentication-ldap.phone_field");
             ldap_group_field = configurationService.getProperty("authentication-ldap.login.groupmap.attribute");
+            includeMailFilter = configurationService.getBooleanProperty("authentication-ldap.include_mail_filter", false);
             useTLS = configurationService.getBooleanProperty("authentication-ldap.starttls", false);
 
             setupSpringLdap(configurationService);
@@ -493,14 +498,20 @@ public class LDAPAuthentication implements AuthenticationMethod {
 
         protected String getDNOfUser(Context context, String netid) {
             try {
-                EqualsFilter filter = new EqualsFilter(ldap_id_field, netid);
-
+                Filter filter;
+                if (includeMailFilter) {
+                    filter = new OrFilter().or(new EqualsFilter(ldap_id_field, netid)).or(new EqualsFilter(ldap_email_field, netid));
+                } else {
+                    filter = new EqualsFilter(ldap_id_field, netid);
+                }
                 log.debug("Searching for user using Spring LDAP filter: {}", filter.toString());
 
                 List<String> foundDNs = ldapTemplate.search(
                     LdapQueryBuilder.query().base(ldap_search_context).filter(filter),
                     (ContextMapper<String>) (originalCtx) -> {
                         DirContextOperations ctx = (DirContextOperations) originalCtx;
+
+                        this.uid = ctx.getStringAttribute(ldap_id_field);
 
                         if (ldap_email_field != null) {
                             this.ldapEmail = ctx.getStringAttribute(ldap_email_field);

--- a/dspace/config/modules/authentication-ldap.cfg
+++ b/dspace/config/modules/authentication-ldap.cfg
@@ -162,3 +162,6 @@ authentication-ldap.autoregister = true
 # Enables support for StartTLS (default is false). If this flag is true be sure provider_url looks like:
 # ldap://ldap.myu.edu:389
 #authentication-ldap.starttls=true
+
+# Enables matching against the email_field in addition to id_field when looking up a user (default is false).
+#authentication-ldap.include_mail_filter=true


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #12794 (if this fixes an issue ticket)

## Description
Adds a configurable option (`"authentication-ldap.include_mail_filter`, default: `false`) that extends the LDAP authentication filter to optionally match the login value against either the configured ID field or the mail field, in addition to the existing ID-only lookup. 

Due to this change, the `netid` parameter used inside the `` function is always based on the ldap uid field in order to prevent the netid changes in case a user used an email instead of its account id as before.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Added a new configuration property `authentication-ldap.include_mail_filter` (default: `false`) to `LDAPAuthentication`.
* Extended `getDNOfUser` to build an `OrFilter` combining `ldap_id_field` and `ldap_email_field` when `include_mail_filter` is enabled, instead of always using a single `EqualsFilter` on `ldap_id_field`.
* Added a new `uid` field to capture the actual LDAP `ldap_id_field` value returned from the directory lookup, since this may now differ from the originally entered `netid` (e.g. when logging in via email).
* Updated `setEpersonAttributes` calls to use `ldap.uid` instead of the raw `netid` parameter, ensuring the ePerson's netid is always set to the actual LDAP ID field value rather than whatever the user typed in the login form.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

In order to test this feature, you need a LDAP server and configure DSpace to use it appropriately. 
During development of this feature I used the following `docker-compose` configuration - which may aid during tests

**ldap service**
I used this image: https://github.com/rroemhild/docker-test-openldap On the project page, the available users, their ids and emails can be seen

```
ldap:
  container_name: dspaceldap
  image: rroemhild/test-openldap:2.1
  ulimits:
    nofile:
      soft: 1024
      hard: 1024
  ports:
    - 10389:389
  networks:
    - dspacenet
```

**dspace config**
The following parameters where added to the `environment` block of the `dspace` service:

```
plugin__P__sequence__P__org__P__dspace__P__authenticate__P__AuthenticationMethod: org.dspace.authenticate.LDAPAuthentication,org.dspace.authenticate.PasswordAuthentication
authentication__D__ldap__P__enable: true
authentication__D__ldap__P__autoregister: true
authentication__D__ldap__P__include_mail_filter: true
authentication__D__ldap__P__provider_url: ldap://dspaceldap:10389/
authentication__D__ldap__P__id_field: uid
authentication__D__ldap__P__object_context: dc=planetexpress\,dc=com
authentication__D__ldap__P__search_context: dc=planetexpress\,dc=com
authentication__D__ldap__P__email_field: mail
authentication__D__ldap__P__surname_field: sn
authentication__D__ldap__P__givenname_field: givenName
authentication__D__ldap__P__search__P__user: 
authentication__D__ldap__P__search__P__password: 
authentication__D__ldap__P__search_scope: 2
authentication__D__ldap__P__search__P__anonymous: true
``` 

When `authentication-ldap.include_mail_filter` is set to `true`, login via mail and uid is possible.
When `authentication-ldap.include_mail_filter` is set to `false` only login via uid is possible.

In both cases, always the `uid` is used as `netid` inside the eperson table

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
