### PR TITLE
Content-based bitstream format identification (Apache Tika) with re-identification tooling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
@@ -7,18 +7,26 @@
  */
 package org.dspace.content;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.tika.Tika;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.dao.BitstreamFormatDAO;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
+import org.dspace.services.ConfigurationService;
+import org.dspace.storage.bitstore.service.BitstreamStorageService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -35,11 +43,37 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
      */
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(BitstreamFormat.class);
 
+    /**
+     * Configuration property that enables content-based (Apache Tika) format
+     * identification. When {@code false}, only the legacy filename-extension
+     * identification is used. Defaults to {@code true}.
+     */
+    protected static final String CFG_IDENTIFY_BY_CONTENT = "bitstream.format.identification.by-content.enabled";
+
+    /**
+     * MIME type Apache Tika returns when it cannot recognise the content. It is
+     * also the MIME type of the registry's "Unknown" format, so we treat it as
+     * "not identified" and fall back to extension-based identification.
+     */
+    protected static final String UNKNOWN_MIME_TYPE = "application/octet-stream";
+
     @Autowired(required = true)
     protected BitstreamFormatDAO bitstreamFormatDAO;
 
     @Autowired(required = true)
     protected AuthorizeService authorizeService;
+
+    @Autowired(required = true)
+    protected BitstreamStorageService bitstreamStorageService;
+
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
+
+    /**
+     * Apache Tika facade used for content-based (magic byte / container) format
+     * identification. Tika is thread-safe, so a single instance is reused.
+     */
+    private final Tika tika = new Tika();
 
     protected BitstreamFormatServiceImpl() {
 
@@ -236,9 +270,84 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
 
     @Override
     public BitstreamFormat guessFormat(Context context, Bitstream bitstream) throws SQLException {
+        // Content-based identification (Apache Tika) takes precedence: it inspects the
+        // actual file content (magic bytes / container structure) instead of trusting the
+        // filename extension, which may be missing, wrong, or deliberately misleading. The
+        // filename is passed to Tika only as a hint. Can be disabled via configuration to
+        // fall back to the legacy extension-only behaviour.
+        if (configurationService.getBooleanProperty(CFG_IDENTIFY_BY_CONTENT, true)) {
+            BitstreamFormat format = guessFormatByContent(context, bitstream);
+            if (format != null) {
+                return format;
+            }
+        }
+
+        // Fall back to filename-extension identification when content detection is disabled
+        // or inconclusive (e.g. the detected MIME type is not present in the registry).
+        return guessFormatByExtension(context, bitstream);
+    }
+
+    /**
+     * Identify a bitstream's format from its actual content, using Apache Tika. The
+     * bitstream's filename (if any) is supplied to Tika only as a hint to disambiguate
+     * content that magic-byte detection alone cannot separate. If the content cannot be
+     * read, Tika cannot recognise it, or the detected MIME type is not present in the
+     * bitstream format registry, {@code null} is returned so the caller can fall back to
+     * extension-based identification.
+     *
+     * @param context   DSpace context object
+     * @param bitstream the bitstream to identify
+     * @return the matching {@link BitstreamFormat}, or {@code null} if it could not be
+     *         determined from the content
+     * @throws SQLException if a database error occurs
+     */
+    protected BitstreamFormat guessFormatByContent(Context context, Bitstream bitstream) throws SQLException {
+        String mimeType;
+        try (InputStream inputStream = bitstreamStorageService.retrieve(context, bitstream)) {
+            if (inputStream == null) {
+                return null;
+            }
+            Metadata metadata = new Metadata();
+            String name = bitstream.getName();
+            if (name != null) {
+                // Provide the filename as a detection hint; it does not override the content.
+                metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+            }
+            // Wrap in a TikaInputStream so container-aware detectors (e.g. OLE2/OOXML for
+            // legacy and modern Office documents) can inspect the file properly.
+            try (TikaInputStream tikaStream = TikaInputStream.get(inputStream)) {
+                mimeType = tika.detect(tikaStream, metadata);
+            }
+        } catch (IOException e) {
+            log.warn(LogHelper.getHeader(context, "guess_format_by_content",
+                "Unable to read content of bitstream " + bitstream.getID()
+                    + " for format identification; falling back to filename"), e);
+            return null;
+        }
+
+        // Tika returns application/octet-stream when it cannot recognise the content.
+        if (mimeType == null || mimeType.equalsIgnoreCase(UNKNOWN_MIME_TYPE)) {
+            return null;
+        }
+
+        // Map the detected MIME type onto a (non-internal) registry format. Returns null
+        // when the registry does not list this MIME type, letting the extension fallback try.
+        return findByMIMEType(context, mimeType);
+    }
+
+    /**
+     * Identify a bitstream's format solely from its filename extension (the legacy
+     * behaviour). Used as a fallback when content-based identification is disabled or
+     * inconclusive.
+     *
+     * @param context   DSpace context object
+     * @param bitstream the bitstream to identify
+     * @return the matching {@link BitstreamFormat}, or {@code null} if the extension is
+     *         missing or unknown
+     * @throws SQLException if a database error occurs
+     */
+    protected BitstreamFormat guessFormatByExtension(Context context, Bitstream bitstream) throws SQLException {
         String filename = bitstream.getName();
-        // FIXME: Just setting format to first guess
-        // For now just get the file name
 
         // Gracefully handle the null case
         if (filename == null) {
@@ -247,8 +356,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
 
         filename = filename.toLowerCase();
 
-        // This isn't rocket science. We just get the name of the
-        // bitstream, get the extension, and see if we know the type.
+        // Get the name of the bitstream, get the extension, and see if we know the type.
         String extension = filename;
         int lastDot = filename.lastIndexOf('.');
 

--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.logging.log4j.Logger;
 import org.apache.tika.Tika;
 import org.apache.tika.io.TikaInputStream;
@@ -49,6 +50,17 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
      * identification is used. Defaults to {@code true}.
      */
     protected static final String CFG_IDENTIFY_BY_CONTENT = "bitstream.format.identification.by-content.enabled";
+
+    /**
+     * Configuration property bounding how many bytes of a bitstream's content are read for
+     * content-based identification. This keeps identification cheap for very large files
+     * (especially container formats such as ZIP/OOXML which Tika would otherwise spool to a
+     * temporary file in full). A value of {@code 0} or less means "read the whole file".
+     */
+    protected static final String CFG_MAX_BYTES = "bitstream.format.identification.by-content.max-bytes";
+
+    /** Default byte bound for content-based identification (32 MiB). */
+    protected static final long DEFAULT_MAX_BYTES = 32L * 1024 * 1024;
 
     /**
      * MIME type Apache Tika returns when it cannot recognise the content. It is
@@ -303,9 +315,22 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
      */
     protected BitstreamFormat guessFormatByContent(Context context, Bitstream bitstream) throws SQLException {
         String mimeType;
+        long maxBytes = configurationService.getLongProperty(CFG_MAX_BYTES, DEFAULT_MAX_BYTES);
         try (InputStream inputStream = bitstreamStorageService.retrieve(context, bitstream)) {
             if (inputStream == null) {
                 return null;
+            }
+            // Bound how many bytes Tika may read/spool so that identifying a very large file
+            // (in particular container formats, which Tika spools to a temporary file to
+            // inspect) stays cheap. Type signatures sit at the start of the file, so a
+            // bounded prefix is enough for the common cases; anything not identified within
+            // the bound falls back to extension-based identification.
+            InputStream boundedStream = inputStream;
+            if (maxBytes > 0) {
+                boundedStream = BoundedInputStream.builder()
+                                                  .setInputStream(inputStream)
+                                                  .setMaxCount(maxBytes)
+                                                  .get();
             }
             Metadata metadata = new Metadata();
             String name = bitstream.getName();
@@ -315,7 +340,7 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
             }
             // Wrap in a TikaInputStream so container-aware detectors (e.g. OLE2/OOXML for
             // legacy and modern Office documents) can inspect the file properly.
-            try (TikaInputStream tikaStream = TikaInputStream.get(inputStream)) {
+            try (TikaInputStream tikaStream = TikaInputStream.get(boundedStream)) {
                 mimeType = tika.detect(tikaStream, metadata);
             }
         } catch (IOException e) {

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamFormatDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/BitstreamFormatDAOImpl.java
@@ -132,7 +132,11 @@ public class BitstreamFormatDAOImpl extends AbstractHibernateDAO<BitstreamFormat
     @Override
     public List<BitstreamFormat> findByFileExtension(Context context, String extension) throws SQLException {
 
-        Query query = createQuery(context, "from BitstreamFormat bf where :extension in elements(bf.fileExtensions)");
+        // Order by id so that, when more than one format claims the same extension, the
+        // caller (e.g. BitstreamFormatService.guessFormat) always gets a deterministic
+        // result instead of one that depends on database row order.
+        Query query = createQuery(context,
+            "from BitstreamFormat bf where :extension in elements(bf.fileExtensions) order by bf.id");
         query.setParameter("extension", extension);
 
         return list(query);

--- a/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormats.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormats.java
@@ -1,0 +1,124 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Bitstream;
+import org.dspace.content.BitstreamFormat;
+import org.dspace.content.Bundle;
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Context;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.curate.Curator;
+import org.dspace.curate.Distributive;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+
+/**
+ * IdentifyFormats re-runs bitstream format identification
+ * ({@link BitstreamFormatService#guessFormat(Context, Bitstream)}) over the bitstreams of
+ * the passed object and updates any whose format can now be determined. Because the modern
+ * identification is content-based (Apache Tika), this can correct bitstreams that were
+ * previously stored as "Unknown" (application/octet-stream) because their filename had a
+ * missing, wrong, or unregistered extension.
+ *
+ * <p>By default only bitstreams currently labelled "Unknown" are re-identified. Set
+ * {@code curate.identifyformats.process-all = true} to re-identify every bitstream (this
+ * may reclassify bitstreams whose stored format disagrees with their actual content).
+ *
+ * <p>The task writes changes, so it must be run by an administrator (e.g.
+ * {@code dspace curate -e admin@example.org -t identifyformats -i <handle|uuid>}).
+ *
+ * @author DSpace
+ */
+@Distributive
+public class IdentifyFormats extends AbstractCurationTask {
+
+    protected static final String CFG_PROCESS_ALL = "curate.identifyformats.process-all";
+
+    protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
+    protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance()
+                                                                                   .getBitstreamFormatService();
+    protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
+                                                                               .getConfigurationService();
+
+    // counters accumulated across the distributed items
+    private int examined;
+    private int corrected;
+    private int stillUnidentified;
+    private StringBuilder changes;
+
+    @Override
+    public int perform(Context context, DSpaceObject dso) throws IOException {
+        examined = 0;
+        corrected = 0;
+        stillUnidentified = 0;
+        changes = new StringBuilder();
+
+        distribute(context, dso);
+
+        StringBuilder result = new StringBuilder();
+        result.append("Bitstream format identification: examined ").append(examined)
+              .append(" bitstream(s), corrected ").append(corrected)
+              .append(", still unidentified ").append(stillUnidentified).append(".\n");
+        if (changes.length() > 0) {
+            result.append(changes);
+        }
+        report(result.toString());
+        setResult(result.toString());
+        return Curator.CURATE_SUCCESS;
+    }
+
+    @Override
+    protected void performItem(Context context, Item item) throws SQLException, IOException {
+        boolean processAll = configurationService.getBooleanProperty(CFG_PROCESS_ALL, false);
+        BitstreamFormat unknownFormat = bitstreamFormatService.findUnknown(context);
+
+        for (Bundle bundle : item.getBundles()) {
+            for (Bitstream bitstream : bundle.getBitstreams()) {
+                BitstreamFormat currentFormat = bitstream.getFormat(context);
+                boolean isUnknown = currentFormat == null
+                    || currentFormat.getID().equals(unknownFormat.getID());
+
+                // By default only attempt to fix bitstreams that are currently unidentified.
+                if (!processAll && !isUnknown) {
+                    continue;
+                }
+                examined++;
+
+                BitstreamFormat guessed = bitstreamFormatService.guessFormat(context, bitstream);
+                boolean guessedUsable = guessed != null && !guessed.getID().equals(unknownFormat.getID());
+
+                if (guessedUsable && (currentFormat == null || !guessed.getID().equals(currentFormat.getID()))) {
+                    String from = currentFormat == null ? "Unknown" : currentFormat.getShortDescription();
+                    try {
+                        bitstreamService.setFormat(context, bitstream, guessed);
+                        bitstreamService.update(context, bitstream);
+                    } catch (AuthorizeException e) {
+                        throw new IOException("Not authorized to update format of bitstream "
+                            + bitstream.getID(), e);
+                    }
+                    corrected++;
+                    changes.append(" - bitstream ").append(bitstream.getID())
+                           .append(" (item ").append(item.getHandle()).append("): ")
+                           .append(from).append(" -> ").append(guessed.getShortDescription())
+                           .append(" (").append(guessed.getMIMEType()).append(")\n");
+                } else if (isUnknown) {
+                    stillUnidentified++;
+                }
+            }
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScript.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScript.java
@@ -1,0 +1,106 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+import org.apache.commons.cli.ParseException;
+import org.dspace.content.Site;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.SiteService;
+import org.dspace.core.Context;
+import org.dspace.curate.Curator;
+import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.utils.DSpace;
+
+/**
+ * Process/script wrapper around the {@link IdentifyFormats} curation task. It re-runs
+ * bitstream format identification and corrects bitstreams stored as "Unknown". Unlike
+ * running the generic {@code curate} script, this script defaults to the whole repository
+ * when no target is given, so an administrator can fix mislabelled bitstreams across the
+ * site from the Admin UI (Administrative &gt; Processes) or the CLI in one step.
+ *
+ * <p>The correction logic is not duplicated here: this script simply invokes the
+ * {@code identifyformats} curation task through a {@link Curator}.
+ *
+ * @author DSpace
+ */
+public class IdentifyFormatsScript extends DSpaceRunnable<IdentifyFormatsScriptConfiguration<IdentifyFormatsScript>> {
+
+    /** Registered id of the curation task this script delegates to (see curate.cfg). */
+    protected static final String TASK_NAME = "identifyformats";
+
+    protected SiteService siteService;
+    protected ConfigurationService configurationService;
+
+    protected String identifier;
+    protected boolean processAll;
+    protected boolean help;
+
+    @Override
+    public IdentifyFormatsScriptConfiguration<IdentifyFormatsScript> getScriptConfiguration() {
+        return new DSpace().getServiceManager()
+            .getServiceByName("identify-formats", IdentifyFormatsScriptConfiguration.class);
+    }
+
+    @Override
+    public void setup() throws ParseException {
+        this.siteService = ContentServiceFactory.getInstance().getSiteService();
+        this.configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+
+        this.help = commandLine.hasOption('h');
+        this.identifier = commandLine.getOptionValue('i');
+        this.processAll = commandLine.hasOption('a');
+    }
+
+    @Override
+    public void internalRun() throws Exception {
+        if (help) {
+            printHelp();
+            return;
+        }
+
+        Context context = new Context();
+        context.turnOffAuthorisationSystem();
+
+        // Optionally widen the task to all bitstreams (not just Unknown) for the duration
+        // of this run, restoring the previous configuration afterwards.
+        String previousProcessAll = configurationService.getProperty(IdentifyFormats.CFG_PROCESS_ALL);
+        if (processAll) {
+            configurationService.setProperty(IdentifyFormats.CFG_PROCESS_ALL, "true");
+        }
+
+        try {
+            Curator curator = new Curator(handler);
+            // A reporter must be set: without one, Curator.report() (called by the task)
+            // routes through the handler with an unparseable format string. The task's full
+            // result is surfaced to the process log via getResult() below, so the reporter
+            // content itself is not needed here.
+            curator.setReporter(new StringBuilder());
+            curator.addTask(context, TASK_NAME);
+
+            if (identifier != null) {
+                handler.logInfo("Identifying bitstream formats under: " + identifier);
+                curator.curate(context, identifier);
+            } else {
+                handler.logInfo("Identifying bitstream formats across the whole repository");
+                Site site = siteService.findSite(context);
+                curator.curate(context, site);
+            }
+
+            handler.logInfo(curator.getResult(TASK_NAME));
+            context.restoreAuthSystemState();
+            context.complete();
+        } catch (Exception e) {
+            context.abort();
+            throw e;
+        } finally {
+            configurationService.setProperty(IdentifyFormats.CFG_PROCESS_ALL, previousProcessAll);
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScriptCli.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScriptCli.java
@@ -1,0 +1,15 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+/**
+ * The {@link IdentifyFormatsScript} for CLI.
+ */
+public class IdentifyFormatsScriptCli extends IdentifyFormatsScript {
+
+}

--- a/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScriptCliConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScriptCliConfiguration.java
@@ -1,0 +1,16 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+/**
+ * The {@link IdentifyFormatsScriptConfiguration} for CLI.
+ */
+public class IdentifyFormatsScriptCliConfiguration
+    extends IdentifyFormatsScriptConfiguration<IdentifyFormatsScriptCli> {
+
+}

--- a/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScriptConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/general/IdentifyFormatsScriptConfiguration.java
@@ -1,0 +1,51 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+import org.apache.commons.cli.Options;
+import org.dspace.scripts.configuration.ScriptConfiguration;
+
+/**
+ * The {@link ScriptConfiguration} for the {@link IdentifyFormatsScript}.
+ */
+public class IdentifyFormatsScriptConfiguration<T extends IdentifyFormatsScript> extends ScriptConfiguration<T> {
+
+    private Class<T> dspaceRunnableClass;
+
+    @Override
+    public Options getOptions() {
+        if (options == null) {
+
+            Options options = new Options();
+
+            options.addOption("i", "identifier", true,
+                "handle or UUID of the community, collection or item to process; "
+                    + "if omitted, the whole repository is processed");
+
+            options.addOption("a", "all", false,
+                "re-identify every bitstream, not only those currently stored as Unknown");
+            options.getOption("a").setType(boolean.class);
+
+            options.addOption("h", "help", false, "help");
+
+            super.options = options;
+        }
+        return options;
+    }
+
+    @Override
+    public Class<T> getDspaceRunnableClass() {
+        return dspaceRunnableClass;
+    }
+
+    @Override
+    public void setDspaceRunnableClass(Class<T> dspaceRunnableClass) {
+        this.dspaceRunnableClass = dspaceRunnableClass;
+    }
+
+}

--- a/dspace-api/src/test/data/dspaceFolder/config/modules/curate.cfg
+++ b/dspace-api/src/test/data/dspaceFolder/config/modules/curate.cfg
@@ -14,6 +14,7 @@ plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredM
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MicrosoftTranslator = translate
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MetadataValueLinkChecker = checklinks
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.IdentifyFormats = identifyformats
 # add new tasks here (or in additional config files)
 
 # Testing tasks

--- a/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
+++ b/dspace-api/src/test/data/dspaceFolder/config/spring/api/scripts.xml
@@ -50,6 +50,11 @@
         <property name="dspaceRunnableClass" value="org.dspace.app.bulkedit.MetadataDeletionCli"/>
     </bean>
 
+    <bean id="identify-formats" class="org.dspace.ctask.general.IdentifyFormatsScriptCliConfiguration">
+        <property name="description" value="Re-identify bitstream formats and correct those stored as Unknown"/>
+        <property name="dspaceRunnableClass" value="org.dspace.ctask.general.IdentifyFormatsScriptCli"/>
+    </bean>
+
     <bean id="filter-media" class="org.dspace.app.mediafilter.MediaFilterScriptConfiguration">
         <property name="description" value="Perform the media filtering to extract full text from documents and to create thumbnails"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.mediafilter.MediaFilterScript"/>

--- a/dspace-api/src/test/java/org/dspace/content/FormatIdentifierTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/FormatIdentifierTest.java
@@ -8,6 +8,7 @@
 package org.dspace.content;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -18,12 +19,14 @@ import org.dspace.AbstractUnitTest;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.content.service.BitstreamService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Unit Tests for class FormatIdentifier
+ * Unit Tests for bitstream format identification (BitstreamFormatService#guessFormat).
  *
  * @author pvillega
  */
@@ -32,6 +35,8 @@ public class FormatIdentifierTest extends AbstractUnitTest {
     protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance()
                                                                                    .getBitstreamFormatService();
+    protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
+                                                                               .getConfigurationService();
 
     /**
      * This method will be run before every test as per @Before. It will
@@ -56,40 +61,70 @@ public class FormatIdentifierTest extends AbstractUnitTest {
     @After
     @Override
     public void destroy() {
+        // Reset any override of the content-based identification toggle
+        configurationService.setProperty("bitstream.format.identification.by-content.enabled", null);
         super.destroy();
     }
 
     /**
-     * Test of guessFormat method, of class FormatIdentifier.
+     * Content-based identification (the default): the real format is detected from the
+     * file content, even when the filename extension is missing, empty, or misleading.
+     * The test bitstream ({@code test.bitstream}) is a PDF.
      */
     @Test
-    public void testGuessFormat() throws Exception {
+    public void testGuessFormatByContent() throws Exception {
         File f = new File(testProps.get("test.bitstream").toString());
-        Bitstream bs;
-        BitstreamFormat result;
         BitstreamFormat pdf = bitstreamFormatService.findByShortDescription(context, "Adobe PDF");
 
-        //test null filename
-        //TODO: the check if filename is null is wrong, as it checks after using a toLowerCase
-        //which can trigger the NPE
-        bs = bitstreamService.create(context, new FileInputStream(f));
+        // No filename at all: still detected as PDF from its content.
+        Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
         bs.setName(context, null);
-        result = bitstreamFormatService.guessFormat(context, bs);
-        assertThat("testGuessFormat 0", result, nullValue());
+        BitstreamFormat result = bitstreamFormatService.guessFormat(context, bs);
+        assertThat("content detection with null name is not null", result, notNullValue());
+        assertThat("content detection with null name -> PDF", result.getID(), equalTo(pdf.getID()));
 
-        //test unknown format
+        // Filename without a usable extension: still detected as PDF from its content.
         bs = bitstreamService.create(context, new FileInputStream(f));
         bs.setName(context, "file_without_extension.");
         result = bitstreamFormatService.guessFormat(context, bs);
-        assertThat("testGuessFormat 1", result, nullValue());
+        assertThat("content detection without extension is not null", result, notNullValue());
+        assertThat("content detection without extension -> PDF", result.getID(), equalTo(pdf.getID()));
 
-        //test known format
+        // Deliberately misleading extension: content wins over the (wrong) extension.
         bs = bitstreamService.create(context, new FileInputStream(f));
-        bs.setName(context, testProps.get("test.bitstream").toString());
+        bs.setName(context, "actually-a-pdf.txt");
         result = bitstreamFormatService.guessFormat(context, bs);
-        assertThat("testGuessFormat 2", result.getID(), equalTo(pdf.getID()));
-        assertThat("testGuessFormat 3", result.getMIMEType(), equalTo(pdf.getMIMEType()));
-        assertThat("testGuessFormat 4", result.getExtensions(), equalTo(pdf.getExtensions()));
+        assertThat("content beats a misleading extension is not null", result, notNullValue());
+        assertThat("content beats a misleading extension -> PDF", result.getID(), equalTo(pdf.getID()));
+    }
+
+    /**
+     * Legacy extension-based fallback (content identification disabled): the format is
+     * guessed purely from the filename extension.
+     */
+    @Test
+    public void testGuessFormatByExtensionFallback() throws Exception {
+        configurationService.setProperty("bitstream.format.identification.by-content.enabled", false);
+
+        File f = new File(testProps.get("test.bitstream").toString());
+        BitstreamFormat pdf = bitstreamFormatService.findByShortDescription(context, "Adobe PDF");
+
+        // Null filename: unknown (null), content is never inspected.
+        Bitstream bs = bitstreamService.create(context, new FileInputStream(f));
+        bs.setName(context, null);
+        assertThat("extension fallback, null name", bitstreamFormatService.guessFormat(context, bs), nullValue());
+
+        // No usable extension: unknown (null).
+        bs = bitstreamService.create(context, new FileInputStream(f));
+        bs.setName(context, "file_without_extension.");
+        assertThat("extension fallback, no extension",
+                   bitstreamFormatService.guessFormat(context, bs), nullValue());
+
+        // A known extension is resolved from the registry (content is not verified).
+        bs = bitstreamService.create(context, new FileInputStream(f));
+        bs.setName(context, "document.pdf");
+        BitstreamFormat result = bitstreamFormatService.guessFormat(context, bs);
+        assertThat("extension fallback, .pdf -> PDF", result.getID(), equalTo(pdf.getID()));
     }
 
 }

--- a/dspace-api/src/test/java/org/dspace/ctask/general/IdentifyFormatsIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/IdentifyFormatsIT.java
@@ -1,0 +1,133 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.core.factory.CoreServiceFactory;
+import org.dspace.curate.Curator;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.Test;
+
+/**
+ * Integration test for the {@link IdentifyFormats} curation task, which re-identifies
+ * bitstream formats and corrects bitstreams that were stored as "Unknown".
+ */
+public class IdentifyFormatsIT extends AbstractIntegrationTestWithDatabase {
+
+    private static final String P_TASK_DEF = "plugin.named.org.dspace.curate.CurationTask";
+    private static final String TASK_NAME = "identifyformats";
+
+    private final ConfigurationService configurationService =
+        DSpaceServicesFactory.getInstance().getConfigurationService();
+    private final BitstreamFormatService bitstreamFormatService =
+        ContentServiceFactory.getInstance().getBitstreamFormatService();
+
+    /**
+     * A bitstream whose PDF content was stored as "Unknown" (because its name had no usable
+     * extension) is corrected to Adobe PDF by re-identifying it from its content.
+     */
+    @Test
+    public void testCorrectsUnknownFormat() throws Exception {
+        // Register the task dynamically so the test does not depend on curate.cfg
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
+        String[] previousTaskDef = configurationService.getArrayProperty(P_TASK_DEF);
+        configurationService.setProperty(P_TASK_DEF,
+            IdentifyFormats.class.getCanonicalName() + " = " + TASK_NAME);
+
+        try {
+            context.turnOffAuthorisationSystem();
+            parentCommunity = CommunityBuilder.createCommunity(context).build();
+            Collection collection = CollectionBuilder.createCollection(context, parentCommunity).build();
+            Item item = ItemBuilder.createItem(context, collection).build();
+
+            // Add a PDF but give it a name with no usable extension, so it is stored as "Unknown".
+            Bitstream bitstream;
+            File pdf = new File(testProps.get("test.bitstream").toString());
+            try (InputStream is = new FileInputStream(pdf)) {
+                bitstream = BitstreamBuilder.createBitstream(context, item, is)
+                                            .withName("mysteryfile")
+                                            .build();
+            }
+            context.restoreAuthSystemState();
+
+            // Precondition: the bitstream is currently unidentified.
+            assertEquals("Unknown", bitstream.getFormat(context).getShortDescription());
+
+            // Run the curation task as an administrator.
+            context.setCurrentUser(admin);
+            Curator curator = new Curator();
+            curator.addTask(context, TASK_NAME);
+            curator.curate(context, item);
+            assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
+
+            // The bitstream is now correctly identified as PDF from its content.
+            Bitstream reloaded = context.reloadEntity(bitstream);
+            assertEquals("Adobe PDF", reloaded.getFormat(context).getShortDescription());
+        } finally {
+            configurationService.setProperty(P_TASK_DEF, previousTaskDef);
+        }
+    }
+
+    /**
+     * A bitstream that is already correctly identified is left untouched (and by default a
+     * non-Unknown bitstream is not even re-examined).
+     */
+    @Test
+    public void testLeavesKnownFormatUntouched() throws Exception {
+        CoreServiceFactory.getInstance().getPluginService().clearNamedPluginClasses();
+        String[] previousTaskDef = configurationService.getArrayProperty(P_TASK_DEF);
+        configurationService.setProperty(P_TASK_DEF,
+            IdentifyFormats.class.getCanonicalName() + " = " + TASK_NAME);
+
+        try {
+            context.turnOffAuthorisationSystem();
+            parentCommunity = CommunityBuilder.createCommunity(context).build();
+            Collection collection = CollectionBuilder.createCollection(context, parentCommunity).build();
+            Item item = ItemBuilder.createItem(context, collection).build();
+
+            Bitstream bitstream;
+            File pdf = new File(testProps.get("test.bitstream").toString());
+            try (InputStream is = new FileInputStream(pdf)) {
+                bitstream = BitstreamBuilder.createBitstream(context, item, is)
+                                            .withName("document.pdf")
+                                            .withMimeType("application/pdf")
+                                            .build();
+            }
+            context.restoreAuthSystemState();
+
+            assertEquals("Adobe PDF", bitstream.getFormat(context).getShortDescription());
+
+            context.setCurrentUser(admin);
+            Curator curator = new Curator();
+            curator.addTask(context, TASK_NAME);
+            curator.curate(context, item);
+            assertEquals("Curation should succeed", Curator.CURATE_SUCCESS, curator.getStatus(TASK_NAME));
+
+            Bitstream reloaded = context.reloadEntity(bitstream);
+            assertEquals("Adobe PDF", reloaded.getFormat(context).getShortDescription());
+        } finally {
+            configurationService.setProperty(P_TASK_DEF, previousTaskDef);
+        }
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/ctask/general/IdentifyFormatsScriptIT.java
+++ b/dspace-api/src/test/java/org/dspace/ctask/general/IdentifyFormatsScriptIT.java
@@ -1,0 +1,83 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.general;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.builder.BitstreamBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.junit.Test;
+
+/**
+ * Integration test for the {@link IdentifyFormatsScript} process, which re-identifies
+ * bitstream formats across the repository (or a given scope) and corrects those stored
+ * as "Unknown".
+ */
+public class IdentifyFormatsScriptIT extends AbstractIntegrationTestWithDatabase {
+
+    /**
+     * With no target, the process scans the whole repository and corrects an Unknown PDF.
+     */
+    @Test
+    public void testCorrectsUnknownFormatRepositoryWide() throws Exception {
+        Bitstream bitstream = createUnknownPdfBitstream();
+
+        assertEquals("Unknown", bitstream.getFormat(context).getShortDescription());
+
+        int status = runDSpaceScript("identify-formats");
+        assertEquals("Process should succeed", 0, status);
+
+        Bitstream reloaded = context.reloadEntity(bitstream);
+        assertEquals("Adobe PDF", reloaded.getFormat(context).getShortDescription());
+    }
+
+    /**
+     * With a target identifier, only that scope is processed.
+     */
+    @Test
+    public void testCorrectsUnknownFormatForScope() throws Exception {
+        Bitstream bitstream = createUnknownPdfBitstream();
+        Item item = bitstream.getBundles().get(0).getItems().get(0);
+
+        assertEquals("Unknown", bitstream.getFormat(context).getShortDescription());
+
+        int status = runDSpaceScript("identify-formats", "-i", item.getID().toString());
+        assertEquals("Process should succeed", 0, status);
+
+        Bitstream reloaded = context.reloadEntity(bitstream);
+        assertEquals("Adobe PDF", reloaded.getFormat(context).getShortDescription());
+    }
+
+    private Bitstream createUnknownPdfBitstream() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity).build();
+        Item item = ItemBuilder.createItem(context, collection).build();
+
+        Bitstream bitstream;
+        File pdf = new File(testProps.get("test.bitstream").toString());
+        try (InputStream is = new FileInputStream(pdf)) {
+            // A PDF whose name has no usable extension is stored as "Unknown".
+            bitstream = BitstreamBuilder.createBitstream(context, item, is)
+                                        .withName("mysteryfile")
+                                        .build();
+        }
+        context.restoreAuthSystemState();
+        return bitstream;
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -264,6 +264,14 @@ message.templates.allowed-config = mail.admin.name
 # purely from the filename extension.
 #bitstream.format.identification.by-content.enabled = true
 
+# Maximum number of bytes read from a bitstream's content for content-based identification.
+# Format signatures sit at the start of a file, so a bounded prefix is enough to identify
+# the common cases while keeping identification cheap for very large files (in particular
+# container formats such as ZIP/OOXML, which Tika would otherwise copy to a temporary file
+# in full). Anything not identified within this bound falls back to extension-based
+# identification. Set to 0 (or a negative value) to read the whole file. Default: 33554432 (32 MiB).
+#bitstream.format.identification.by-content.max-bytes = 33554432
+
 ##### Logging configuration #####
 # Main logging settings can be found in config/log4j2.xml
 # Below are some configuration properties for the server webapp that can be

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -253,6 +253,17 @@ message.templates.allowed-config = mail.admin.name
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml
 
+##### Bitstream format identification #####
+# When a bitstream is ingested, DSpace guesses its format (and MIME type) from the
+# bitstream format registry. When this property is true (the default), identification
+# is driven by the actual file content using Apache Tika (magic bytes / container
+# inspection), with the filename used only as a hint. This correctly identifies files
+# whose extension is missing, wrong, or deliberately misleading, and resolves extensions
+# that map to more than one format (e.g. .mp4 as audio vs video).
+# When set to false, DSpace falls back to the legacy behaviour of guessing the format
+# purely from the filename extension.
+#bitstream.format.identification.by-content.enabled = true
+
 ##### Logging configuration #####
 # Main logging settings can be found in config/log4j2.xml
 # Below are some configuration properties for the server webapp that can be

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -16,8 +16,14 @@ plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredM
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MicrosoftTranslator = translate
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MetadataValueLinkChecker = checklinks
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RegisterDOI = registerdoi
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.IdentifyFormats = identifyformats
 #plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.CitationPage = citationpage
 # add new tasks here (or in additional config files)
+
+# IdentifyFormats: re-run bitstream format identification. By default only bitstreams
+# currently labelled "Unknown" (application/octet-stream) are re-identified; set to true
+# to re-identify every bitstream.
+#curate.identifyformats.process-all = false
 
 ## task queue implementation
 plugin.single.org.dspace.curate.TaskQueue = org.dspace.curate.FileTaskQueue

--- a/dspace/config/spring/api/scripts.xml
+++ b/dspace/config/spring/api/scripts.xml
@@ -67,6 +67,12 @@
         <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleanerCli"/>
     </bean>
 
+    <bean id="identify-formats" class="org.dspace.ctask.general.IdentifyFormatsScriptCliConfiguration">
+        <property name="description"
+                  value="Re-identify bitstream formats and correct those stored as Unknown"/>
+        <property name="dspaceRunnableClass" value="org.dspace.ctask.general.IdentifyFormatsScriptCli"/>
+    </bean>
+
     <bean id="filter-media" class="org.dspace.app.mediafilter.MediaFilterScriptConfiguration">
         <property name="description" value="Perform the media filtering to extract full text from documents and to create thumbnails"/>
         <property name="dspaceRunnableClass" value="org.dspace.app.mediafilter.MediaFilterScript"/>

--- a/dspace/config/spring/rest/scripts.xml
+++ b/dspace/config/spring/rest/scripts.xml
@@ -49,6 +49,12 @@
         <property name="dspaceRunnableClass" value="org.dspace.administer.ProcessCleaner"/>
     </bean>
 
+    <bean id="identify-formats" class="org.dspace.ctask.general.IdentifyFormatsScriptConfiguration" primary="true">
+        <property name="description"
+                  value="Re-identify bitstream formats and correct those stored as Unknown"/>
+        <property name="dspaceRunnableClass" value="org.dspace.ctask.general.IdentifyFormatsScript"/>
+    </bean>
+
     <bean id="orcid-bulk-push" class="org.dspace.orcid.script.OrcidBulkPushScriptConfiguration" primary="true">
         <property name="description" value="Perform the bulk synchronization of all the BATCH configured ORCID entities placed in the ORCID queue"/>
         <property name="dspaceRunnableClass" value="org.dspace.orcid.script.OrcidBulkPush"/>


### PR DESCRIPTION
## References

* Fixes #12797

## Description

Bitstream format (MIME type) identification currently relies entirely on the filename extension, which mislabels valid files (e.g. PDFs/Word documents stored as `application/octet-stream`) when the extension is missing, wrong, or deliberately misleading, and resolves shared extensions (e.g. `.mp4` audio vs video) non-deterministically. This PR makes identification content-based using Apache Tika (already a dependency), makes the extension fallback deterministic, and adds tooling to re-identify already-ingested bitstreams.

## Instructions for Reviewers

List of changes in this PR:

* **Content-based identification.** `BitstreamFormatServiceImpl.guessFormat()` now inspects the actual file content with Apache Tika (magic bytes / container inspection), using the filename only as a hint. It falls back to the existing extension-based lookup when content detection is disabled or inconclusive (detected MIME type not in the registry), then to `Unknown`. This fixes valid files being labelled `application/octet-stream` and resolves ambiguous extensions from the real content. Controlled by `bitstream.format.identification.by-content.enabled` (default `true`).
* **Bounded read for large files.** Magic-detected types (PDF, images, video) are cheap regardless of size, but container formats (ZIP/OOXML, OLE2) make Tika spool the whole stream to a temp file. The content stream is wrapped in a `BoundedInputStream` so at most `bitstream.format.identification.by-content.max-bytes` (default 32 MiB; `0` = whole file) are read/spooled. Signatures sit at the start of a file, so a bounded prefix covers the common cases; anything not identified within the bound falls back to the extension.
* **Deterministic extension fallback.** `BitstreamFormatDAOImpl.findByFileExtension()` now orders by id, so when multiple formats share an extension the result is stable instead of depending on database row order.
* **`IdentifyFormats` curation task** (id `identifyformats`) re-runs identification over an object's bitstreams and corrects those stored as `Unknown` (by default; `curate.identifyformats.process-all=true` re-identifies all). Runnable from the Admin UI "Curate" tab or `dspace curate -t identifyformats -i <handle|uuid>`.
* **`identify-formats` Process/script** (Admin UI &gt; Administrative &gt; Processes, or `dspace identify-formats`) is a thin wrapper that runs the `identifyformats` curation task through a `Curator` (no logic duplication). Unlike the generic `curate` script it defaults to the whole repository when no `-i` target is given; `-a` re-identifies all bitstreams.

No new dependencies (Apache Tika and commons-io are already present). No REST endpoint/contract changes (the new script is exposed through the existing scripts framework).

**How to test:**

1. Upload a valid PDF or `.docx` whose name has no extension (or an extension not in the registry), or via a client that sends `Content-Type: application/octet-stream`. Before this PR its format is `Unknown` / `application/octet-stream`; with this PR it is correctly identified (Adobe PDF, Microsoft Word, ...).
2. Rename a non-PDF to `something.pdf` and upload it: it is identified by its real content rather than trusted on the extension.
3. To correct pre-existing mislabelled bitstreams, run the process repository-wide (`dspace identify-formats`) or the curation task on a scope (`dspace curate -t identifyformats -i <handle>`), then confirm the affected bitstreams now report the correct format.
4. New/updated automated coverage: `FormatIdentifierTest` (content path + extension fallback), `IdentifyFormatsIT`, `IdentifyFormatsScriptIT`. Existing upload/format ITs (`WorkspaceItemRestRepositoryIT`, `BitstreamRestRepositoryIT`, `BundleRestRepositoryIT`, `BitstreamFormatRestRepositoryIT`, `BundleUploadBitstreamControllerIT`, `MediaFilterIT`, `ItemImportCLIIT`) pass unchanged.

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (excluding comments & integration tests).
- [x] My PR **passes Checkstyle** validation based on the Code Style Guide.
- [x] My PR **includes Javadoc** for all new (or modified) public methods and classes.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests**.
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies, I've made sure their licenses align with the DSpace BSD License. (No new dependencies; Apache Tika and commons-io are already used.)
- [ ] If my PR modifies REST API endpoints, I've opened a separate REST Contract PR. (No REST endpoint changes.)
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. (Documented in `dspace.cfg`: `bitstream.format.identification.by-content.enabled`, `bitstream.format.identification.by-content.max-bytes`, `curate.identifyformats.process-all`.)
- [x] If my PR fixes an issue ticket, I've linked them together.
