### PR TITLE
Opt-in bitstream format upload whitelist (reject Unknown/unsupported file types)

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/BitstreamFormatServiceImpl.java
@@ -19,6 +19,7 @@ import org.dspace.content.dao.BitstreamFormatDAO;
 import org.dspace.content.service.BitstreamFormatService;
 import org.dspace.core.Context;
 import org.dspace.core.LogHelper;
+import org.dspace.services.ConfigurationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -35,11 +36,31 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
      */
     private static Logger log = org.apache.logging.log4j.LogManager.getLogger(BitstreamFormat.class);
 
+    /**
+     * Configuration property that enables the upload format whitelist. When {@code true},
+     * bitstreams whose identified format has a support level below
+     * {@link #CFG_WHITELIST_MIN_SUPPORT_LEVEL} are rejected on upload. Defaults to
+     * {@code false} (no restriction).
+     */
+    protected static final String CFG_WHITELIST_ENABLED = "bitstream.format.upload.whitelist.enabled";
+
+    /**
+     * Configuration property holding the minimum support level a format must have to be
+     * accepted on upload when the whitelist is enabled. Values match the
+     * {@link BitstreamFormat} support-level constants (0 = UNKNOWN, 1 = KNOWN,
+     * 2 = SUPPORTED). Defaults to {@link BitstreamFormat#KNOWN}.
+     */
+    protected static final String CFG_WHITELIST_MIN_SUPPORT_LEVEL =
+        "bitstream.format.upload.whitelist.min-support-level";
+
     @Autowired(required = true)
     protected BitstreamFormatDAO bitstreamFormatDAO;
 
     @Autowired(required = true)
     protected AuthorizeService authorizeService;
+
+    @Autowired(required = true)
+    protected ConfigurationService configurationService;
 
     protected BitstreamFormatServiceImpl() {
 
@@ -232,6 +253,21 @@ public class BitstreamFormatServiceImpl implements BitstreamFormatService {
         }
 
         return -1;
+    }
+
+    @Override
+    public boolean isUploadAllowed(BitstreamFormat bitstreamFormat) {
+        // When the whitelist is disabled (the default), every format is accepted.
+        if (!configurationService.getBooleanProperty(CFG_WHITELIST_ENABLED, false)) {
+            return true;
+        }
+        // An unidentified format (null) is treated as "Unknown" and therefore not allowed.
+        if (bitstreamFormat == null) {
+            return false;
+        }
+        int minSupportLevel = configurationService.getIntProperty(CFG_WHITELIST_MIN_SUPPORT_LEVEL,
+                                                                  BitstreamFormat.KNOWN);
+        return bitstreamFormat.getSupportLevel() >= minSupportLevel;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/service/BitstreamFormatService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/BitstreamFormatService.java
@@ -128,4 +128,16 @@ public interface BitstreamFormatService extends DSpaceCRUDService<BitstreamForma
      * @throws SQLException if database error
      */
     public BitstreamFormat guessFormat(Context context, Bitstream bitstream) throws SQLException;
+
+    /**
+     * Determine whether a bitstream of the given format may be uploaded, according to the
+     * configurable upload format whitelist. When the whitelist is disabled (the default),
+     * every format is allowed. When it is enabled, only formats whose support level is at
+     * least the configured minimum are allowed; an unidentified format ({@code null}) is
+     * treated as "Unknown" and is not allowed.
+     *
+     * @param bitstreamFormat the format to check (may be {@code null} if unidentified)
+     * @return {@code true} if a bitstream of this format may be uploaded, {@code false} otherwise
+     */
+    public boolean isUploadAllowed(BitstreamFormat bitstreamFormat);
 }

--- a/dspace-api/src/test/java/org/dspace/content/BitstreamFormatTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/BitstreamFormatTest.java
@@ -31,6 +31,8 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.BitstreamFormatService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -549,5 +551,40 @@ public class BitstreamFormatTest extends AbstractUnitTest {
         assertThat("setExtensions 6", bf.getExtensions(), notNullValue());
         assertTrue("setExtensions 7", bf.getExtensions().size() == 0);
         bf.setExtensions(backupExtensions);
+    }
+
+    /**
+     * Test of isUploadAllowed method, of class BitstreamFormat.
+     */
+    @Test
+    public void testIsUploadAllowed() throws SQLException {
+        ConfigurationService configurationService =
+            DSpaceServicesFactory.getInstance().getConfigurationService();
+        BitstreamFormat known = bitstreamFormatService.findByShortDescription(context, "Adobe PDF");
+        assertThat("Adobe PDF should have KNOWN support level",
+                   known.getSupportLevel(), equalTo(BitstreamFormat.KNOWN));
+
+        try {
+            // Whitelist disabled (default): everything is allowed, including Unknown and null.
+            configurationService.setProperty("bitstream.format.upload.whitelist.enabled", null);
+            assertTrue("disabled: known allowed", bitstreamFormatService.isUploadAllowed(known));
+            assertTrue("disabled: unknown allowed", bitstreamFormatService.isUploadAllowed(bunknown));
+            assertTrue("disabled: null allowed", bitstreamFormatService.isUploadAllowed(null));
+
+            // Whitelist enabled, default minimum support level (KNOWN): Unknown/null rejected.
+            configurationService.setProperty("bitstream.format.upload.whitelist.enabled", true);
+            configurationService.setProperty("bitstream.format.upload.whitelist.min-support-level", null);
+            assertTrue("enabled: known allowed", bitstreamFormatService.isUploadAllowed(known));
+            assertFalse("enabled: unknown rejected", bitstreamFormatService.isUploadAllowed(bunknown));
+            assertFalse("enabled: null rejected", bitstreamFormatService.isUploadAllowed(null));
+
+            // Stricter minimum (SUPPORTED): a KNOWN format is now rejected too.
+            configurationService.setProperty("bitstream.format.upload.whitelist.min-support-level",
+                                             BitstreamFormat.SUPPORTED);
+            assertFalse("strict: known rejected", bitstreamFormatService.isUploadAllowed(known));
+        } finally {
+            configurationService.setProperty("bitstream.format.upload.whitelist.enabled", null);
+            configurationService.setProperty("bitstream.format.upload.whitelist.min-support-level", null);
+        }
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
@@ -145,6 +145,21 @@ public class UploadStep extends AbstractProcessingStep
             bf = bitstreamFormatService.guessFormat(context, source);
             source.setFormat(context, bf);
 
+            // Enforce the (opt-in) upload format whitelist: reject files whose identified
+            // format is not allowed, removing the just-uploaded bitstream from the item.
+            if (!bitstreamFormatService.isUploadAllowed(bf)) {
+                Bundle bundle = source.getBundles().get(0);
+                bundleService.removeBitstream(context, bundle, source);
+                if (bundle.getBitstreams().isEmpty()) {
+                    itemService.removeBundle(context, item, bundle);
+                }
+                ErrorRest result = new ErrorRest();
+                result.setMessage("error.validation.upload.format-not-allowed");
+                result.getPaths().add(
+                    "/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + stepConfig.getId());
+                return Pair.of(null, result);
+            }
+
             // Update to DB
             bitstreamService.update(context, source);
             itemService.update(context, item);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/UploadStepFormatWhitelistIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/UploadStepFormatWhitelistIT.java
@@ -1,0 +1,120 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.WorkspaceItemBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.WorkspaceItem;
+import org.dspace.services.ConfigurationService;
+import org.junit.After;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+/**
+ * Integration tests for the (opt-in) bitstream format upload whitelist enforced by the
+ * submission {@link org.dspace.app.rest.submit.step.UploadStep}.
+ */
+public class UploadStepFormatWhitelistIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @After
+    public void resetWhitelistConfig() {
+        configurationService.setProperty("bitstream.format.upload.whitelist.enabled", null);
+        configurationService.setProperty("bitstream.format.upload.whitelist.min-support-level", null);
+    }
+
+    /**
+     * With the whitelist enabled, a file whose format resolves to "Unknown" (an unregistered
+     * extension such as .exe) is rejected: the submission reports a format error and no
+     * bitstream is added.
+     */
+    @Test
+    public void uploadDisallowedFormatIsRejected() throws Exception {
+        configurationService.setProperty("bitstream.format.upload.whitelist.enabled", true);
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("Community").build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col)
+                                                  .withTitle("Test WorkspaceItem")
+                                                  .withIssueDate("2024-01-01")
+                                                  .build();
+        context.restoreAuthSystemState();
+
+        MockMultipartFile exeFile = new MockMultipartFile("file", "malware.exe",
+            "application/octet-stream", "not really an executable".getBytes());
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken).perform(multipart("/api/submission/workspaceitems/" + witem.getID()).file(exeFile))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.upload.format-not-allowed')]", hasSize(1)))
+            .andExpect(jsonPath("$.sections.upload.files", hasSize(0)));
+    }
+
+    /**
+     * With the whitelist enabled, a file whose format is KNOWN (e.g. a .pdf) is accepted.
+     */
+    @Test
+    public void uploadAllowedFormatIsAccepted() throws Exception {
+        configurationService.setProperty("bitstream.format.upload.whitelist.enabled", true);
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("Community").build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col)
+                                                  .withTitle("Test WorkspaceItem")
+                                                  .withIssueDate("2024-01-01")
+                                                  .build();
+        context.restoreAuthSystemState();
+
+        MockMultipartFile pdfFile = new MockMultipartFile("file", "document.pdf",
+            "application/pdf", "%PDF-1.4 fake pdf".getBytes());
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken).perform(multipart("/api/submission/workspaceitems/" + witem.getID()).file(pdfFile))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.upload.format-not-allowed')]", hasSize(0)))
+            .andExpect(jsonPath("$.sections.upload.files[0].metadata['dc.title'][0].value", is("document.pdf")));
+    }
+
+    /**
+     * With the whitelist disabled (the default), the same "Unknown" file is accepted.
+     */
+    @Test
+    public void uploadDisallowedFormatAcceptedWhenWhitelistDisabled() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("Community").build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection").build();
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col)
+                                                  .withTitle("Test WorkspaceItem")
+                                                  .withIssueDate("2024-01-01")
+                                                  .build();
+        context.restoreAuthSystemState();
+
+        MockMultipartFile exeFile = new MockMultipartFile("file", "malware.exe",
+            "application/octet-stream", "not really an executable".getBytes());
+
+        String authToken = getAuthToken(eperson.getEmail(), password);
+        getClient(authToken).perform(multipart("/api/submission/workspaceitems/" + witem.getID()).file(exeFile))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.errors[?(@.message=='error.validation.upload.format-not-allowed')]", hasSize(0)))
+            .andExpect(jsonPath("$.sections.upload.files", hasSize(1)));
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -253,6 +253,21 @@ message.templates.allowed-config = mail.admin.name
 ##### Asset Storage (bitstreams / files) ######
 # Moved to config/spring/api/bitstore.xml
 
+##### Bitstream format upload whitelist #####
+# The bitstream format registry assigns each format a support level: 0 = UNKNOWN,
+# 1 = KNOWN, 2 = SUPPORTED. When this whitelist is enabled, files uploaded through the
+# submission are rejected unless their identified format has a support level of at least
+# 'min-support-level' below. This lets institutions keep unwanted or potentially unsafe
+# file types (e.g. executables, which are identified as "Unknown") out of the repository
+# by curating the format registry: only formats marked KNOWN or SUPPORTED are accepted.
+# Disabled by default (all formats accepted).
+#bitstream.format.upload.whitelist.enabled = false
+
+# Minimum support level a format must have to be accepted on upload when the whitelist is
+# enabled. 1 = KNOWN (reject only UNKNOWN, the recommended setting), 2 = SUPPORTED (stricter:
+# accept only explicitly supported formats). Default: 1.
+#bitstream.format.upload.whitelist.min-support-level = 1
+
 ##### Logging configuration #####
 # Main logging settings can be found in config/log4j2.xml
 # Below are some configuration properties for the server webapp that can be


### PR DESCRIPTION
## References

* Fixes #9963

## Description

Adds an opt-in "upload format whitelist" so institutions can keep unwanted or potentially unsafe file types (e.g. executables, which are identified as "Unknown") out of the repository by curating the bitstream format registry: when enabled, a submission upload is rejected unless its identified format has a support level of at least a configured minimum.

## Instructions for Reviewers

The bitstream format registry already assigns each format a support level (`0 = UNKNOWN`, `1 = KNOWN`, `2 = SUPPORTED`). This PR turns that into an enforceable allowlist, without introducing a new status.

List of changes in this PR:

* **`BitstreamFormatService.isUploadAllowed(BitstreamFormat)`** — returns `true` when the whitelist is disabled (the default), otherwise `true` only when the format's support level is at least the configured minimum. A `null`/unidentified format is treated as "Unknown" and is not allowed.
* **`UploadStep` enforcement** — when the whitelist is enabled and the uploaded file's identified format is not allowed, the submission returns the error `error.validation.upload.format-not-allowed` and the just-created bitstream (and its now-empty bundle) is removed from the item, so nothing lingers.
* **Configuration** (documented in `dspace.cfg`):
  * `bitstream.format.upload.whitelist.enabled` (default `false`)
  * `bitstream.format.upload.whitelist.min-support-level` (default `1` = KNOWN; set `2` = SUPPORTED for a stricter policy)

**Scope / discussion:** this first implementation enforces the whitelist on the interactive submission path (`UploadStep`), which covers the main use case from the issue (users uploading executables). The reusable `isUploadAllowed(...)` check is ready to be applied to the other ingestion paths (SAF batch import, SWORD, packager ingest, OAI/ORE harvesting) as well — I've deliberately kept this PR focused so we can agree on how broadly to enforce before extending it. Feedback welcome on that scope, and on the configuration approach (support-level threshold vs. an explicit allow/deny list).

This pairs naturally with content-based format identification (#12797 / PR #12798): with reliable identification, a valid PDF or Word document is no longer mislabelled "Unknown", so the whitelist rejects only genuinely unrecognized/unwanted content. This PR does not depend on that one and works with the current extension-based identification.

**How to test:**

1. Set `bitstream.format.upload.whitelist.enabled = true` in `local.cfg`.
2. In a submission, try to upload a file whose format is not KNOWN in the registry (e.g. a file named `malware.exe`). The upload is rejected with a format error and no bitstream is added to the item.
3. Upload a file whose format is KNOWN (e.g. a `.pdf`). It is accepted as normal.
4. Set the property back to `false` (or leave it unset): all uploads are accepted, i.e. behaviour is unchanged from today.
5. Automated coverage: `BitstreamFormatTest#testIsUploadAllowed` (unit) and `UploadStepFormatWhitelistIT` (integration: reject Unknown when enabled, accept KNOWN when enabled, accept Unknown when disabled).

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (excluding comments & integration tests).
- [x] My PR **passes Checkstyle** validation based on the Code Style Guide.
- [x] My PR **includes Javadoc** for all new (or modified) public methods and classes.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests**.
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies, I've made sure their licenses align with the DSpace BSD License. (No new dependencies.)
- [ ] If my PR modifies REST API endpoints, I've opened a separate REST Contract PR. (No new endpoints; adds a submission validation error to the existing upload flow.)
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. (`bitstream.format.upload.whitelist.enabled`, `bitstream.format.upload.whitelist.min-support-level`, documented in `dspace.cfg`.)
- [x] If my PR fixes an issue ticket, I've linked them together.
