### PR TITLE
Fixes SEOHealthIndicator to have UP_WITH_ISSUES status in case of configuration problems

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/health/SEOHealthIndicator.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/health/SEOHealthIndicator.java
@@ -7,9 +7,11 @@
  */
 package org.dspace.app.rest.health;
 
+import static org.dspace.app.rest.configuration.ActuatorConfiguration.UP_WITH_ISSUES_STATUS;
+
 import org.apache.commons.lang3.StringUtils;
 import org.dspace.services.ConfigurationService;
-import org.dspace.services.factory.DSpaceServicesFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.web.client.RestTemplate;
@@ -22,9 +24,26 @@ import org.springframework.web.client.RestTemplate;
  */
 public class SEOHealthIndicator extends AbstractHealthIndicator {
 
-    ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+    public static final String SITEMAP = "sitemap";
+    public static final String ROBOTS_TXT = "robots.txt";
+    public static final String SSR = "ssr";
+    public static final String OK = "OK";
+    public static final String SITEMAP_MISSING = "Sitemaps are missing or inaccessible. Please see the " +
+        "DSpace Documentation on Search Engine Optimization for how to enable " +
+        "Sitemaps.";
+    public static final String ROBOTS_MISSING = "Missing or inaccessible. Please see the DSpace Documentation on " +
+        "Search Engine Optimization for how to create a robots.txt.";
+    public static final String ROBOTS_INVALID = "Invalid because it contains localhost URLs. This is often a sign " +
+        "that a proxy is failing to pass X-Forwarded headers to DSpace. Please see the DSpace " +
+        "Documentation on Search Engine Optimization for how to pass X-Forwarded headers.";
+    public static final String SSR_DISABLED = "Server-side rendering (SSR) appears to be disabled.  Most " +
+        "search engines require enabling SSR for proper indexing. Please see the DSpace Documentation on" +
+        " Search Engine Optimization for more details.";
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    @Autowired
+    private ConfigurationService configurationService;
+
+    private RestTemplate restTemplate = new RestTemplate();
 
     @Override
     protected void doHealthCheck(Health.Builder builder) {
@@ -36,27 +55,21 @@ public class SEOHealthIndicator extends AbstractHealthIndicator {
 
         if (sitemapOk && robotsTxtStatus == RobotsTxtStatus.VALID && ssrOk) {
             builder.up()
-                   .withDetail("sitemap", "OK")
-                   .withDetail("robots.txt", "OK")
-                   .withDetail("ssr", "OK");
+                   .withDetail(SITEMAP, OK)
+                   .withDetail(ROBOTS_TXT, OK)
+                   .withDetail(SSR, OK);
         } else {
-            builder.down();
-            builder.withDetail("sitemap", sitemapOk ? "OK" : "Sitemaps are missing or inaccessible. Please see the " +
-                    "DSpace Documentation on Search Engine Optimization for how to enable Sitemaps.");
+            builder.status(UP_WITH_ISSUES_STATUS)
+                   .withDetail(SITEMAP, sitemapOk ? OK : SITEMAP_MISSING);
 
             if (robotsTxtStatus == RobotsTxtStatus.MISSING) {
-                builder.withDetail("robots.txt", "Missing or inaccessible. Please see the DSpace Documentation on " +
-                        "Search Engine Optimization for how to create a robots.txt.");
+                builder.withDetail(ROBOTS_TXT, ROBOTS_MISSING);
             } else if (robotsTxtStatus == RobotsTxtStatus.INVALID) {
-                builder.withDetail("robots.txt", "Invalid because it contains localhost URLs. This is often a sign " +
-                        "that a proxy is failing to pass X-Forwarded headers to DSpace. Please see the DSpace " +
-                        "Documentation on Search Engine Optimization for how to pass X-Forwarded headers.");
+                builder.withDetail(ROBOTS_TXT, ROBOTS_INVALID);
             } else {
-                builder.withDetail("robots.txt", "OK");
+                builder.withDetail(ROBOTS_TXT, OK);
             }
-            builder.withDetail("ssr", ssrOk ? "OK" : "Server-side rendering (SSR) appears to be disabled.  Most " +
-                    "search engines require enabling SSR for proper indexing. Please see the DSpace Documentation on" +
-                    " Search Engine Optimization for more details.");
+            builder.withDetail(SSR, ssrOk ? OK : SSR_DISABLED);
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/health/SEOHealthIndicatorTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/health/SEOHealthIndicatorTest.java
@@ -1,0 +1,123 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.health;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.dspace.app.rest.configuration.ActuatorConfiguration;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Unit tests for {@link SEOHealthIndicator}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SEOHealthIndicatorTest {
+
+    private static final String BASE_URL = "https://demo.dspace.org";
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private SEOHealthIndicator seoHealthIndicator;
+
+    @Before
+    public void setUp() {
+        when(configurationService.getProperty("dspace.ui.url")).thenReturn(BASE_URL);
+    }
+
+    @Test
+    public void testWithSeoConfiguredCorrectly() {
+        when(restTemplate.getForEntity(anyString(), eq(String.class)))
+            .thenReturn(ResponseEntity.ok("<sitemap/>"));
+        when(restTemplate.getForObject(eq(BASE_URL + "/robots.txt"), eq(String.class)))
+            .thenReturn("User-agent: *\nSitemap: " + BASE_URL + "/sitemap_index.xml");
+        when(restTemplate.getForObject(eq(BASE_URL), eq(String.class)))
+            .thenReturn("<html><body>Rendered content</body></html>");
+
+        Health health = seoHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.UP));
+        assertThat(health.getDetails(), is(Map.of(
+            SEOHealthIndicator.SITEMAP, SEOHealthIndicator.OK,
+            SEOHealthIndicator.ROBOTS_TXT, SEOHealthIndicator.OK,
+            SEOHealthIndicator.SSR, SEOHealthIndicator.OK)));
+    }
+
+    @Test
+    public void testWithSeoChecksFailingReportsUpWithIssues() {
+        when(restTemplate.getForEntity(anyString(), eq(String.class)))
+            .thenThrow(new RestClientException("connection refused"));
+        when(restTemplate.getForObject(anyString(), eq(String.class)))
+            .thenThrow(new RestClientException("connection refused"));
+
+        Health health = seoHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(ActuatorConfiguration.UP_WITH_ISSUES_STATUS));
+        assertThat(health.getDetails(), is(Map.of(
+            SEOHealthIndicator.SITEMAP, SEOHealthIndicator.SITEMAP_MISSING,
+            SEOHealthIndicator.ROBOTS_TXT, SEOHealthIndicator.ROBOTS_MISSING,
+            SEOHealthIndicator.SSR, SEOHealthIndicator.SSR_DISABLED)));
+    }
+
+    @Test
+    public void testWithRobotsTxtContainingLocalhostReportsUpWithIssues() {
+        when(restTemplate.getForEntity(anyString(), eq(String.class)))
+            .thenReturn(ResponseEntity.ok("<sitemap/>"));
+        when(restTemplate.getForObject(eq(BASE_URL + "/robots.txt"), eq(String.class)))
+            .thenReturn("Sitemap: http://localhost:8080/sitemap_index.xml");
+        when(restTemplate.getForObject(eq(BASE_URL), eq(String.class)))
+            .thenReturn("<html><body>Rendered content</body></html>");
+
+        Health health = seoHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(ActuatorConfiguration.UP_WITH_ISSUES_STATUS));
+        assertThat(health.getDetails(), is(Map.of(
+            SEOHealthIndicator.SITEMAP, SEOHealthIndicator.OK,
+            SEOHealthIndicator.ROBOTS_TXT, SEOHealthIndicator.ROBOTS_INVALID,
+            SEOHealthIndicator.SSR, SEOHealthIndicator.OK)));
+    }
+
+    @Test
+    public void testWithSsrDisabledReportsUpWithIssues() {
+        when(restTemplate.getForEntity(anyString(), eq(String.class)))
+            .thenReturn(ResponseEntity.ok("<sitemap/>"));
+        when(restTemplate.getForObject(eq(BASE_URL + "/robots.txt"), eq(String.class)))
+            .thenReturn("User-agent: *\nSitemap: " + BASE_URL + "/sitemap_index.xml");
+        when(restTemplate.getForObject(eq(BASE_URL), eq(String.class)))
+            .thenReturn("<ds-app></ds-app>");
+
+        Health health = seoHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(ActuatorConfiguration.UP_WITH_ISSUES_STATUS));
+        assertThat(health.getDetails(), is(Map.of(
+            SEOHealthIndicator.SITEMAP, SEOHealthIndicator.OK,
+            SEOHealthIndicator.ROBOTS_TXT, SEOHealthIndicator.OK,
+            SEOHealthIndicator.SSR, SEOHealthIndicator.SSR_DISABLED)));
+    }
+}


### PR DESCRIPTION
## References
* Fixes #12672
* Related to the existing `geoIp` health indicator, whose `UP_WITH_ISSUES` pattern is reused here.

## Description
The `seo` health indicator previously reported `DOWN` whenever any SEO check (sitemap, robots.txt, SSR) failed, which incorrectly degraded the overall application health. This PR changes it to report `UP_WITH_ISSUES` instead (matching the `geoIp` indicator), hardens the bean for Spring dependency injection, extracts the detail messages into reusable constants, and adds unit-test coverage.

## Instructions for Reviewers

List of changes in this PR:
* **Report `UP_WITH_ISSUES` instead of `DOWN`** — in `SEOHealthIndicator.doHealthCheck`, the failure branch now calls `builder.status(UP_WITH_ISSUES_STATUS)` rather than `builder.down()`, so failing SEO checks no longer mark the instance as `DOWN`. This mirrors the behaviour of `GeoIpHealthIndicator`.
* **Extracted detail messages into public constants** — `SITEMAP`, `ROBOTS_TXT`, `SSR`, `OK`, `SITEMAP_MISSING`, `ROBOTS_MISSING`, `ROBOTS_INVALID`, `SSR_DISABLED`. This removes duplicated literals between the `up`/`down` branches and lets tests assert on the same source of truth.
* **Made `restTemplate` non-`final`** so it can be replaced with a mock in unit tests (no behavioural change in production, still defaults to `new RestTemplate()`).
* **Added `SEOHealthIndicatorTest`** — a Mockito-based unit test (mirroring `GeoIpHealthIndicatorTest`) with mocked `ConfigurationService` and `RestTemplate`.

**How to test/review:**
* Run the unit test:
  `mvn test dspace-server-webapp -DskipUnitTests=false -Dtest=SEOHealthIndicatorTest  -DfailIfNoTests=false`
* The test covers four scenarios:
  1. All checks pass → status `UP`, details all `OK`.
  2. All checks fail (RestTemplate throws) → status `UP_WITH_ISSUES`, details `SITEMAP_MISSING` / `ROBOTS_MISSING` / `SSR_DISABLED`.
  3. `robots.txt` contains `localhost` URLs → status `UP_WITH_ISSUES`, `robots.txt` = `ROBOTS_INVALID`.
  4. SSR disabled (response contains `<ds-app></ds-app>`) → status `UP_WITH_ISSUES`, `ssr` = `SSR_DISABLED`.
* Manual check: as an admin, `GET /actuator/health` and confirm that when SEO checks fail the overall status is `UP_WITH_ISSUES` rather than `DOWN`.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. _(N/A — no new dependencies.)_
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. _(N/A — no REST contract change; `/actuator/health` response structure is unchanged, only the reported status value differs.)_
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. _(N/A — no new configuration.)_
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
