### PR TITLE
Fix unit conversion in BitstreamStorageServiceImpl::isRecent method

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
@@ -463,9 +464,9 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
             return true;
         }
 
-        long waitHours = configurationService.getLongProperty("bitstream.cleanup.isRecent.hours", 1L);
-        long waitMilli = waitHours * 60 * 60 * 1000;
-        return (now - lastModified) < waitMilli;
+        long waitWindowHours = configurationService.getLongProperty("bitstream.cleanup.isRecent.hours", 1L);
+        long waitWindowMilli = TimeUnit.HOURS.toMillis(waitWindowHours);
+        return (now - lastModified) < waitWindowMilli;
     }
 
     protected BitStoreService getStore(int position) throws IOException {

--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -459,13 +459,13 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
     protected boolean isRecent(Long lastModified) {
         long now = Instant.now().toEpochMilli();
 
-        if (lastModified >= now) {
+        if (lastModified == null || lastModified >= now) {
             return true;
         }
 
-        // Less than one hour old
-        return (now - lastModified) <
-                (configurationService.getLongProperty("bitstream.cleanup.isRecent.hours", 1L) * 60 * 1000);
+        long waitHours = configurationService.getLongProperty("bitstream.cleanup.isRecent.hours", 1L);
+        long waitMilli = waitHours * 60 * 60 * 1000;
+        return (now - lastModified) < waitMilli;
     }
 
     protected BitStoreService getStore(int position) throws IOException {


### PR DESCRIPTION
## Description

While investigating why the cleanup cronjob wasn't working as expected, I discovered that the unit conversion from hours to milliseconds was missing a multiplication by 60 in a helper method.

The value used for the wait window was intended to be in hours, but the calculation resulted in minutes (i.e., 1 minute by default).

## Instructions for Reviewers

List of changes in this PR:
* Fix unit conversion and also handles possible null value for safety

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
