### PR TITLE
[Port dspace-8_x] Restrict External Sources in REST API to logged in users

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ExternalSourcesRestController.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.PagedModel;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -54,6 +55,7 @@ public class ExternalSourcesRestController {
      * @return              A paginated list of ExternalSourceEntryResource objects that comply with the params
      */
     @RequestMapping(method = RequestMethod.GET, value = "/entries")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public PagedModel<ExternalSourceEntryResource> getExternalSourceEntries(
         @PathVariable("externalSourceName") String externalSourceName,
         @RequestParam(name = "query") String query,
@@ -81,6 +83,7 @@ public class ExternalSourcesRestController {
      * @return              An ExternalSourceEntryResource that complies with the above params
      */
     @RequestMapping(method = RequestMethod.GET, value = "/entryValues/{entryId}")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public ExternalSourceEntryResource getExternalSourceEntryValue(@PathVariable("externalSourceName") String
                                                                            externalSourceName,
                                                                    @PathVariable("entryId") String entryId) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ExternalSourceRestRepository.java
@@ -82,7 +82,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
     }
 
     @Override
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public ExternalSourceRest findOne(Context context, String externalSourceName) {
         ExternalDataProvider externalDataProvider = externalDataService.getExternalDataProvider(externalSourceName);
         if (externalDataProvider == null) {
@@ -93,7 +93,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
     }
 
     @Override
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public Page<ExternalSourceRest> findAll(Context context, Pageable pageable) {
         List<ExternalDataProvider> externalSources = externalDataService.getExternalDataProviders();
         return converter.toRestPage(externalSources, pageable, utils.obtainProjection());
@@ -107,7 +107,7 @@ public class ExternalSourceRestRepository extends DSpaceRestRepository<ExternalS
      * @param entityType    Entity type label
      * @return
      */
-    @PreAuthorize("permitAll()")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
     @SearchRestMethod(name = "findByEntityType")
     public Page<ExternalSourceRest> findByEntityType(Context context, Pageable pageable,
           @Parameter(required = true, value = "entityType") String entityType) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ExternalSourcesRestControllerIT.java
@@ -26,6 +26,7 @@ import org.dspace.external.provider.AbstractExternalDataProvider;
 import org.dspace.external.provider.ExternalDataProvider;
 import org.dspace.external.service.ExternalDataService;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -34,9 +35,19 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     @Autowired
     private ExternalDataService externalDataService;
 
+    String token;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
+    }
+
     @Test
     public void findAllExternalSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources"))
+        getClient(token).perform(get("/api/integration/externalsources"))
                             .andExpect(status().isOk())
                             .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItems(
                                 ExternalSourceMatcher.matchExternalSource("mock", "mock", false),
@@ -58,22 +69,35 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
+    public void findAllExternalSourcesAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources").param("size", "21"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findOneExternalSourcesExistingSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock"))
+        getClient(token).perform(get("/api/integration/externalsources/mock"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.is(
                        ExternalSourceMatcher.matchExternalSource("mock", "mock", false)
                    )));
     }
+
+    @Test
+    public void findOneExternalSourcesExistingSourcesAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/mock"))
+                        .andExpect(status().isUnauthorized());
+    }
+
     @Test
     public void findOneExternalSourcesNotExistingSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock2"))
+        getClient(token).perform(get("/api/integration/externalsources/mock2"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntryValue() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entryValues/one"))
+        getClient(token).perform(get("/api/integration/externalsources/mock/entryValues/one"))
                    .andExpect(status().isOk())
                     .andExpect(jsonPath("$", Matchers.is(
                         ExternalSourceEntryMatcher.matchExternalSourceEntry("one", "one", "one", "mock")
@@ -81,27 +105,33 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
+    public void findOneExternalSourceEntryValueAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/mock/entryValues/one"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findOneExternalSourceEntryValueInvalidEntryId() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entryValues/entryIdInvalid"))
+        getClient(token).perform(get("/api/integration/externalsources/mock/entryValues/entryIdInvalid"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntryValueInvalidSource() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mocktwo/entryValues/one"))
+        getClient(token).perform(get("/api/integration/externalsources/mocktwo/entryValues/one"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntriesInvalidSource() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mocktwo/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mocktwo/entries")
                                 .param("query", "test"))
                    .andExpect(status().isNotFound());
     }
 
     @Test
     public void findOneExternalSourceEntriesApplicableQuery() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "one"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.containsInAnyOrder(
@@ -112,8 +142,15 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
-    public void findOneExternalSourceEntriesApplicableQueryPagination() throws Exception {
+    public void findOneExternalSourceEntriesApplicableQueryAnonymous() throws Exception {
         getClient().perform(get("/api/integration/externalsources/mock/entries")
+                                     .param("query", "one"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findOneExternalSourceEntriesApplicableQueryPagination() throws Exception {
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "one").param("size", "1"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(
@@ -121,7 +158,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                    )))
                    .andExpect(jsonPath("$.page", PageMatcher.pageEntryWithTotalPagesAndElements(0, 1, 2, 2)));
 
-        getClient().perform(get("/api/integration/externalsources/mock/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "one").param("size", "1").param("page", "1"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(
@@ -132,7 +169,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void findOneExternalSourceEntriesNoReturnQuery() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entries")
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries")
                                 .param("query", "randomqueryfornoresults"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded").doesNotExist());
@@ -140,7 +177,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
 
     @Test
     public void findOneExternalSourceEntriesNoQuery() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/mock/entries"))
+        getClient(token).perform(get("/api/integration/externalsources/mock/entries"))
                    .andExpect(status().isBadRequest());
     }
 
@@ -151,7 +188,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         List<ExternalDataProvider> journalProviders =
                 externalDataService.getExternalDataProvidersForEntityType("Journal");
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Publication"))
                    .andExpect(status().isOk())
                    // Expect that Publication sources match (check a max of 20 as that is default page size)
@@ -160,7 +197,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                               ))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(publicationProviders.size())));
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal"))
                    .andExpect(status().isOk())
                    // Check that Journal sources match (check a max of 20 as that is default page size)
@@ -171,8 +208,15 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
     }
 
     @Test
+    public void findExternalSourcesByEntityTypeAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+                        .param("entityType", "Publication"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findExternalSourcesByEntityTypeBadRequestTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType"))
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType"))
                    .andExpect(status().isBadRequest());
     }
 
@@ -186,7 +230,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
         int pageSize = 2;
         int numberOfPages = (int) Math.ceil((double) numJournalProviders / pageSize);
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal")
                    .param("size", String.valueOf(pageSize)))
                    .andExpect(status().isOk())
@@ -196,7 +240,7 @@ public class ExternalSourcesRestControllerIT extends AbstractControllerIntegrati
                    .andExpect(jsonPath("$.page.totalPages", Matchers.is(numberOfPages)))
                    .andExpect(jsonPath("$.page.totalElements", Matchers.is(numJournalProviders)));
 
-        getClient().perform(get("/api/integration/externalsources/search/findByEntityType")
+        getClient(token).perform(get("/api/integration/externalsources/search/findByEntityType")
                    .param("entityType", "Journal")
                    .param("page", "1")
                    .param("size", String.valueOf(pageSize)))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenaireFundingExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OpenaireFundingExternalSourcesIT.java
@@ -17,9 +17,20 @@ import org.dspace.app.rest.matcher.ExternalSourceEntryMatcher;
 import org.dspace.app.rest.matcher.ExternalSourceMatcher;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 
 public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrationTest {
+
+    String token;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
+    }
 
     /**
      * Test openaire funding external source
@@ -28,7 +39,7 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
      */
     @Test
     public void findOneOpenaireFundingExternalSourceTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources")).andExpect(status().isOk())
+        getClient(token).perform(get("/api/integration/externalsources")).andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.externalsources", Matchers.hasItem(
                         ExternalSourceMatcher.matchExternalSource("openaireFunding", "openaireFunding", false))));
     }
@@ -40,9 +51,16 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
      */
     @Test
     public void findOneOpenaireFundingExternalSourceEntriesEmptyWithQueryTest() throws Exception {
-
-        getClient().perform(get("/api/integration/externalsources/openaireFunding/entries").param("query", "empty"))
+        getClient(token).perform(get("/api/integration/externalsources/openaireFunding/entries")
+                                     .param("query", "empty"))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
+    }
+
+    @Test
+    public void findOneOpenaireFundingExternalSourceEntriesEmptyWithQueryAnonymousTest() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/openaireFunding/entries")
+                                     .param("query", "empty"))
+                        .andExpect(status().isUnauthorized());
     }
 
     /**
@@ -54,7 +72,7 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
     @Test
     public void findOneOpenaireFundingExternalSourceEntriesWithQueryMultipleKeywordsTest() throws Exception {
 
-        getClient()
+        getClient(token)
                 .perform(
                         get("/api/integration/externalsources/openaireFunding/entries").param("query", "empty+results"))
                 .andExpect(status().isOk()).andExpect(jsonPath("$.page.number", is(0)));
@@ -67,7 +85,8 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
      */
     @Test
     public void findOneOpenaireFundingExternalSourceEntriesWithQueryTest() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/openaireFunding/entries").param("query", "mushroom"))
+        getClient(token).perform(get("/api/integration/externalsources/openaireFunding/entries")
+                                     .param("query", "mushroom"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.externalSourceEntries",
                         Matchers.hasItem(ExternalSourceEntryMatcher.matchExternalSourceEntry(
@@ -90,7 +109,7 @@ public class OpenaireFundingExternalSourcesIT extends AbstractControllerIntegrat
         String projectName = "Portuguese Wild Mushrooms: Chemical characterization and functional study"
                 + " of antiproliferative and proapoptotic properties in cancer cell lines";
 
-        getClient().perform(get("/api/integration/externalsources/openaireFunding/entryValues/" + projectID))
+        getClient(token).perform(get("/api/integration/externalsources/openaireFunding/entryValues/" + projectID))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$",
                         Matchers.allOf(hasJsonPath("$.id", is(projectID)), hasJsonPath("$.display", is(projectName)),

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/OrcidExternalSourcesIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/OrcidExternalSourcesIT.java
@@ -23,6 +23,7 @@ import org.dspace.external.provider.impl.OrcidV3AuthorDataProvider;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -55,9 +56,19 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
         }
     }
 
+    String token;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        // All tests just require basic authentication privileges
+        token = getAuthToken(eperson.getEmail(), password);
+    }
+
     @Test
     public void findOneExternalSourcesExistingSources() throws Exception {
-        getClient().perform(get("/api/integration/externalsources/orcid"))
+        getClient(token).perform(get("/api/integration/externalsources/orcid"))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.allOf(
                            hasJsonPath("$.id", is("orcid")),
@@ -68,11 +79,17 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void findOneExternalSourcesExistingSourcesAnonymous() throws Exception {
+        getClient().perform(get("/api/integration/externalsources/orcid"))
+                        .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void findOneExternalSourcesExistingSourcesWithentryValueTest() throws Exception {
         // this test will query the real ORCID API if configured in the CI otherwise will be skipped
         onlyRunIfConfigExists();
         String entry = "0000-0002-9029-1854";
-        getClient().perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.allOf(
                            hasJsonPath("$.id", is(entry)),
@@ -92,7 +109,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
         // this test will query the real ORCID API if configured in the CI otherwise will be skipped
         onlyRunIfConfigExists();
         String q = "orcid:0000-0002-9029-1854";
-        getClient().perform(get("/api/integration/externalsources/orcid/entries")
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                    .param("query", q))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries[0]", Matchers.allOf(
@@ -117,7 +134,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
         // this test will query the real ORCID API if configured in the CI otherwise will be skipped
         onlyRunIfConfigExists();
         String q = "family-name:bollini AND given-names:andrea";
-        getClient().perform(get("/api/integration/externalsources/orcid/entries")
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                    .param("query", q))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(
@@ -158,7 +175,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                 });
 
         String entry = "0000-0002-9029-1854";
-        getClient().perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
+        getClient(token).perform(get("/api/integration/externalsources/orcid/entryValues/" + entry))
                    .andExpect(status().isOk())
                    .andExpect(jsonPath("$", Matchers.allOf(
                            hasJsonPath("$.id", is(entry)),
@@ -200,7 +217,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                         }
                     });
             String q = "orcid:0000-0002-9029-1854";
-            getClient().perform(get("/api/integration/externalsources/orcid/entries")
+            getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                        .param("query", q))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries[0]", Matchers.allOf(
@@ -253,7 +270,7 @@ public class OrcidExternalSourcesIT extends AbstractControllerIntegrationTest {
                         }
                     });
             String q = "family-name:bollini AND given-names:andrea";
-            getClient().perform(get("/api/integration/externalsources/orcid/entries")
+            getClient(token).perform(get("/api/integration/externalsources/orcid/entries")
                        .param("query", q))
                        .andExpect(status().isOk())
                        .andExpect(jsonPath("$._embedded.externalSourceEntries", Matchers.hasItem(


### PR DESCRIPTION
Manual port of #12660 to `dspace-8_x`.  

This PR is not identical because some of the fixed ITs in #12660 do **not** exist in `dspace-9_x`.  Therefore, only the first two commits were ported (and the second commit had to be updated for minor code conflicts and the removal of all OpenAlex-related ITs, as those didn't exist in 8.x)