### PR TITLE
[GitHub Actions] Fix our broken `port_pr` action after the upgrade to `checkout@v7`

### DIFF
--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -19,11 +19,21 @@ permissions:
 jobs:
   port_pr:
     runs-on: ubuntu-slim
-    # Don't run on closed *unmerged* pull requests
-    if: github.event.pull_request.merged
+    # Only run on MERGED pull requests,
+    # and only run if the merged PR has a label that starts with "port to"
+    if: >
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"port to ')
     steps:
       # Checkout code
       - uses: actions/checkout@v7
+        with:
+          # When using 'pull_request_target' (see above), this 'checkout' step will always fail because it
+          # may make the codebase vulnerable to "pwn requests" via the user-created PR.
+          # See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          # However, we are allowing this unsafe checkout because (1) it's required to backport the PR, and
+          # (2) this job only runs when a PR is MERGED, and merger only happens after a thorough review of the PR.
+          allow-unsafe-pr-checkout: true
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests


### PR DESCRIPTION
## Description

As of `checkout@v7`, for security reasons the `checkout` action will **always fail** when run on the `pull_request_target` event.  

See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target

However, we need to run the `port_pr` job on the `pull_request_target` event to allow it to create backported PRs.  We also need to run the `checkout` command in order to checkout the code which is being backported.

Therefore, this small PR enables the `allow-unsafe-pr-checkout` option of the `checkout` job.  While this is bypassing security protections, in this scenario I feel we are safe **because this job ONLY triggers during PR merger, and we ONLY merge PRs which are tested, reviewed and trusted** (and scanned by CodeQL for security).  

Therefore, it should not be possible for someone to add code in a PR which can result in an attack on the DSpace codebase.  Those attacks should be found by human reviewers, human testers or CodeQL _before merger would occur_.

This PR also includes a very tiny improvement:
* Ensure this `port_pr` job will trigger if a `port to...` label exists on the PR.  
    * This doesn't change behavior, as the job currently will run & do nothing if that label doesn't exist.  But, this small change just ensures the job doesn't even run if the label doesn't exist.

**NOTE:** This PR will need to be backported to all active branches to ensure the same settings exist for PRs on all branches.  It also must be ported to the `DSpace/dspace-angular` repository.

## Instructions for Reviewers
* Verify you agree with the changed settings in this PR, especially the newly added `allow-unsafe-pr-checkout` option