### PR TITLE
[GitHub Actions] Skip Codecov step on forked repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,9 @@ jobs:
   codecov:
     # Must run after 'tests' job above
     needs: tests
+    # Only run on the upstream repository: forks do not have the CODECOV_TOKEN secret,
+    # and Codecov refuses to create a commit on a protected branch without a token.
+    if: github.repository == 'dspace/dspace'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## References
* Partial port of https://github.com/DSpace/dspace-angular/pull/5661 to our backend repo  (This PR just ports the CodeCov settings, as the GHCR ones don't apply to the backend)

## Description
This small PR ensures that the `codecov` step of our build process in `build.yml` does NOT execute on forks of our repository, because those forks may or may not use Codecov.

In other words, the new behavior would be:
* If the commit or PR is created against https://github.com/DSpace/dspace/, then Codecov task would still run
* However, if the commit or PR is created against a fork (like https://github.com/tdonohue/dspace/), then the Codecov task would be skipped.  (The forked repo could decide to reenable this by removing the check)