### PR TITLE
[dspace-9_x] Use ThreadLocal collection during authority resolution for imports

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -78,6 +78,7 @@ import org.dspace.content.BitstreamFormat;
 import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.DSpaceObjectServiceImpl;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataField;
 import org.dspace.content.MetadataSchema;
@@ -756,7 +757,14 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         String itemPathDir = itemPath.toString() + File.separatorChar;
 
         // now fill out dublin core for item
-        loadMetadata(c, myitem, itemPathDir);
+        Collection authorityCollection = mycollections.iterator().next();
+        try {
+            // Make the target collection available during authority resolution until the item has an owning collection.
+            DSpaceObjectServiceImpl.setIngestCollection(authorityCollection);
+            loadMetadata(c, myitem, itemPathDir);
+        } finally {
+            DSpaceObjectServiceImpl.clearIngestCollection();
+        }
 
         // and the bitstreams from the contents file
         // process contents file, add bistreams and bundles, return any

--- a/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/DSpaceObjectServiceImpl.java
@@ -55,6 +55,8 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
      */
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(DSpaceObjectServiceImpl.class);
 
+    private static final ThreadLocal<Collection> ingestCollection = new ThreadLocal<>();
+
     @Autowired(required = true)
     protected ChoiceAuthorityService choiceAuthorityService;
     @Autowired(required = true)
@@ -368,13 +370,11 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
             if (metadataAuthorityService.isAuthorityControlled(fieldKey)) {
                 List<String> authorities = new ArrayList<>();
                 List<Integer> confidences = new ArrayList<>();
+                // Resolve the collection from the import context when the item has not yet been assigned an owning
+                // collection.
+                Collection collection = resolveAuthorityCollection(dso);
                 for (int i = 0; i < values.size(); ++i) {
-                    if (dso instanceof Item) {
-                        getAuthoritiesAndConfidences(fieldKey, ((Item) dso).getOwningCollection(), values, authorities,
-                                                     confidences, i);
-                    } else {
-                        getAuthoritiesAndConfidences(fieldKey, null, values, authorities, confidences, i);
-                    }
+                    getAuthoritiesAndConfidences(fieldKey, collection, values, authorities, confidences, i);
                 }
                 return addMetadata(context, dso, metadataField, language, values, authorities, confidences);
             } else {
@@ -549,6 +549,22 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
 
         // If we get this far, we have a match
         return true;
+    }
+
+    /**
+     * Resolve the collection to use for authority resolution.
+     * Falls back to the current import context when the item has not yet been
+     * assigned an owning collection.
+     *
+     * @param dso the DSpace object being updated
+     * @return the collection to use for authority resolution, or {@code null} if none is available
+     */
+    protected Collection resolveAuthorityCollection(T dso) {
+        Collection collection = ingestCollection.get();
+        if (collection == null && dso instanceof Item) {
+            collection = ((Item) dso).getOwningCollection();
+        }
+        return collection;
     }
 
     protected void getAuthoritiesAndConfidences(String fieldKey, Collection collection, List<String> values,
@@ -857,6 +873,23 @@ public abstract class DSpaceObjectServiceImpl<T extends DSpaceObject> implements
 
         throw new NotImplementedException();
 
+    }
+
+
+    /**
+     * Set the collection to use for authority resolution during import.
+     *
+     * @param collection the import target collection
+     */
+    public static void setIngestCollection(Collection collection) {
+        ingestCollection.set(collection);
+    }
+
+    /**
+     * Clear the import collection context used for authority resolution.
+     */
+    public static void clearIngestCollection() {
+        ingestCollection.remove();
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/AbstractMETSIngester.java
@@ -35,6 +35,7 @@ import org.dspace.content.Bundle;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
+import org.dspace.content.DSpaceObjectServiceImpl;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.content.WorkspaceItem;
@@ -458,8 +459,13 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
 
         // -- Step 4 --
         // Run our Descriptive metadata (dublin core, etc) crosswalks!
-        crosswalkObjectDmd(context, dso, manifest, callback, manifest
-            .getItemDmds(), params);
+        // Make the target collection available during authority resolution while crosswalking metadata.
+        Collection authorityCollection = null;
+        if (parent != null && parent.getType() == Constants.COLLECTION) {
+            authorityCollection = (Collection) parent;
+        }
+        crosswalkObjectDmdForIngest(context, dso, manifest, callback, manifest.getItemDmds(), params,
+                                    authorityCollection);
 
         // For Items, also sanity-check the metadata for minimum requirements.
         if (type == Constants.ITEM) {
@@ -625,6 +631,7 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
 
         // -- Step 4 --
         // Add all content files as bitstreams on new DSpace Object
+        Collection authorityCollection = null;
         if (dso.getType() == Constants.ITEM) {
             Item item = (Item) dso;
 
@@ -637,22 +644,22 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
             addBitstreams(context, item, manifest, pkgFile, params, callback);
 
             // have subclass manage license since it may be extra package file.
-            Collection owningCollection = (Collection) ContentServiceFactory.getInstance().getDSpaceObjectService(dso)
-                                                                            .getParentObject(context, dso);
-            if (owningCollection == null) {
+            authorityCollection = (Collection) ContentServiceFactory.getInstance().getDSpaceObjectService(dso)
+                                                                    .getParentObject(context, dso);
+            if (authorityCollection == null) {
                 //We are probably dealing with an item that isn't archived yet
                 InProgressSubmission inProgressSubmission = workspaceItemService.findByItem(context, item);
                 if (inProgressSubmission == null) {
                     inProgressSubmission = WorkflowServiceFactory.getInstance().getWorkflowItemService()
                                                                  .findByItem(context, item);
                 }
-                owningCollection = inProgressSubmission.getCollection();
+                authorityCollection = inProgressSubmission.getCollection();
             }
 
-            itemService.populateWithTemplateItemMetadata(context, owningCollection, params.useCollectionTemplate(),
+            itemService.populateWithTemplateItemMetadata(context, authorityCollection, params.useCollectionTemplate(),
                 item);
 
-            addLicense(context, item, license, owningCollection
+            addLicense(context, item, license, authorityCollection
                 , params);
 
             // FIXME ?
@@ -668,8 +675,8 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
 
         // -- Step 5 --
         // Run our Descriptive metadata (dublin core, etc) crosswalks!
-        crosswalkObjectDmd(context, dso, manifest, callback, manifest
-            .getItemDmds(), params);
+        crosswalkObjectDmdForIngest(context, dso, manifest, callback, manifest.getItemDmds(), params,
+                                    authorityCollection);
 
         // For Items, also sanity-check the metadata for minimum requirements.
         if (dso.getType() == Constants.ITEM) {
@@ -1017,7 +1024,8 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                     Element[] templateDmds = manifest.getDmdElements(templateDmdIds);
 
                     // Run our Descriptive metadata (dublin core, etc) crosswalks to add metadata to template item
-                    crosswalkObjectDmd(context, templateItem, manifest, callback, templateDmds, params);
+                    crosswalkObjectDmdForIngest(context, templateItem, manifest, callback, templateDmds, params,
+                                                collection);
 
                     // update the template item to save metadata changes
                     PackageUtils.updateDSpaceObject(context, templateItem);
@@ -1456,6 +1464,32 @@ public abstract class AbstractMETSIngester extends AbstractPackageIngester {
                                             PackageParameters params) throws CrosswalkException,
         PackageValidationException, AuthorizeException, SQLException,
         IOException;
+
+    /**
+     * Crosswalk descriptive metadata while making the target collection available
+     * for authority resolution during ingest.
+     *
+     * @param context the DSpace context
+     * @param dso the target DSpace object
+     * @param manifest the METS manifest
+     * @param callback the ingest callback
+     * @param dmdSecs the descriptive metadata sections
+     * @param params package parameters
+     * @param collection the target collection for authority resolution
+     */
+    private void crosswalkObjectDmdForIngest(Context context, DSpaceObject dso, METSManifest manifest,
+                                             MdrefManager callback, Element[] dmds, PackageParameters params,
+                                             Collection collection)
+        throws CrosswalkException, PackageValidationException, AuthorizeException, SQLException, IOException {
+        try {
+            if (collection != null) {
+                DSpaceObjectServiceImpl.setIngestCollection(collection);
+            }
+            crosswalkObjectDmd(context, dso, manifest, callback, dmds, params);
+        } finally {
+            DSpaceObjectServiceImpl.clearIngestCollection();
+        }
+    }
 
     /**
      * Add license(s) to Item based on contents of METS and other policies. The


### PR DESCRIPTION
## References
* Fixes #12816

## Description
Ensure authority-controlled metadata can be resolved during item imports before the item has an owning collection. This updates the import flows to provide the target collection during authority resolution for both SAF and METS/SWORD ingestion.

## Instructions for Reviewers
List of changes in this PR:
* Added a temporary collection context in `DSpaceObjectServiceImpl` to use during authority resolution when an item has no owning collection yet.
* Updated `AbstractMETSIngester` to set and clear the collection context while ingesting descriptive metadata.
* Updated `ItemImportServiceImpl` to set and clear the collection context while loading metadata during SAF imports.

#### SAF import
1. Configure an authority-controlled metadata field (e.g. `dc.subject`).
2. Import an SAF package containing a value for that metadata field.
3. Verify the import completes successfully and no `NullPointerException` occurs during authority resolution.

#### METS/SWORD import
1. Configure the same authority-controlled metadata field.
2. Deposit a METS/SWORD package containing that metadata.
3. Verify the package is imported successfully and authority resolution completes without errors.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
