### PR TITLE
[Port dspace-9_x] [GitHub Actions] Fix our broken `port_pr` action after the upgrade to `checkout@v7`

### DIFF
--- a/.github/workflows/port_merged_pull_request.yml
+++ b/.github/workflows/port_merged_pull_request.yml
@@ -18,12 +18,22 @@ permissions:
 
 jobs:
   port_pr:
-    runs-on: ubuntu-latest
-    # Don't run on closed *unmerged* pull requests
-    if: github.event.pull_request.merged
+    runs-on: ubuntu-slim
+    # Only run on MERGED pull requests,
+    # and only run if the merged PR has a label that starts with "port to"
+    if: >
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"port to ')
     steps:
       # Checkout code
       - uses: actions/checkout@v7
+        with:
+          # When using 'pull_request_target' (see above), this 'checkout' step will always fail because it
+          # may make the codebase vulnerable to "pwn requests" via the user-created PR.
+          # See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          # However, we are allowing this unsafe checkout because (1) it's required to backport the PR, and
+          # (2) this job only runs when a PR is MERGED, and merger only happens after a thorough review of the PR.
+          allow-unsafe-pr-checkout: true
       # Port PR to other branch (ONLY if labeled with "port to")
       # See https://github.com/korthout/backport-action
       - name: Create backport pull requests


### PR DESCRIPTION
Manual port of #12812 to `dspace-9_x` branch