### PR TITLE
[Port dspace-8_x] [GitHub Actions] Skip Codecov step on forked repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,9 @@ jobs:
   codecov:
     # Must run after 'tests' job above
     needs: tests
+    # Only run on the upstream repository: forks do not have the CODECOV_TOKEN secret,
+    # and Codecov refuses to create a commit on a protected branch without a token.
+    if: github.repository == 'dspace/dspace'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Manual port of #12814 to `dspace-8_x`