### PR TITLE
CODE_STYLE.md: suggest avoiding magic numbers

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -124,6 +124,21 @@ the [`checkstyle-suppressions.xml`](checkstyle-suppressions.xml) configuration f
     * http://www.dspace.org/license/
     */
    ```
+13. Prefer named constants, enum constants, or standard library utility methods over magic numbers.
+  * For HTTP status codes, use enums (e.g., `HttpStatus.NO_CONTENT` instead of `204`).
+  * For DSpace entities, use defined constants, such as `Constants.ITEM` instead of `2`.
+  * For time-based calculations, use `java.util.concurrent.TimeUnit` instead of manual multiplication, e.g.
+   ```java
+   // This is INCORRECT. These values lack context, and manual arithmetic is prone to errors.
+   if (status == 204) { ... }
+   if (type == 3) { ... }
+   long waitWindow = waitHours * 60 * 60 * 1000;
+
+   // This is CORRECT. The code is self-documenting.
+   if (status == HttpStatus.NO_CONTENT) { ... }
+   if (type == Constants.ITEM) { ...}
+   long waitWindow = TimeUnit.HOURS.toMillis(waitHours);
+   ```
 
 ## IDE Support
 


### PR DESCRIPTION
This PR adds a new recommendation to CODE_STYLE.md to avoid magic numbers (e.g. `variable * 60 * 60 * 1000`) and instead prefer named constants, enums, or standard library utility methods (e.g. `TimeUnit.HOURS.toMillis(variable)`).

Documentation change only. No testing required.