### PR TITLE
fix(ldn): add ActivityStreams2 Page type to COAR notify templates

### DIFF
--- a/dspace/config/ldn/announce-relationship
+++ b/dspace/config/ldn/announce-relationship
@@ -35,7 +35,10 @@
         "sorg:ScholarlyArticle"
       ]
     },
-    "type": "sorg:AboutPage"
+    "type": [
+      "Page",
+      "sorg:AboutPage"
+    ]
   },
   "id": "${params[9]}",
   "object": {

--- a/dspace/config/ldn/request-endorsement
+++ b/dspace/config/ldn/request-endorsement
@@ -27,7 +27,10 @@
   "object": {
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
-    "type": "sorg:AboutPage",
+    "type": [
+      "Page",
+      "sorg:AboutPage"
+    ],
     "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",

--- a/dspace/config/ldn/request-endorsement-resubmission
+++ b/dspace/config/ldn/request-endorsement-resubmission
@@ -28,7 +28,10 @@
   "object": {
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
-    "type": "sorg:AboutPage",
+    "type": [
+      "Page",
+      "sorg:AboutPage"
+    ],
     "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",

--- a/dspace/config/ldn/request-ingest
+++ b/dspace/config/ldn/request-ingest
@@ -25,7 +25,10 @@
   "object": {
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
-    "type": "sorg:AboutPage",
+    "type": [
+      "Page",
+      "sorg:AboutPage"
+    ],
     "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",

--- a/dspace/config/ldn/request-review
+++ b/dspace/config/ldn/request-review
@@ -26,7 +26,10 @@
   "object": {
     "id": "${params[5]}",
     "ietf:cite-as": "${params[6]}",
-    "type": "sorg:AboutPage",
+    "type": [
+      "Page",
+      "sorg:AboutPage"
+    ],
     "ietf:item": {
       "id": "${params[7]}",
       "mediaType": "${params[8]}",


### PR DESCRIPTION
## References
* Fixes #12828

## Description
Default COAR Notify LDN templates listed `sorg:AboutPage` alone for the resource page type. Per the [COAR Notify specification](https://coar-notify.net/specification/1.0.1/request-endorsement/), the mandatory ActivityStreams2 `Page` class must also be present.

## Instructions for Reviewers
List of changes in this PR:
* Updated `object.type` in `request-review`, `request-endorsement`, `request-endorsement-resubmission`, and `request-ingest` from `"sorg:AboutPage"` to `["Page", "sorg:AboutPage"]`
* Updated `context.type` in `announce-relationship` with the same `Page` + `sorg:AboutPage` array (that template places the AboutPage on `context` rather than `object`)

**How to test/review:**
1. Compare each updated file under `dspace/config/ldn/` against the corresponding COAR Notify example JSON (e.g. [request-endorsement/index.json](https://coar-notify.net/specification/1.0.1/request-endorsement/index.json))
2. Confirm the `$object.type` (or `$context.type` for announce-relationship) now includes both `Page` and `sorg:AboutPage`

No Java code or REST API changes; config-only JSON template update.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md). _(N/A — config JSON only)_
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. _(N/A — no Java changes)_
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). _(N/A — config-only change)_
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. _(N/A)_
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. _(N/A)_
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).


Made with [Cursor](https://cursor.com)