### PR TITLE
W2P-141449 Heartbeat support for scripts & processes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
+++ b/dspace-api/src/main/java/org/dspace/administer/ProcessCleaner.java
@@ -103,6 +103,7 @@ public class ProcessCleaner extends DSpaceRunnable<ProcessCleanerConfiguration<P
         handler.logInfo("Found " + processes.size() + " processes to be deleted");
         for (Process process : processes) {
             processService.delete(context, process);
+            handler.registerHeartbeat();
         }
 
         handler.logInfo("Process cleanup completed");

--- a/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkaccesscontrol/BulkAccessControl.java
@@ -370,6 +370,7 @@ public class BulkAccessControl extends DSpaceRunnable<BulkAccessControlScriptCon
 
             context.commit();
             context.uncacheEntity(item);
+            handler.registerHeartbeat();
             counter++;
 
             if (counter == limit) {

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -622,6 +622,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             if (change && (rowCount % configurationService.getIntProperty("bulkedit.change.commit.count", 100) == 0)) {
                 c.commit();
                 handler.logInfo(LogHelper.getHeader(c, "metadata_import_commit", "lineNumber=" + rowCount));
+                handler.registerHeartbeat();
             }
             populateRefAndRowMap(line, item == null ? null : item.getID());
             // keep track of current rows processed

--- a/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
+++ b/dspace-api/src/main/java/org/dspace/app/harvest/Harvest.java
@@ -374,7 +374,7 @@ public class Harvest extends DSpaceRunnable<HarvestScriptConfiguration> {
         try {
             Collection collection = resolveCollection(context, collectionID);
             HarvestedCollection hc = harvestedCollectionService.find(context, collection);
-            harvester = new OAIHarvester(context, collection, hc);
+            harvester = new OAIHarvester(context, collection, hc, handler);
             handler.logInfo("Initialized the harvester successfully");
         } catch (HarvestingException hex) {
             handler.logError("Initializing the harvester failed.");

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -151,6 +151,7 @@ public class ItemExportServiceImpl implements ItemExportService {
             Item item = i.next();
             exportItem(c, item, fullPath, mySequenceNumber, migrate, excludeBitstreams);
             c.uncacheEntity(item);
+            handler.registerHeartbeat();
             mySequenceNumber++;
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -320,6 +320,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                     itemFolderMap.put(dircontents[i], item);
 
                     c.uncacheEntity(item);
+                    handler.registerHeartbeat();
                     logInfo(i + " " + dircontents[i]);
                 }
             }
@@ -689,6 +690,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             Item newItem = addItem(c, mycollections, sourceDir, newItemName, null, template);
             c.uncacheEntity(oldItem);
             c.uncacheEntity(newItem);
+            handler.registerHeartbeat();
         }
     }
 
@@ -715,6 +717,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                 logInfo("Deleting item " + itemID);
                 deleteItem(c, myitem);
                 c.uncacheEntity(myitem);
+                handler.registerHeartbeat();
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -320,7 +320,9 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                     itemFolderMap.put(dircontents[i], item);
 
                     c.uncacheEntity(item);
-                    handler.registerHeartbeat();
+                    if (handler != null) {
+                        handler.registerHeartbeat();
+                    }
                     logInfo(i + " " + dircontents[i]);
                 }
             }
@@ -690,7 +692,9 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             Item newItem = addItem(c, mycollections, sourceDir, newItemName, null, template);
             c.uncacheEntity(oldItem);
             c.uncacheEntity(newItem);
-            handler.registerHeartbeat();
+            if (handler != null) {
+                handler.registerHeartbeat();
+            }
         }
     }
 
@@ -717,7 +721,9 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                 logInfo("Deleting item " + itemID);
                 deleteItem(c, myitem);
                 c.uncacheEntity(myitem);
-                handler.registerHeartbeat();
+                if (handler != null) {
+                    handler.registerHeartbeat();
+                }
             }
         }
     }

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -196,6 +196,7 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             // commit after each item to release DB resources
             c.commit();
             currentItem = null;
+            handler.registerHeartbeat();
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/MediaFilterServiceImpl.java
@@ -196,7 +196,9 @@ public class MediaFilterServiceImpl implements MediaFilterService, InitializingB
             // commit after each item to release DB resources
             c.commit();
             currentItem = null;
-            handler.registerHeartbeat();
+            if (handler != null) {
+                handler.registerHeartbeat();
+            }
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -99,7 +99,9 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
             Item item = toExport.next();
             csv.addItem(item);
             context.uncacheEntity(item);
-            handler.registerHeartbeat();
+            if (handler != null) {
+                handler.registerHeartbeat();
+            }
         }
 
         context.setMode(originalMode);

--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -81,6 +81,7 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
         }
 
         DSpaceCSV csv = this.export(context, toExport, exportAllMetadata, handler);
+        DSpaceCSV csv = this.export(context, toExport, exportAllMetadata, handler);
         return csv;
     }
 
@@ -144,6 +145,33 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
         }
 
         return result.iterator();
+    }
+
+    /**
+     * Exports the given items to a DSpaceCSV. Registers a heartbeat after every item exported.
+     *
+     * @param context       The DSpace context
+     * @param toExport      Iterator over the items to export
+     * @param exportAll     Whether to export all metadata fields or only the non-hidden ones
+     * @param handler       The handler to register the heartbeat with
+     * @return              A DSpaceCSV containing the exported items
+     * @throws Exception    If something goes wrong during the export
+     */
+    @Override
+    public DSpaceCSV export(Context context, Iterator<Item> toExport, boolean exportAll,
+                            DSpaceRunnableHandler handler) throws Exception {
+        Context.Mode originalMode = context.getCurrentMode();
+        context.setMode(Context.Mode.READ_ONLY);
+        DSpaceCSV csv = new DSpaceCSV(exportAll);
+        while (toExport.hasNext()) {
+            Item item = toExport.next();
+            csv.addItem(item);
+            context.uncacheEntity(item);
+            // Register a heartbeat after every item to indicate the process is still running
+            handler.registerHeartbeat();
+        }
+        context.setMode(originalMode);
+        return csv;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -81,7 +81,6 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
         }
 
         DSpaceCSV csv = this.export(context, toExport, exportAllMetadata, handler);
-        DSpaceCSV csv = this.export(context, toExport, exportAllMetadata, handler);
         return csv;
     }
 
@@ -148,33 +147,6 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
         }
 
         return result.iterator();
-    }
-
-    /**
-     * Exports the given items to a DSpaceCSV. Registers a heartbeat after every item exported.
-     *
-     * @param context       The DSpace context
-     * @param toExport      Iterator over the items to export
-     * @param exportAll     Whether to export all metadata fields or only the non-hidden ones
-     * @param handler       The handler to register the heartbeat with
-     * @return              A DSpaceCSV containing the exported items
-     * @throws Exception    If something goes wrong during the export
-     */
-    @Override
-    public DSpaceCSV export(Context context, Iterator<Item> toExport, boolean exportAll,
-                            DSpaceRunnableHandler handler) throws Exception {
-        Context.Mode originalMode = context.getCurrentMode();
-        context.setMode(Context.Mode.READ_ONLY);
-        DSpaceCSV csv = new DSpaceCSV(exportAll);
-        while (toExport.hasNext()) {
-            Item item = toExport.next();
-            csv.addItem(item);
-            context.uncacheEntity(item);
-            // Register a heartbeat after every item to indicate the process is still running
-            handler.registerHeartbeat();
-        }
-        context.setMode(originalMode);
-        return csv;
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/MetadataDSpaceCsvExportServiceImpl.java
@@ -99,6 +99,7 @@ public class MetadataDSpaceCsvExportServiceImpl implements MetadataDSpaceCsvExpo
             Item item = toExport.next();
             csv.addItem(item);
             context.uncacheEntity(item);
+            handler.registerHeartbeat();
         }
 
         context.setMode(originalMode);

--- a/dspace-api/src/main/java/org/dspace/content/service/MetadataDSpaceCsvExportService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/MetadataDSpaceCsvExportService.java
@@ -37,6 +37,18 @@ public interface MetadataDSpaceCsvExportService {
                                   String identifier, DSpaceRunnableHandler dSpaceRunnableHandler) throws Exception;
 
     /**
+     * This method will export all the Items in the given toExport iterator to a DSpaceCSV
+     * @param context       The relevant DSpace context
+     * @param toExport      The iterator containing the items to export
+     * @param exportAll     Defines if all metadata should be exported or only the allowed ones
+     * @param handler       The handler to register the heartbeat with
+     * @return              A DSpaceCSV object containing the exported information
+     * @throws Exception    If something goes wrong
+     */
+    public DSpaceCSV export(Context context, Iterator<Item> toExport, boolean exportAll,
+                                            DSpaceRunnableHandler handler) throws Exception;
+
+    /**
      * This method will export all the Items within the given Community to a DSpaceCSV
      * @param context       The relevant DSpace context
      * @param community     The Community that contains the Items to be exported
@@ -46,18 +58,6 @@ public interface MetadataDSpaceCsvExportService {
      */
     public DSpaceCSV export(Context context, Community community,
                             boolean exportAll, DSpaceRunnableHandler handler) throws Exception;
-    /**
-     * Exports the given items to a DSpaceCSV. Registers a heartbeat after every item exported.
-     *
-     * @param context       The relevant DSpace context
-     * @param toExport      Iterator over the items to export
-     * @param exportAll     Defines if all metadata should be exported or only the allowed ones
-     * @param handler       The handler to register the heartbeat with
-     * @return              A DSpaceCSV object containing the exported information
-     * @throws Exception    If something goes wrong
-     */
-    public DSpaceCSV export(Context context, Iterator<Item> toExport, boolean exportAll,
-                                    DSpaceRunnableHandler handler) throws Exception;
 
     int getCsvExportLimit();
 

--- a/dspace-api/src/main/java/org/dspace/content/service/MetadataDSpaceCsvExportService.java
+++ b/dspace-api/src/main/java/org/dspace/content/service/MetadataDSpaceCsvExportService.java
@@ -37,17 +37,6 @@ public interface MetadataDSpaceCsvExportService {
                                   String identifier, DSpaceRunnableHandler dSpaceRunnableHandler) throws Exception;
 
     /**
-     * This method will export all the Items in the given toExport iterator to a DSpaceCSV
-     * @param context       The relevant DSpace context
-     * @param toExport      The iterator containing the items to export
-     * @param exportAll     Defines if all metadata should be exported or only the allowed ones
-     * @return              A DSpaceCSV object containing the exported information
-     * @throws Exception    If something goes wrong
-     */
-    public DSpaceCSV export(Context context, Iterator<Item> toExport,
-                            boolean exportAll, DSpaceRunnableHandler handler) throws Exception;
-
-    /**
      * This method will export all the Items within the given Community to a DSpaceCSV
      * @param context       The relevant DSpace context
      * @param community     The Community that contains the Items to be exported
@@ -57,6 +46,18 @@ public interface MetadataDSpaceCsvExportService {
      */
     public DSpaceCSV export(Context context, Community community,
                             boolean exportAll, DSpaceRunnableHandler handler) throws Exception;
+    /**
+     * Exports the given items to a DSpaceCSV. Registers a heartbeat after every item exported.
+     *
+     * @param context       The relevant DSpace context
+     * @param toExport      Iterator over the items to export
+     * @param exportAll     Defines if all metadata should be exported or only the allowed ones
+     * @param handler       The handler to register the heartbeat with
+     * @return              A DSpaceCSV object containing the exported information
+     * @throws Exception    If something goes wrong
+     */
+    public DSpaceCSV export(Context context, Iterator<Item> toExport, boolean exportAll,
+                                    DSpaceRunnableHandler handler) throws Exception;
 
     int getCsvExportLimit();
 

--- a/dspace-api/src/main/java/org/dspace/core/Context.java
+++ b/dspace-api/src/main/java/org/dspace/core/Context.java
@@ -35,6 +35,7 @@ import org.dspace.event.factory.EventServiceFactory;
 import org.dspace.event.service.EventService;
 import org.dspace.storage.rdbms.DatabaseConfigVO;
 import org.dspace.storage.rdbms.DatabaseUtils;
+import org.dspace.storage.rdbms.ObjectBoundHibernateDBConnection;
 import org.dspace.utils.DSpace;
 import org.hibernate.Session;
 import org.springframework.util.CollectionUtils;
@@ -141,6 +142,8 @@ public class Context implements AutoCloseable {
      */
     private Mode mode;
 
+    private Type type;
+
     /**
      * Cache that is only used the context is in READ_ONLY mode
      */
@@ -159,6 +162,11 @@ public class Context implements AutoCloseable {
         READ_ONLY,
         READ_WRITE,
         BATCH_EDIT
+    }
+
+    public enum Type {
+        THREAD_BOUND,
+        OBJECT_BOUND
     }
 
     protected Context(EventService eventService, DBConnection dbConnection) {
@@ -187,19 +195,34 @@ public class Context implements AutoCloseable {
         init();
     }
 
+    public Context(Type type) {
+        this(type, Mode.READ_WRITE);
+    }
+
+    public Context(Type type, Mode mode) {
+        this.mode = mode;
+        this.type = type;
+        init();
+    }
+
     /**
      * Initializes a new context object.
      */
     protected void init() {
         updateDatabase();
-
+        if (type == null) {
+            type = Type.THREAD_BOUND;
+        }
         if (eventService == null) {
             eventService = EventServiceFactory.getInstance().getEventService();
         }
         if (dbConnection == null) {
-            // Obtain a non-auto-committing connection
-            dbConnection = new DSpace().getServiceManager()
-                                       .getServiceByName(null, DBConnection.class);
+            if (type == Type.OBJECT_BOUND) {
+                dbConnection = new ObjectBoundHibernateDBConnection();
+            } else {
+                dbConnection = new DSpace().getServiceManager()
+                        .getServiceByName(null, DBConnection.class);
+            }
             if (dbConnection == null) {
                 log.fatal("Cannot obtain the bean which provides a database connection. " +
                               "Check previous entries in the dspace.log to find why the db failed to initialize.");
@@ -223,7 +246,6 @@ public class Context implements AutoCloseable {
         if (this.mode != null) {
             setMode(this.mode);
         }
-
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/curate/Curator.java
+++ b/dspace-api/src/main/java/org/dspace/curate/Curator.java
@@ -533,9 +533,12 @@ public class Curator {
                 statusCode = task.perform(context, dso);
                 logInfo(logMessage(id));
                 visit(context);
+                // Register a heartbeat after the visit to indicate the process is still running
+                if (handler != null) {
+                    handler.registerHeartbeat();
+                }
                 return !suspend(statusCode);
             } catch (IOException ioe) {
-                //log error & pass exception upwards
                 System.out.println("Error executing curation task '" + task.getName() + "'; " + ioe);
                 throw ioe;
             }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -81,70 +81,69 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         }
 
         switch (indexClientOptions) {
-            case REMOVE:
-                handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
-                indexer.unIndexContent(context, indexableObject.get().getUniqueIndexID());
-                break;
-            case CLEAN:
-                handler.logInfo("Cleaning Index");
-                indexer.cleanIndex();
-                break;
-            case DELETE:
-                handler.logInfo("Deleting Index");
-                indexer.deleteIndex();
-                break;
-            case BUILD:
-            case BUILDANDSPELLCHECK:
-                handler.logInfo("(Re)building index from scratch.");
-                if (StringUtils.isNotBlank(type)) {
-                    handler.logWarning(String.format(
-                            "Type option, %s, not applicable for entire index rebuild option, b"
-                                    + ", type will be ignored",
-                            TYPE_OPTION));
-                }
-                indexer.deleteIndex();
-                indexer.createIndex(context);
-                if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
-                    checkRebuildSpellCheck(commandLine, indexer);
-                }
-                break;
-            case OPTIMIZE:
-                handler.logInfo("Optimizing search core.");
-                indexer.optimize();
-                break;
-            case SPELLCHECK:
+        case REMOVE:
+            handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
+            indexer.unIndexContent(context, indexableObject.get().getUniqueIndexID());
+            break;
+        case CLEAN:
+            handler.logInfo("Cleaning Index");
+            indexer.cleanIndex(handler);
+            break;
+        case DELETE:
+            handler.logInfo("Deleting Index");
+            indexer.deleteIndex();
+            break;
+        case BUILD:
+        case BUILDANDSPELLCHECK:
+            handler.logInfo("(Re)building index from scratch.");
+            if (StringUtils.isNotBlank(type)) {
+                handler.logWarning(String.format(
+                        "Type option, %s, not applicable for entire index rebuild option, b"
+                        + ", type will be ignored",
+                        TYPE_OPTION));
+            }
+            indexer.deleteIndex();
+            indexer.createIndex(context);
+            if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
                 checkRebuildSpellCheck(commandLine, indexer);
-                break;
-            case INDEX:
-                handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
-                final long startTimeMillis = Instant.now().toEpochMilli();
-                final long count = indexAll(indexer, ContentServiceFactory.getInstance().getItemService(), context,
+            }
+            break;
+        case OPTIMIZE:
+            handler.logInfo("Optimizing search core.");
+            indexer.optimize();
+            break;
+        case SPELLCHECK:
+            checkRebuildSpellCheck(commandLine, indexer);
+            break;
+        case INDEX:
+            handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
+            final long startTimeMillis = Instant.now().toEpochMilli();
+            final long count = indexAll(indexer, ContentServiceFactory.getInstance().getItemService(), context,
                     indexableObject.get());
-                final long seconds = (Instant.now().toEpochMilli() - startTimeMillis) / 1000;
-                handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") +
-                                " in " + seconds + " seconds");
-                break;
-            case UPDATE:
-            case UPDATEANDSPELLCHECK:
-                handler.logInfo("Updating Index");
-                indexer.updateIndex(context, false, type);
-                if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
-                    checkRebuildSpellCheck(commandLine, indexer);
-                }
-                break;
-            case FORCEUPDATE:
-            case FORCEUPDATEANDSPELLCHECK:
-                handler.logInfo("Updating Index");
-                indexer.updateIndex(context, true, type);
-                if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
-                    checkRebuildSpellCheck(commandLine, indexer);
-                }
-                break;
-            default:
-                handler.handleException("Invalid index client option.");
-                break;
-        }
-
+            final long seconds = (Instant.now().toEpochMilli() - startTimeMillis) / 1000;
+            handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") +
+                    " in " + seconds + " seconds");
+            break;
+        case UPDATE:
+        case UPDATEANDSPELLCHECK:
+            handler.logInfo("Updating Index");
+            indexer.updateIndex(context, false, type, handler);
+            if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
+                checkRebuildSpellCheck(commandLine, indexer);
+            }
+            break;
+        case FORCEUPDATE:
+        case FORCEUPDATEANDSPELLCHECK:
+            handler.logInfo("Updating Index");
+            indexer.updateIndex(context, true, type, handler);
+            if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
+                checkRebuildSpellCheck(commandLine, indexer);
+            }
+            break;
+        default:
+            handler.handleException("Invalid index client option.");
+            break;
+    }
         handler.logInfo("Done with indexing");
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexClient.java
@@ -81,69 +81,69 @@ public class IndexClient extends DSpaceRunnable<IndexDiscoveryScriptConfiguratio
         }
 
         switch (indexClientOptions) {
-        case REMOVE:
-            handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
-            indexer.unIndexContent(context, indexableObject.get().getUniqueIndexID());
-            break;
-        case CLEAN:
-            handler.logInfo("Cleaning Index");
-            indexer.cleanIndex(handler);
-            break;
-        case DELETE:
-            handler.logInfo("Deleting Index");
-            indexer.deleteIndex();
-            break;
-        case BUILD:
-        case BUILDANDSPELLCHECK:
-            handler.logInfo("(Re)building index from scratch.");
-            if (StringUtils.isNotBlank(type)) {
-                handler.logWarning(String.format(
-                        "Type option, %s, not applicable for entire index rebuild option, b"
-                        + ", type will be ignored",
-                        TYPE_OPTION));
-            }
-            indexer.deleteIndex();
-            indexer.createIndex(context);
-            if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
+            case REMOVE:
+                handler.logInfo("Removing " + commandLine.getOptionValue("r") + " from Index");
+                indexer.unIndexContent(context, indexableObject.get().getUniqueIndexID());
+                break;
+            case CLEAN:
+                handler.logInfo("Cleaning Index");
+                indexer.cleanIndex(handler);
+                break;
+            case DELETE:
+                handler.logInfo("Deleting Index");
+                indexer.deleteIndex();
+                break;
+            case BUILD:
+            case BUILDANDSPELLCHECK:
+                handler.logInfo("(Re)building index from scratch.");
+                if (StringUtils.isNotBlank(type)) {
+                    handler.logWarning(String.format(
+                            "Type option, %s, not applicable for entire index rebuild option, b"
+                            + ", type will be ignored",
+                            TYPE_OPTION));
+                }
+                indexer.deleteIndex();
+                indexer.createIndex(context);
+                if (indexClientOptions == IndexClientOptions.BUILDANDSPELLCHECK) {
+                    checkRebuildSpellCheck(commandLine, indexer);
+                }
+                break;
+            case OPTIMIZE:
+                handler.logInfo("Optimizing search core.");
+                indexer.optimize();
+                break;
+            case SPELLCHECK:
                 checkRebuildSpellCheck(commandLine, indexer);
-            }
-            break;
-        case OPTIMIZE:
-            handler.logInfo("Optimizing search core.");
-            indexer.optimize();
-            break;
-        case SPELLCHECK:
-            checkRebuildSpellCheck(commandLine, indexer);
-            break;
-        case INDEX:
-            handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
-            final long startTimeMillis = Instant.now().toEpochMilli();
-            final long count = indexAll(indexer, ContentServiceFactory.getInstance().getItemService(), context,
-                    indexableObject.get());
-            final long seconds = (Instant.now().toEpochMilli() - startTimeMillis) / 1000;
-            handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") +
-                    " in " + seconds + " seconds");
-            break;
-        case UPDATE:
-        case UPDATEANDSPELLCHECK:
-            handler.logInfo("Updating Index");
-            indexer.updateIndex(context, false, type, handler);
-            if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
-                checkRebuildSpellCheck(commandLine, indexer);
-            }
-            break;
-        case FORCEUPDATE:
-        case FORCEUPDATEANDSPELLCHECK:
-            handler.logInfo("Updating Index");
-            indexer.updateIndex(context, true, type, handler);
-            if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
-                checkRebuildSpellCheck(commandLine, indexer);
-            }
-            break;
-        default:
-            handler.handleException("Invalid index client option.");
-            break;
-    }
+                break;
+            case INDEX:
+                handler.logInfo("Indexing " + commandLine.getOptionValue('i') + " force " + commandLine.hasOption("f"));
+                final long startTimeMillis = Instant.now().toEpochMilli();
+                final long count = indexAll(indexer, ContentServiceFactory.getInstance().getItemService(), context,
+                        indexableObject.get());
+                final long seconds = (Instant.now().toEpochMilli() - startTimeMillis) / 1000;
+                handler.logInfo("Indexed " + count + " object" + (count > 1 ? "s" : "") +
+                        " in " + seconds + " seconds");
+                break;
+            case UPDATE:
+            case UPDATEANDSPELLCHECK:
+                handler.logInfo("Updating Index");
+                indexer.updateIndex(context, false, type, handler);
+                if (indexClientOptions == IndexClientOptions.UPDATEANDSPELLCHECK) {
+                    checkRebuildSpellCheck(commandLine, indexer);
+                }
+                break;
+            case FORCEUPDATE:
+            case FORCEUPDATEANDSPELLCHECK:
+                handler.logInfo("Updating Index");
+                indexer.updateIndex(context, true, type, handler);
+                if (indexClientOptions == IndexClientOptions.FORCEUPDATEANDSPELLCHECK) {
+                    checkRebuildSpellCheck(commandLine, indexer);
+                }
+                break;
+            default:
+                handler.handleException("Invalid index client option.");
+                break;
+        }
         handler.logInfo("Done with indexing");
     }
 

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -65,7 +65,7 @@ public interface IndexingService {
 
     void updateIndex(Context context, boolean force);
 
-    void updateIndex(Context context, boolean force, String type);
+    void updateIndex(Context context, boolean force, String type, DSpaceRunnableHandler handler);
 
     void cleanIndex() throws IOException, SQLException, SearchServiceException;
 
@@ -87,26 +87,5 @@ public interface IndexingService {
      */
     void atomicUpdate(Context context, String uniqueIndexId, String field, Map<String,Object> fieldModifier)
             throws SolrServerException, IOException;
-    /**
-     * Iterates over all documents in the Lucene index and verifies they are in
-     * the database, if not, they are removed. Registers a heartbeat after each batch.
-     *
-     * @param handler       The handler to register the heartbeat with
-     * @throws IOException            IO exception
-     * @throws SQLException           sql exception
-     * @throws SearchServiceException occurs when something went wrong with querying the solr server
-     */
-    void cleanIndex(DSpaceRunnableHandler handler)
-        throws IOException, SQLException, SearchServiceException;
 
-    /**
-     * Iterates over all Items, Collections and Communities and updates them in
-     * the index. Registers a heartbeat after every object is indexed.
-     *
-     * @param context The DSpace context
-     * @param force   Whether the reindexing should be forced
-     * @param type    The type of object to index
-     * @param handler The runnable handler used to register heartbeats
-     */
-    void updateIndex(Context context, boolean force, String type, DSpaceRunnableHandler handler);
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrServerException;
 import org.dspace.core.Context;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
 
 /**
  * Interface used for indexing IndexableObject into discovery
@@ -86,4 +87,26 @@ public interface IndexingService {
      */
     void atomicUpdate(Context context, String uniqueIndexId, String field, Map<String,Object> fieldModifier)
             throws SolrServerException, IOException;
+    /**
+     * Iterates over all documents in the Lucene index and verifies they are in
+     * the database, if not, they are removed. Registers a heartbeat after each batch.
+     *
+     * @param handler       The handler to register the heartbeat with
+     * @throws IOException            IO exception
+     * @throws SQLException           sql exception
+     * @throws SearchServiceException occurs when something went wrong with querying the solr server
+     */
+    void cleanIndex(DSpaceRunnableHandler handler)
+        throws IOException, SQLException, SearchServiceException;
+
+    /**
+     * Iterates over all Items, Collections and Communities and updates them in
+     * the index. Registers a heartbeat after every object is indexed.
+     *
+     * @param context The DSpace context
+     * @param force   Whether the reindexing should be forced
+     * @param type    The type of object to index
+     * @param handler The runnable handler used to register heartbeats
+     */
+    void updateIndex(Context context, boolean force, String type, DSpaceRunnableHandler handler);
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/IndexingService.java
@@ -88,4 +88,6 @@ public interface IndexingService {
     void atomicUpdate(Context context, String uniqueIndexId, String field, Map<String,Object> fieldModifier)
             throws SolrServerException, IOException;
 
+    void cleanIndex(DSpaceRunnableHandler handler) throws IOException, SQLException, SearchServiceException;
+
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -1670,4 +1670,57 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
         return null;
     }
+    @Override
+    public SolrSearchCore getSolrSearchCore() {
+        return solrSearchCore;
+    }
+    @Override
+    public void cleanIndex(DSpaceRunnableHandler handler) throws IOException, SQLException, SearchServiceException {
+        Context context = new Context();
+        context.turnOffAuthorisationSystem();
+
+        try {
+            if (solrSearchCore.getSolr() == null) {
+                return;
+            }
+            SolrQuery countQuery = new SolrQuery("*:*");
+            countQuery.setRows(0);
+            QueryResponse totalResponse = solrSearchCore.getSolr().query(countQuery, solrSearchCore.REQUEST_METHOD);
+            long total = totalResponse.getResults().getNumFound();
+
+            int start = 0;
+            int batch = 100;
+
+            SolrQuery query = new SolrQuery();
+            query.setFields(SearchUtils.RESOURCE_UNIQUE_ID, SearchUtils.RESOURCE_ID_FIELD,
+                            SearchUtils.RESOURCE_TYPE_FIELD);
+            query.addSort(SearchUtils.RESOURCE_UNIQUE_ID, SolrQuery.ORDER.asc);
+            query.setQuery("*:*");
+            query.setRows(batch);
+
+            while (start < total) {
+                query.setStart(start);
+                QueryResponse rsp = solrSearchCore.getSolr().query(query, solrSearchCore.REQUEST_METHOD);
+                SolrDocumentList docs = rsp.getResults();
+
+                for (SolrDocument doc : docs) {
+                    String uniqueID = (String) doc.getFieldValue(SearchUtils.RESOURCE_UNIQUE_ID);
+                    IndexableObject o = findIndexableObject(context, doc);
+                    if (o == null) {
+                        log.info("Deleting: " + uniqueID);
+                        unIndexContent(context, uniqueID);
+                    } else {
+                        log.debug("Keeping: " + o.getUniqueIndexID());
+                    }
+                }
+
+                start += batch;
+                handler.registerHeartbeat();
+            }
+        } catch (IOException | SQLException | SolrServerException e) {
+            log.error("Error cleaning discovery index: " + e.getMessage(), e);
+        } finally {
+            context.abort();
+        }
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -77,6 +77,7 @@ import org.dspace.discovery.indexobject.factory.ItemIndexFactory;
 import org.dspace.eperson.Group;
 import org.dspace.eperson.factory.EPersonServiceFactory;
 import org.dspace.eperson.service.GroupService;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1667,6 +1668,79 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         return null;
     }
 
+
+    @Override
+    public void cleanIndex(DSpaceRunnableHandler handler) throws IOException, SQLException, SearchServiceException {
+        Context context = new Context();
+        context.turnOffAuthorisationSystem();
+
+        try {
+            if (solrSearchCore.getSolr() == null) {
+                return;
+            }
+            SolrQuery countQuery = new SolrQuery("*:*");
+            countQuery.setRows(0);
+            QueryResponse totalResponse = solrSearchCore.getSolr().query(countQuery, solrSearchCore.REQUEST_METHOD);
+            long total = totalResponse.getResults().getNumFound();
+
+            int start = 0;
+            int batch = 100;
+
+            SolrQuery query = new SolrQuery();
+            query.setFields(SearchUtils.RESOURCE_UNIQUE_ID, SearchUtils.RESOURCE_ID_FIELD,
+                            SearchUtils.RESOURCE_TYPE_FIELD);
+            query.addSort(SearchUtils.RESOURCE_UNIQUE_ID, SolrQuery.ORDER.asc);
+            query.setQuery("*:*");
+            query.setRows(batch);
+
+            while (start < total) {
+                query.setStart(start);
+                QueryResponse rsp = solrSearchCore.getSolr().query(query, solrSearchCore.REQUEST_METHOD);
+                SolrDocumentList docs = rsp.getResults();
+
+                for (SolrDocument doc : docs) {
+                    String uniqueID = (String) doc.getFieldValue(SearchUtils.RESOURCE_UNIQUE_ID);
+                    IndexableObject o = findIndexableObject(context, doc);
+                    if (o == null) {
+                        log.info("Deleting: " + uniqueID);
+                        unIndexContent(context, uniqueID);
+                    } else {
+                        log.debug("Keeping: " + o.getUniqueIndexID());
+                    }
+                }
+
+                start += batch;
+                handler.registerHeartbeat();
+            }
+        } catch (IOException | SQLException | SolrServerException e) {
+            log.error("Error cleaning discovery index: " + e.getMessage(), e);
+        } finally {
+            context.abort();
+        }
+    }
+
+    @Override
+    public void updateIndex(Context context, boolean force, String type, DSpaceRunnableHandler handler) {
+        try {
+            final List<IndexFactory> indexableObjectServices = indexObjectServiceFactory.getIndexFactories();
+            for (IndexFactory indexableObjectService : indexableObjectServices) {
+                if (type == null || StringUtils.equals(indexableObjectService.getType(), type)) {
+                    final Iterator<IndexableObject> indexableObjects = indexableObjectService.findAll(context);
+                    while (indexableObjects.hasNext()) {
+                        final IndexableObject indexableObject = indexableObjects.next();
+                        indexContent(context, indexableObject, force);
+                        context.uncacheEntity(indexableObject.getIndexedObject());
+                        handler.registerHeartbeat();
+                    }
+                }
+            }
+            if (solrSearchCore.getSolr() != null) {
+                solrSearchCore.getSolr().commit();
+            }
+        } catch (IOException | SQLException | SolrServerException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
     @Override
     public SolrSearchCore getSolrSearchCore() {
         return solrSearchCore;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -336,11 +336,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
      */
     @Override
     public void updateIndex(Context context, boolean force) {
-        updateIndex(context, force, null);
+        updateIndex(context, force, (String) null, (DSpaceRunnableHandler) null);
     }
 
     @Override
-    public void updateIndex(Context context, boolean force, String type) {
+    public void updateIndex(Context context, boolean force, String type, DSpaceRunnableHandler handler) {
         try {
             final List<IndexFactory> indexableObjectServices = indexObjectServiceFactory.
                 getIndexFactories();
@@ -355,6 +355,9 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                         indexObject++;
                         if ((indexObject % 100) == 0 && indexableObjectService instanceof ItemIndexFactory) {
                             context.uncacheEntities();
+                        }
+                        if (handler != null) {
+                            handler.registerHeartbeat();
                         }
                     }
                 }
@@ -1667,83 +1670,4 @@ public class SolrServiceImpl implements SearchService, IndexingService {
         }
         return null;
     }
-
-
-    @Override
-    public void cleanIndex(DSpaceRunnableHandler handler) throws IOException, SQLException, SearchServiceException {
-        Context context = new Context();
-        context.turnOffAuthorisationSystem();
-
-        try {
-            if (solrSearchCore.getSolr() == null) {
-                return;
-            }
-            SolrQuery countQuery = new SolrQuery("*:*");
-            countQuery.setRows(0);
-            QueryResponse totalResponse = solrSearchCore.getSolr().query(countQuery, solrSearchCore.REQUEST_METHOD);
-            long total = totalResponse.getResults().getNumFound();
-
-            int start = 0;
-            int batch = 100;
-
-            SolrQuery query = new SolrQuery();
-            query.setFields(SearchUtils.RESOURCE_UNIQUE_ID, SearchUtils.RESOURCE_ID_FIELD,
-                            SearchUtils.RESOURCE_TYPE_FIELD);
-            query.addSort(SearchUtils.RESOURCE_UNIQUE_ID, SolrQuery.ORDER.asc);
-            query.setQuery("*:*");
-            query.setRows(batch);
-
-            while (start < total) {
-                query.setStart(start);
-                QueryResponse rsp = solrSearchCore.getSolr().query(query, solrSearchCore.REQUEST_METHOD);
-                SolrDocumentList docs = rsp.getResults();
-
-                for (SolrDocument doc : docs) {
-                    String uniqueID = (String) doc.getFieldValue(SearchUtils.RESOURCE_UNIQUE_ID);
-                    IndexableObject o = findIndexableObject(context, doc);
-                    if (o == null) {
-                        log.info("Deleting: " + uniqueID);
-                        unIndexContent(context, uniqueID);
-                    } else {
-                        log.debug("Keeping: " + o.getUniqueIndexID());
-                    }
-                }
-
-                start += batch;
-                handler.registerHeartbeat();
-            }
-        } catch (IOException | SQLException | SolrServerException e) {
-            log.error("Error cleaning discovery index: " + e.getMessage(), e);
-        } finally {
-            context.abort();
-        }
-    }
-
-    @Override
-    public void updateIndex(Context context, boolean force, String type, DSpaceRunnableHandler handler) {
-        try {
-            final List<IndexFactory> indexableObjectServices = indexObjectServiceFactory.getIndexFactories();
-            for (IndexFactory indexableObjectService : indexableObjectServices) {
-                if (type == null || StringUtils.equals(indexableObjectService.getType(), type)) {
-                    final Iterator<IndexableObject> indexableObjects = indexableObjectService.findAll(context);
-                    while (indexableObjects.hasNext()) {
-                        final IndexableObject indexableObject = indexableObjects.next();
-                        indexContent(context, indexableObject, force);
-                        context.uncacheEntity(indexableObject.getIndexedObject());
-                        handler.registerHeartbeat();
-                    }
-                }
-            }
-            if (solrSearchCore.getSolr() != null) {
-                solrSearchCore.getSolr().commit();
-            }
-        } catch (IOException | SQLException | SolrServerException e) {
-            log.error(e.getMessage(), e);
-        }
-    }
-    @Override
-    public SolrSearchCore getSolrSearchCore() {
-        return solrSearchCore;
-    }
-
 }

--- a/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
+++ b/dspace-api/src/main/java/org/dspace/harvest/OAIHarvester.java
@@ -64,6 +64,7 @@ import org.dspace.handle.service.HandleService;
 import org.dspace.harvest.factory.HarvestServiceFactory;
 import org.dspace.harvest.service.HarvestedCollectionService;
 import org.dspace.harvest.service.HarvestedItemService;
+import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.jdom2.Document;
@@ -131,9 +132,11 @@ public class OAIHarvester {
     // DOMbuilder class for the DOM -> JDOM conversions
     private static final DOMBuilder db = new DOMBuilder();
     // The point at which this thread should terminate itself
+    protected DSpaceRunnableHandler handler;
 
     /* Initialize the harvester with a collection object */
-    public OAIHarvester(Context c, DSpaceObject dso, HarvestedCollection hc) throws HarvestingException, SQLException {
+    public OAIHarvester(Context c, DSpaceObject dso, HarvestedCollection hc,
+                        DSpaceRunnableHandler handler) throws HarvestingException, SQLException {
         bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
         bitstreamFormatService = ContentServiceFactory.getInstance().getBitstreamFormatService();
         bundleService = ContentServiceFactory.getInstance().getBundleService();
@@ -148,6 +151,7 @@ public class OAIHarvester {
         pluginService = CoreServiceFactory.getInstance().getPluginService();
 
         configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        this.handler = handler;
 
         if (dso.getType() != Constants.COLLECTION) {
             throw new HarvestingException("OAIHarvester can only harvest collections");
@@ -179,7 +183,11 @@ public class OAIHarvester {
             throw new HarvestingException("Metadata declaration not found");
         }
     }
-
+     /* Initialize the harvester with a collection object */
+    public OAIHarvester(Context c, DSpaceObject dso, HarvestedCollection hc)
+            throws HarvestingException, SQLException {
+        this(c, dso, hc, null);
+    }
 
     /**
      * Search the configuration options and find the ORE serialization string
@@ -384,6 +392,9 @@ public class OAIHarvester {
                         currentRecord++;
 
                         processRecord(record, OREPrefix, currentRecord, totalListSize);
+                        if (handler != null) {
+                            handler.registerHeartbeat();
+                        }
                         ourContext.dispatchEvents();
 
                         intermediateCommit();

--- a/dspace-api/src/main/java/org/dspace/orcid/script/OrcidBulkPush.java
+++ b/dspace-api/src/main/java/org/dspace/orcid/script/OrcidBulkPush.java
@@ -115,6 +115,7 @@ public class OrcidBulkPush extends DSpaceRunnable<OrcidBulkPushScriptConfigurati
 
         for (OrcidQueue queueRecord : queueRecords) {
             performSynchronization(queueRecord);
+            handler.registerHeartbeat();
         }
 
     }

--- a/dspace-api/src/main/java/org/dspace/scripts/Process.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/Process.java
@@ -8,7 +8,6 @@
 package org.dspace.scripts;
 
 import java.time.Instant;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -90,6 +89,7 @@ public class Process implements ReloadableEntity<Integer> {
 
     @Column(name = "creation_time", nullable = false)
     private Instant creationTime;
+
     @Column(name = "heartbeat")
     private Instant heartbeat;
 

--- a/dspace-api/src/main/java/org/dspace/scripts/Process.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/Process.java
@@ -93,6 +93,7 @@ public class Process implements ReloadableEntity<Integer> {
     @Column(name = "heartbeat")
     private Instant heartbeat;
 
+
     public static final String BITSTREAM_TYPE_METADATAFIELD = "dspace.process.filetype";
     public static final String OUTPUT_TYPE = "script_output";
 

--- a/dspace-api/src/main/java/org/dspace/scripts/Process.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/Process.java
@@ -8,6 +8,7 @@
 package org.dspace.scripts;
 
 import java.time.Instant;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,6 +90,8 @@ public class Process implements ReloadableEntity<Integer> {
 
     @Column(name = "creation_time", nullable = false)
     private Instant creationTime;
+    @Column(name = "heartbeat")
+    private Instant heartbeat;
 
     public static final String BITSTREAM_TYPE_METADATAFIELD = "dspace.process.filetype";
     public static final String OUTPUT_TYPE = "script_output";
@@ -233,6 +236,13 @@ public class Process implements ReloadableEntity<Integer> {
      */
     public void setGroups(List<Group> groups) {
         this.groups = groups;
+    }
+
+    public Instant getHeartbeat() {
+        return heartbeat;
+    }
+    public void setHeartbeat(Instant heartbeat) {
+        this.heartbeat = heartbeat;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/scripts/handler/DSpaceRunnableHandler.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/handler/DSpaceRunnableHandler.java
@@ -124,4 +124,10 @@ public interface DSpaceRunnableHandler {
      * @return List containing UUIDs of Special Groups of the associated Process.
      */
     public List<UUID> getSpecialGroups();
+    /**
+     * Registers a heartbeat for the currently running process.
+     * Implementations can use this to update the heartbeat timestamp
+     * of long-running scripts or processes.
+     */
+    public void registerHeartbeat();
 }

--- a/dspace-api/src/main/java/org/dspace/scripts/handler/impl/CommandLineDSpaceRunnableHandler.java
+++ b/dspace-api/src/main/java/org/dspace/scripts/handler/impl/CommandLineDSpaceRunnableHandler.java
@@ -121,4 +121,8 @@ public class CommandLineDSpaceRunnableHandler implements DSpaceRunnableHandler {
     public List<UUID> getSpecialGroups() {
         return Collections.emptyList();
     }
+
+    @Override
+    public void registerHeartbeat() {
+    }
 }

--- a/dspace-api/src/main/java/org/dspace/storage/rdbms/ObjectBoundHibernateDBConnection.java
+++ b/dspace-api/src/main/java/org/dspace/storage/rdbms/ObjectBoundHibernateDBConnection.java
@@ -1,0 +1,98 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms;
+
+import java.sql.SQLException;
+
+import org.dspace.core.HibernateDBConnection;
+import org.dspace.utils.DSpace;
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+/**
+ * A Hibernate database connection bound to an object rather than a thread, suitable for short-lived isolated
+ * database operations that need to run alongside an existing thread-bound connection.
+ */
+public class ObjectBoundHibernateDBConnection extends HibernateDBConnection {
+
+    private final SessionFactory sessionFactory;
+    private Session session;
+    private Transaction transaction;
+
+    public ObjectBoundHibernateDBConnection() {
+        this.sessionFactory = new DSpace().getServiceManager()
+                                         .getServiceByName("sessionFactory", SessionFactory.class);
+    }
+
+    @Override
+    public Session getSession() throws SQLException {
+        if (session == null || !session.isOpen()) {
+            session = sessionFactory.openSession();
+        }
+
+        if (transaction == null || !transaction.isActive()) {
+            transaction = session.beginTransaction();
+            configureDatabaseMode();
+        }
+
+        return session;
+    }
+
+    @Override
+    public boolean isSessionAlive() {
+        return session != null && session.isOpen();
+    }
+
+    @Override
+    public boolean isTransActionAlive() {
+        return transaction != null && transaction.isActive();
+    }
+
+    @Override
+    protected Transaction getTransaction() {
+        return transaction;
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        if (isTransActionAlive()) {
+            transaction.commit();
+        }
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        if (isTransActionAlive()) {
+            transaction.rollback();
+        }
+    }
+
+    @Override
+    public void closeDBConnection() throws SQLException {
+        try {
+            if (isTransActionAlive()) {
+                transaction.rollback();
+            }
+        } finally {
+            if (session != null && session.isOpen()) {
+                session.close();
+            }
+            session = null;
+            transaction = null;
+        }
+    }
+
+    private void configureDatabaseMode() {
+        if (isOptimizedForBatchProcessing()) {
+            session.setHibernateFlushMode(FlushMode.ALWAYS);
+        } else {
+            session.setHibernateFlushMode(FlushMode.AUTO);
+        }
+    }
+}

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2026.05.18__add_process_heartbeat.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/h2/V7.6_2026.05.18__add_process_heartbeat.sql
@@ -1,0 +1,14 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-------------------------------------------------------------------------------
+-- Add heartbeat column to process table
+-- Stores the last time a process reported it was still running
+-------------------------------------------------------------------------------
+
+ALTER TABLE process ADD COLUMN heartbeat TIMESTAMP;

--- a/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2026.05.18__add_process_heartbeat.sql
+++ b/dspace-api/src/main/resources/org/dspace/storage/rdbms/sqlmigration/postgres/V7.6_2026.05.18__add_process_heartbeat.sql
@@ -1,0 +1,14 @@
+--
+-- The contents of this file are subject to the license and copyright
+-- detailed in the LICENSE and NOTICE files at the root of the source
+-- tree and available online at
+--
+-- http://www.dspace.org/license/
+--
+
+-------------------------------------------------------------------------------
+-- Add heartbeat column to process table
+-- Stores the last time a process reported it was still running
+-------------------------------------------------------------------------------
+
+ALTER TABLE process ADD COLUMN heartbeat TIMESTAMP;

--- a/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
+++ b/dspace-api/src/test/java/org/dspace/builder/ProcessBuilder.java
@@ -79,6 +79,10 @@ public class ProcessBuilder extends AbstractBuilder<Process, ProcessService> {
                                                                   .atZone(ZoneId.systemDefault()).toInstant());
         return this;
     }
+    public ProcessBuilder withHeartbeat(Instant heartbeat) {
+        process.setHeartbeat(heartbeat);
+        return this;
+    }
 
     @Override
     public void cleanup() throws Exception {

--- a/dspace-api/src/test/java/org/dspace/storage/rdbms/ObjectBoundHibernateDBConnectionIT.java
+++ b/dspace-api/src/test/java/org/dspace/storage/rdbms/ObjectBoundHibernateDBConnectionIT.java
@@ -1,0 +1,140 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.storage.rdbms;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.Community;
+import org.dspace.content.MetadataSchemaEnum;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.CommunityService;
+import org.dspace.core.Context;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link ObjectBoundHibernateDBConnection} and {@link Context.Type#OBJECT_BOUND},
+ * verifying persistence, reusability across multiple commits, transactional isolation, and context lifecycle.
+ */
+public class ObjectBoundHibernateDBConnectionIT extends AbstractUnitTest {
+
+    /**
+     * Verify that changes committed through an OBJECT_BOUND context are
+     * persisted and visible to a separate THREAD_BOUND context.
+     */
+    @Test
+    public void testCommittedChangesAreVisibleFromOtherContext()
+            throws SQLException, AuthorizeException, IOException {
+        CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+        Context objectBoundContext = new Context(Context.Type.OBJECT_BOUND);
+        objectBoundContext.turnOffAuthorisationSystem();
+
+        Community community = communityService.create(null, objectBoundContext);
+        communityService.setMetadataSingleValue(objectBoundContext, community,
+            MetadataSchemaEnum.DC.getName(), "title", null, null, "Heartbeat Test Community");
+        communityService.update(objectBoundContext, community);
+        objectBoundContext.commit();
+
+        Community found = communityService.find(context, community.getID());
+        assertNotNull("Community committed in OBJECT_BOUND context should be visible to other contexts", found);
+
+        objectBoundContext.complete();
+        context.turnOffAuthorisationSystem();
+        communityService.delete(context, context.reloadEntity(community));
+        context.restoreAuthSystemState();
+        context.commit();
+    }
+
+    /**
+     * Verify that an OBJECT_BOUND context can be reused across multiple
+     * commit cycles: create -> commit -> modify -> commit -> complete.
+     */
+    @Test
+    public void testContextCanBeReusedAcrossMultipleCommits()
+            throws SQLException, AuthorizeException, IOException {
+        CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+        Context objectBoundContext = new Context(Context.Type.OBJECT_BOUND);
+        objectBoundContext.turnOffAuthorisationSystem();
+
+        Community community = communityService.create(null, objectBoundContext);
+        communityService.setMetadataSingleValue(objectBoundContext, community,
+            MetadataSchemaEnum.DC.getName(), "title", null, null, "First Commit");
+        communityService.update(objectBoundContext, community);
+        objectBoundContext.commit();
+        assertTrue("Context should still be valid after first commit", objectBoundContext.isValid());
+
+        community = objectBoundContext.reloadEntity(community);
+        communityService.setMetadataSingleValue(objectBoundContext, community,
+            MetadataSchemaEnum.DC.getName(), "title", null, null, "Second Commit");
+        communityService.update(objectBoundContext, community);
+        objectBoundContext.commit();
+        assertTrue("Context should still be valid after second commit", objectBoundContext.isValid());
+
+        objectBoundContext.complete();
+        assertFalse("Context should be invalid after complete()", objectBoundContext.isValid());
+
+        context.turnOffAuthorisationSystem();
+        community = communityService.find(context, community.getID());
+        communityService.delete(context, community);
+        context.restoreAuthSystemState();
+        context.commit();
+    }
+
+    /**
+     * Verify that uncommitted changes in an OBJECT_BOUND context are not
+     * visible to the thread-bound context before commit.
+     */
+    @Test
+    public void testObjectBoundContextIsIsolatedFromThreadBoundContext()
+            throws SQLException, AuthorizeException, IOException {
+        CommunityService communityService = ContentServiceFactory.getInstance().getCommunityService();
+
+        Context objectBoundContext = new Context(Context.Type.OBJECT_BOUND);
+        objectBoundContext.turnOffAuthorisationSystem();
+
+        Community community = communityService.create(null, objectBoundContext);
+        communityService.setMetadataSingleValue(objectBoundContext, community,
+            MetadataSchemaEnum.DC.getName(), "title", null, null, "Uncommitted Community");
+        communityService.update(objectBoundContext, community);
+
+
+        Community notYetVisible = communityService.find(context, community.getID());
+        assertTrue("Uncommitted changes should not be visible to thread-bound context",
+                notYetVisible == null || !"Uncommitted Community".equals(notYetVisible.getName()));
+
+        objectBoundContext.commit();
+        Community nowVisible = communityService.find(context, community.getID());
+        assertNotNull("After commit, community should be visible to thread-bound context", nowVisible);
+
+        objectBoundContext.complete();
+        context.turnOffAuthorisationSystem();
+        communityService.delete(context, context.reloadEntity(community));
+        context.restoreAuthSystemState();
+        context.commit();
+    }
+
+    /**
+     * Verify that after complete() the OBJECT_BOUND context is no longer valid.
+     */
+    @Test
+    public void testContextIsInvalidAfterComplete() throws SQLException {
+        Context objectBoundContext = new Context(Context.Type.OBJECT_BOUND);
+        assertTrue("Context should be valid before complete()", objectBoundContext.isValid());
+
+        objectBoundContext.complete();
+        assertFalse("Context should be invalid after complete()", objectBoundContext.isValid());
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ProcessConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/ProcessConverter.java
@@ -46,6 +46,7 @@ public class ProcessConverter implements DSpaceConverter<Process, ProcessRest> {
         processRest.setStartTime(process.getStartTime());
         processRest.setEndTime(process.getFinishedTime());
         processRest.setCreationTime(process.getCreationTime());
+        processRest.setHeartbeat(process.getHeartbeat());
         processRest.setParameterRestList(processService.getParameters(process).stream()
                 .map(x -> (ParameterValueRest) converter.toRest(x, projection)).collect(Collectors.toList()));
         return processRest;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/ProcessRest.java
@@ -33,6 +33,7 @@ public class ProcessRest extends BaseObjectRest<Integer> {
     public static final String FILES = "files";
     public static final String FILE_TYPES = "filetypes";
     public static final String OUTPUT = "output";
+    private Instant heartbeat;
 
     public String getCategory() {
         return CATEGORY;
@@ -123,6 +124,13 @@ public class ProcessRest extends BaseObjectRest<Integer> {
 
     public void setEndTime(Instant endTime) {
         this.endTime = endTime;
+    }
+    public Instant getHeartbeat() {
+        return heartbeat;
+    }
+
+    public void setHeartbeat(Instant heartbeat) {
+        this.heartbeat = heartbeat;
     }
 
     @JsonIgnore

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/scripts/handler/impl/RestDSpaceRunnableHandler.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -328,5 +329,27 @@ public class RestDSpaceRunnableHandler implements DSpaceRunnableHandler {
             }
         }
         return specialGroups;
+    }
+
+    @Override
+    public void registerHeartbeat() {
+        Context context = new Context(Context.Type.OBJECT_BOUND);
+        try {
+            Process process = processService.find(context, processId);
+            Instant now = Instant.now();
+            Instant last = process.getHeartbeat();
+            if (last != null && last.isAfter(now.minusSeconds(60))) {
+                return;
+            }
+            process.setHeartbeat(now);
+            processService.update(context, process);
+            context.commit();
+        } catch (SQLException e) {
+            log.error("Error updating heartbeat for process {}", processId, e);
+        } finally {
+            if (context.isValid()) {
+                context.abort();
+            }
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -20,9 +20,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.InputStream;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedList;
 import java.util.List;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -7,12 +7,14 @@
  */
 package org.dspace.app.rest;
 
+import static com.jayway.jsonpath.JsonPath.read;
 import static org.dspace.app.rest.matcher.ProcessMatcher.matchProcess;
 import static org.dspace.content.ProcessStatus.SCHEDULED;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -20,20 +22,30 @@ import java.io.InputStream;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
+import org.dspace.app.rest.converter.DSpaceRunnableParameterConverter;
 import org.dspace.app.rest.matcher.PageMatcher;
 import org.dspace.app.rest.matcher.ProcessFileTypesMatcher;
 import org.dspace.app.rest.matcher.ProcessMatcher;
+import org.dspace.app.rest.model.ParameterValueRest;
+import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
 import org.dspace.builder.ProcessBuilder;
 import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
 import org.dspace.content.ProcessStatus;
 import org.dspace.scripts.DSpaceCommandLineParameter;
 import org.dspace.scripts.Process;
@@ -44,10 +56,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+
+
+
 public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Autowired
     private ProcessService processService;
+
+    @Autowired
+    private DSpaceRunnableParameterConverter dSpaceRunnableParameterConverter;
 
     Process process;
 
@@ -952,5 +970,77 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
                         .andExpect(jsonPath("$.metadata['dspace.process.filetype'][0].value",
                                             is("script_output")));
 
+    }
+    @Test
+    public void getProcessWithNullHeartbeat() throws Exception {
+        Process processWithoutHeartbeat = ProcessBuilder
+            .createProcess(context, admin, "mock-script", parameters)
+            .build();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/processes/" + processWithoutHeartbeat.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.heartbeat").value(Matchers.nullValue()));
+    }
+
+    @Test
+    public void getProcessWithHeartbeat() throws Exception {
+        Instant heartbeat = Instant.now();
+
+        Process processWithHeartbeat = ProcessBuilder
+            .createProcess(context, admin, "mock-script", parameters)
+            .withHeartbeat(heartbeat)
+            .build();
+
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/processes/" + processWithHeartbeat.getID()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.heartbeat").value(heartbeat.toString()));
+    }
+    @Test
+    public void getProcessHeartbeatUpdatedDuringDiscovery() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                        .withName("Test Community")
+                                        .build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity)
+                                        .withName("Test Collection")
+                                        .build();
+        ItemBuilder.createItem(context, col).withTitle("Test Item 1").build();
+        ItemBuilder.createItem(context, col).withTitle("Test Item 2").build();
+        ItemBuilder.createItem(context, col).withTitle("Test Item 3").build();
+
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(admin.getEmail(), password);
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        LinkedList<DSpaceCommandLineParameter> discoveryParams = new LinkedList<>();
+        discoveryParams.add(new DSpaceCommandLineParameter("-f", "true"));
+
+        List<ParameterValueRest> list = new LinkedList<>();
+        for (DSpaceCommandLineParameter param : discoveryParams) {
+            list.add((ParameterValueRest) dSpaceRunnableParameterConverter.convert(param, Projection.DEFAULT));
+        }
+
+        try {
+            getClient(token)
+                .perform(multipart("/api/system/scripts/index-discovery/processes")
+                    .param("properties", new ObjectMapper().writeValueAsString(list)))
+                .andExpect(status().isAccepted())
+                .andDo(result -> idRef
+                    .set(read(result.getResponse().getContentAsString(), "$.processId")));
+
+            Thread.sleep(10000);
+
+            getClient(token).perform(get("/api/system/processes/" + idRef.get()))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.heartbeat").value(Matchers.notNullValue()));
+        } finally {
+            ProcessBuilder.deleteProcess(idRef.get());
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ProcessRestRepositoryIT.java
@@ -23,6 +23,7 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -986,7 +987,7 @@ public class ProcessRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     @Test
     public void getProcessWithHeartbeat() throws Exception {
-        Instant heartbeat = Instant.now();
+        Instant heartbeat = Instant.now().truncatedTo(ChronoUnit.MICROS);
 
         Process processWithHeartbeat = ProcessBuilder
             .createProcess(context, admin, "mock-script", parameters)


### PR DESCRIPTION
## Description
Fixes https://github.com/DSpace/DSpace/issues/12967

Adds heartbeat support to the scripts & processes framework. Long-running scripts periodically report a timestamp indicating they are still alive, throttled to at most once per minute to avoid excessive database writes.

## Instructions for Reviewers
* Added `heartbeat` column to the `process` table (Postgres + H2 migrations)
* Extended `Process` entity with an `Instant heartbeat` field
* Added `registerHeartbeat()` to `DSpaceRunnableHandler`, implemented in `RestDSpaceRunnableHandler` (throttled to 1/min), no-op in `CommandLineDSpaceRunnableHandler`
* Wired heartbeat calls into: indexing (clean/update), metadata import/export, curation, harvesting, item import/export, bulk access control, media filters, ORCID bulk push, process cleanup
* Added `ObjectBoundHibernateDBConnection` and `Context.Type` (THREAD_BOUND/OBJECT_BOUND) to support short-lived, isolated database updates
* Exposed `heartbeat` via `ProcessRest`/`ProcessConverter`
* Added/updated integration tests (`ProcessRestRepositoryIT`, `ObjectBoundHibernateDBConnectionIT`)

Requires the corresponding frontend PR: DSpace/dspace-angular#5984

## Testing
Run a long-running script (e.g. `index-discovery -f` with enough items) and observe the heartbeat updating via `GET /server/api/system/processes/{id}`.