### PR TITLE
Avoid spurious Hibernate ObjectNotFoundException on collection/community logo permission checks

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.repository.BitstreamRestRepository;
 import org.dspace.app.rest.utils.ContextUtil;
-import org.dspace.app.rest.utils.DSpaceObjectUtils;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
@@ -44,8 +43,6 @@ public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPe
     @Autowired
     private RequestService requestService;
     @Autowired
-    private DSpaceObjectUtils dspaceObjectUtil;
-    @Autowired
     AuthorizeService authorizeService;
     @Autowired
     protected BitstreamService bitstreamService;
@@ -61,9 +58,14 @@ public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPe
 
             try {
                 UUID dsoUuid = UUID.fromString(targetId.toString());
-                DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, dsoUuid);
-                if (dso instanceof Bitstream) {
-                    return this.metadataReadPermissionOnBitstream(context, (Bitstream) dso);
+                // Look up the target as a Bitstream directly. This permission plugin only applies to
+                // Bitstreams, so a typed lookup avoids the generic DSpaceObjectUtils#findDSpaceObject sweep,
+                // which probes every DSpaceObject type and (given the shared-UUID JOINED inheritance model)
+                // logs a spurious Hibernate ObjectNotFoundException when the UUID is resolved as the wrong
+                // type (e.g. a Collection/Community logo bitstream). See issue #12839.
+                Bitstream bitstream = bitstreamService.find(context, dsoUuid);
+                if (bitstream != null) {
+                    return this.metadataReadPermissionOnBitstream(context, bitstream);
                 }
             } catch (SQLException e) {
                 log.error(e::getMessage, e);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -58,11 +58,9 @@ public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPe
 
             try {
                 UUID dsoUuid = UUID.fromString(targetId.toString());
-                // Look up the target as a Bitstream directly. This permission plugin only applies to
-                // Bitstreams, so a typed lookup avoids the generic DSpaceObjectUtils#findDSpaceObject sweep,
-                // which probes every DSpaceObject type and (given the shared-UUID JOINED inheritance model)
-                // logs a spurious Hibernate ObjectNotFoundException when the UUID is resolved as the wrong
-                // type (e.g. a Collection/Community logo bitstream). See issue #12839.
+                // Resolve the target as a Bitstream directly: this plugin only handles Bitstreams, and the
+                // untyped DSpaceObjectUtils#findDSpaceObject sweep logs a spurious Hibernate
+                // ObjectNotFoundException here (see #12839).
                 Bitstream bitstream = bitstreamService.find(context, dsoUuid);
                 if (bitstream != null) {
                     return this.metadataReadPermissionOnBitstream(context, bitstream);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1697,6 +1697,30 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
     }
 
     @Test
+    public void embedLogoAsAnonymousUserTest() throws Exception {
+        // Regression test for #12839: an anonymous user requesting a Collection with its logo
+        // embedded must receive the logo. Resolving the logo Bitstream's METADATA_READ permission
+        // must not fall back to the generic DSpaceObjectUtils#findDSpaceObject type sweep, which
+        // logged a spurious Hibernate ObjectNotFoundException for the logo bitstream on every
+        // such request.
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col = CollectionBuilder.createCollection(context, parentCommunity)
+                                          .withName("Collection With Logo")
+                                          .withLogo("TestingContentForLogo")
+                                          .build();
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/collections/" + col.getID()).param("embed", "logo"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$.id", is(col.getID().toString())))
+                   .andExpect(jsonPath("$._embedded.logo", Matchers.not(Matchers.empty())))
+                   .andExpect(jsonPath("$._embedded.logo.type", is("bitstream")));
+    }
+
+    @Test
     public void projectonLevelEmbedLevelDepthHigherThanEmbedMaxBadRequestTest() throws Exception {
         //We turn off the authorization system in order to create the structure as defined below
         context.turnOffAuthorisationSystem();

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/CollectionRestRepositoryIT.java
@@ -1698,11 +1698,10 @@ public class CollectionRestRepositoryIT extends AbstractControllerIntegrationTes
 
     @Test
     public void embedLogoAsAnonymousUserTest() throws Exception {
-        // Regression test for #12839: an anonymous user requesting a Collection with its logo
-        // embedded must receive the logo. Resolving the logo Bitstream's METADATA_READ permission
-        // must not fall back to the generic DSpaceObjectUtils#findDSpaceObject type sweep, which
-        // logged a spurious Hibernate ObjectNotFoundException for the logo bitstream on every
-        // such request.
+        // An anonymous user requesting a Collection with its logo embedded must receive the logo.
+        // This covers the non-admin branch of the logo Bitstream's METADATA_READ evaluation
+        // (BitstreamMetadataReadPermissionEvaluatorPlugin falls through to a READ authorization
+        // check), which projectonLevelTest does not reach because it embeds the logo as an admin.
         context.turnOffAuthorisationSystem();
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPluginTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPluginTest.java
@@ -1,0 +1,110 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.security;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.content.Bitstream;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.core.Constants;
+import org.dspace.core.Context;
+import org.dspace.services.RequestService;
+import org.dspace.services.model.Request;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * This class verifies that {@link BitstreamMetadataReadPermissionEvaluatorPlugin} resolves its
+ * target through a typed {@link BitstreamService} lookup.
+ *
+ * <p>The plugin only ever handles Bitstreams, so it must not resolve the target with the untyped
+ * {@link org.dspace.app.rest.utils.DSpaceObjectUtils#findDSpaceObject(Context, UUID)} sweep: that
+ * sweep calls {@code find} on every {@code DSpaceObjectService} in turn, and loading a Bitstream's
+ * UUID as a Collection or Community makes Hibernate log a spurious {@code HHH000327} /
+ * {@code ObjectNotFoundException} for every Collection or Community logo (see #12839).</p>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class BitstreamMetadataReadPermissionEvaluatorPluginTest {
+
+    private static final String METADATA_READ = "METADATA_READ";
+
+    @InjectMocks
+    private BitstreamMetadataReadPermissionEvaluatorPlugin plugin;
+
+    @Mock
+    private RequestService requestService;
+    @Mock
+    private AuthorizeService authorizeService;
+    @Mock
+    private BitstreamService bitstreamService;
+
+    @Mock
+    private Request request;
+    @Mock
+    private HttpServletRequest httpServletRequest;
+    @Mock
+    private Context context;
+    @Mock
+    private Bitstream bitstream;
+
+    private MockedStatic<ContextUtil> contextUtil;
+    private UUID uuid;
+
+    @Before
+    public void setUp() throws Exception {
+        uuid = UUID.randomUUID();
+        contextUtil = mockStatic(ContextUtil.class);
+        when(requestService.getCurrentRequest()).thenReturn(request);
+        when(request.getHttpServletRequest()).thenReturn(httpServletRequest);
+        contextUtil.when(() -> ContextUtil.obtainContext(httpServletRequest)).thenReturn(context);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        contextUtil.close();
+    }
+
+    @Test
+    public void resolvesTargetViaBitstreamService() throws Exception {
+        when(bitstreamService.find(context, uuid)).thenReturn(bitstream);
+        when(authorizeService.authorizeActionBoolean(context, bitstream, Constants.READ)).thenReturn(true);
+
+        assertTrue(plugin.hasPermission(null, uuid.toString(), "BITSTREAM", METADATA_READ));
+
+        // The target must be looked up as a Bitstream and as nothing else, so that no wrong-type
+        // load is ever issued for it (see #12839).
+        verify(bitstreamService).find(context, uuid);
+        verifyNoMoreInteractions(bitstreamService);
+    }
+
+    @Test
+    public void returnsFalseWhenTargetIsNotABitstream() throws Exception {
+        when(bitstreamService.find(context, uuid)).thenReturn(null);
+
+        assertFalse(plugin.hasPermission(null, uuid.toString(), "BITSTREAM", METADATA_READ));
+
+        verify(bitstreamService).find(context, uuid);
+        verifyNoMoreInteractions(bitstreamService);
+    }
+}


### PR DESCRIPTION
## References

* Fixes #12839
* Related to #8883 (same harmless Hibernate `HHH000327` log symptom, different trigger)

## Description

`BitstreamMetadataReadPermissionEvaluatorPlugin` resolved its target with the untyped
`DSpaceObjectUtils#findDSpaceObject`, whose brute-force type sweep makes Hibernate log a spurious
`HHH000327` / `ObjectNotFoundException` (with a full stack trace) every time a Collection/Community
logo bitstream's `METADATA_READ` permission is evaluated. This switches the plugin to a typed
`bitstreamService.find` lookup.

## Instructions for Reviewers

The `METADATA_READ` permission check for a Bitstream did:

```java
DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, dsoUuid);
if (dso instanceof Bitstream) { ... }
```

`DSpaceObjectUtils#findDSpaceObject` (untyped) iterates over **every** `DSpaceObjectService` calling
`find()` until one matches (its own Javadoc notes it "has poor performance"). Because DSpace uses
JOINED inheritance with a single shared-UUID `dspaceobject` table, calling
`collectionService.find(<logo-bitstream-uuid>)` makes Hibernate narrow an existing proxy to
`Collection`, find no `collection` row, and log `HHH000327: Error performing load command` with a
full stack trace. Hibernate then catches that exception internally and returns `null` (see #8883),
so the request still succeeds and the logo is returned, but a large stack trace has already been
written on every affected render. On one production instance this was logged ~39,000 times in a
single day, concentrated on a handful of frequently-requested collections (crawler + concurrent UI
traffic), each with a logo. There is a per-request cost too: the sweep runs several redundant DB
lookups per permission check.

List of changes in this PR:
* `BitstreamMetadataReadPermissionEvaluatorPlugin` now resolves the target with a typed
  `bitstreamService.find(context, uuid)` instead of the untyped `findDSpaceObject` sweep. The plugin
  only acts on Bitstreams (`dso instanceof Bitstream`), so behaviour is unchanged: it returns `null`
  (and the check returns `false`) for any non-Bitstream target, exactly as before, but no wrong-type
  `get` is issued, so the spurious `HHH000327` is never produced for this path.
* Removed the now-unused `DSpaceObjectUtils` autowired dependency from the plugin.
* Added `CollectionRestRepositoryIT#embedLogoAsAnonymousUserTest`, asserting that an anonymous user
  requesting a collection with its logo embedded receives the logo (the reported scenario).

**How to test:**
1. Create a Collection with a logo.
2. Tail `dspace.log` on the backend and request
   `GET /server/api/core/collections/<uuid>?embed=logo&embed=parentCommunity/parentCommunity`
   (what the Angular collection page issues).
3. Before this change, an `HHH000327 ... ObjectNotFoundException: Collection#<logo-bitstream-uuid>`
   stack trace is logged (the HTTP response is still a normal 200 with the logo). After this change,
   no such stack trace is logged and the logo is still returned.

Note: this is the same underlying Hibernate proxy-narrowing logging discussed in #8883 (and
HHH-7861); that ticket's trigger (deleting an in-progress submission) references a genuinely deleted
object and is not addressed here. This PR fixes the separate, high-volume logo/read-path trigger,
which is cleanly avoidable via the typed lookup.

## Checklist

- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size**.
- [x] My PR **follows all coding best practices**.
- [x] My PR **passes Checkstyle** validation.
- [x] My PR **includes Javadoc** for all new (or modified) public methods and classes (no public API changed; behaviour-preserving refactor with an explanatory comment).
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests**.
- [x] My PR **includes details on how to test it**.
- [x] My PR does not include new libraries/dependencies.
- [x] My PR does not modify REST API endpoints (response is unchanged).
- [x] My PR does not include new configurations.
- [x] My PR fixes an issue ticket and links them together.
