### PR TITLE
Fix failing ITs on Windows accidentally caused by invalid path parsing in XMLUtils

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/DCInputsReader.java
@@ -129,7 +129,7 @@ public class DCInputsReader {
         File inputFile = new File(fileName);
         String inputFileDir = inputFile.toPath().normalize().getParent().toString();
 
-        String uri = "file:" + inputFile.getAbsolutePath();
+        String uri = inputFile.toURI().toString();
 
         try {
             // This document builder will *not* disable external

--- a/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/SubmissionConfigReader.java
@@ -188,7 +188,7 @@ public class SubmissionConfigReader {
         entityTypeToSubmissionConfig = new HashMap<String, String>();
         submitDefns = new LinkedHashMap<String, List<Map<String, String>>>();
 
-        String uri = "file:" + new File(fileName).getAbsolutePath();
+        String uri = new File(fileName).toURI().toString();
 
         try {
             // This document builder factory will *not* disable external

--- a/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
@@ -338,21 +338,31 @@ public class XMLUtils {
                 return null;
             }
 
-            String filePath;
-            if (systemId.startsWith("file://")) {
-                filePath = systemId.substring(7);
-            } else if (systemId.startsWith("file:")) {
-                filePath = systemId.substring(5);
-            } else if (!systemId.contains("://")) {
-                filePath = systemId;
-            } else {
+            URI fileUri;
+            try {
+                // First, try to parse this string as a URI.
+                fileUri = new URI(systemId);
+            } catch (Exception e) {
+                try {
+                    // Could not be parsed as a URI.
+                    // Second, try to parse it as a Path and convert to URI.
+                    fileUri = Paths.get(systemId).toUri();
+                } catch (Exception e2) {
+                    // Doesn't appear to be a valid URI or a Path, so we'll have to throw an error.
+                    throw new SAXException("Invalid path: " + systemId, e2);
+                }
+            }
+
+            // Only allow for "file" scheme or empty scheme
+            String scheme = fileUri.getScheme();
+            if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
                 throw new SAXException("External resources not allowed: " + systemId +
                         ". Only local file paths are permitted.");
             }
 
             Path resolvedPath;
             try {
-                resolvedPath = Paths.get(filePath).toAbsolutePath().normalize();
+                resolvedPath = Paths.get(fileUri).toAbsolutePath().normalize();
             } catch (Exception e) {
                 throw new SAXException("Invalid path: " + systemId, e);
             }

--- a/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
+++ b/dspace-api/src/main/java/org/dspace/app/util/XMLUtils.java
@@ -12,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -349,13 +350,25 @@ public class XMLUtils {
                     fileUri = Paths.get(systemId).toUri();
                 } catch (Exception e2) {
                     // Doesn't appear to be a valid URI or a Path, so we'll have to throw an error.
-                    throw new SAXException("Invalid path: " + systemId, e2);
+                    throw new SAXException("Invalid URI or path: " + systemId, e2);
                 }
             }
 
-            // Only allow for "file" scheme or empty scheme
             String scheme = fileUri.getScheme();
-            if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
+
+            // If our URI has a null scheme, that means it's a relative URI or missing its scheme (e.g. /tmp/path)
+            // Because we only accept file URIs, we'll attempt to recreate it as a file URI.
+            if (scheme == null) {
+                try {
+                    fileUri = new URI("file", fileUri.getSchemeSpecificPart(), fileUri.getFragment());
+                    scheme = fileUri.getScheme();
+                } catch (URISyntaxException e) {
+                    throw new SAXException("Cannot convert to absolute file URI:" + systemId, e);
+                }
+            }
+
+            // Only allow for "file" scheme
+            if (!"file".equalsIgnoreCase(scheme)) {
                 throw new SAXException("External resources not allowed: " + systemId +
                         ". Only local file paths are permitted.");
             }
@@ -480,7 +493,7 @@ public class XMLUtils {
 
         @Override
         public Source resolve(String href, String base) throws TransformerException {
-            final URI uri;
+            URI uri;
             // Base path is optional, as the "href" might already be an absolute path
             if (base == null || base.isEmpty()) {
                 uri = URI.create(href);
@@ -488,9 +501,21 @@ public class XMLUtils {
                 uri = URI.create(base).resolve(href);
             }
 
-            // Only allow for "file" scheme or empty scheme
             String scheme = uri.getScheme();
-            if (scheme != null && !"file".equalsIgnoreCase(scheme)) {
+
+            // If our URI has a null scheme, that means it's a relative URI or missing its scheme (e.g. /tmp/path)
+            // Because we only accept file URIs, we'll attempt to recreate it as a file URI.
+            if (scheme == null) {
+                try {
+                    uri = new URI("file", uri.getSchemeSpecificPart(), uri.getFragment());
+                    scheme = uri.getScheme();
+                } catch (URISyntaxException e) {
+                    throw new TransformerException("Cannot convert to absolute file URI:" + uri, e);
+                }
+            }
+
+            // Only allow for "file" scheme
+            if (!"file".equalsIgnoreCase(scheme)) {
                 throw new TransformerException("External resources not allowed: " + uri +
                                            ". Only local file paths are permitted.");
             }

--- a/dspace-api/src/test/java/org/dspace/app/util/XMLUtils_PathRestrictedEntityResolverTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/XMLUtils_PathRestrictedEntityResolverTest.java
@@ -1,0 +1,160 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.dspace.app.util.XMLUtils.PathRestrictedEntityResolver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * Unit tests for {@link XMLUtils.PathRestrictedEntityResolver}.
+ *
+ * These unit tests exercise the resolver in isolation without the full application.
+ * Therefore, this PURPOSEFULLY doesn't extend AbstractUnitTest because it doesn't need a database setup.
+ */
+public class XMLUtils_PathRestrictedEntityResolverTest {
+
+    @Rule
+    public TemporaryFolder allowedFolder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder disallowedFolder = new TemporaryFolder();
+
+    private Path allowedDir;
+    private Path allowedFile;
+
+    @Before
+    public void setUp() throws IOException {
+        allowedDir = allowedFolder.getRoot().toPath();
+        allowedFile = allowedFolder.newFile("allowed.dtd").toPath();
+    }
+
+    @Test
+    public void nullSystemId_returnsNull() throws Exception {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+        assertNull(resolver.resolveEntity("somePublicId", null));
+    }
+
+    @Test
+    public void plainFilePath_withinAllowedDir_isResolved() throws Exception {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+
+        // systemId is a raw filesystem path (NOT a "file://" URI)
+        String systemId = allowedFile.toString();
+        assertFalse(systemId.startsWith("file://"));
+
+        InputSource result = resolver.resolveEntity(null, systemId);
+        // resolved successfully!
+        assertNotNull(result);
+    }
+
+    @Test
+    public void fileURI_withinAllowedDir_isResolved() throws Exception {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+
+        // systemId using "file://" prefix, e.g. file:///path/to/allowed.dtd
+        String systemId = allowedFile.toUri().toString();
+        assertTrue(systemId.startsWith("file://"));
+
+        InputSource result = resolver.resolveEntity(null, systemId);
+        // resolved successfully!
+        assertNotNull(result);
+    }
+
+    @Test
+    public void externalSystemId_isRejected() {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+
+        // systemId is an HTTP link
+        SAXException ex = assertThrows(SAXException.class,
+                                       () -> resolver.resolveEntity(null, "http://example.com/evil.dtd"));
+        assertTrue(ex.getMessage().contains("External resources not allowed"));
+
+        // systemId is an FTP link
+        SAXException ex2 = assertThrows(SAXException.class,
+                                       () -> resolver.resolveEntity(null, "ftp://example.com/evil.dtd"));
+        assertTrue(ex2.getMessage().contains("External resources not allowed"));
+
+        // systemId is an HTTPS link
+        SAXException ex3 = assertThrows(SAXException.class,
+                                        () -> resolver.resolveEntity(null, "https://example.com/evil.dtd"));
+        assertTrue(ex3.getMessage().contains("External resources not allowed"));
+    }
+
+    @Test
+    public void pathOutsideAllowedDir_isDenied() throws IOException {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+
+        Path outsideFile = disallowedFolder.newFile("disallowed.dtd").toPath();
+
+        // systemId points at an existing file in a disallowed directory
+        SAXException ex = assertThrows(SAXException.class,
+                                       () -> resolver.resolveEntity(null, outsideFile.toString()));
+        assertTrue(ex.getMessage().contains("Access denied"));
+    }
+
+    @Test
+    public void pathTraversalOutOfAllowedDir_isDenied() {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+
+        // systemId is an attempt at directory traversal attack starting from allowed directory
+        String traversalAttempt = allowedDir.resolve("../../../etc/passwd").toString();
+
+        SAXException ex = assertThrows(SAXException.class,
+                                       () -> resolver.resolveEntity(null, traversalAttempt));
+        assertTrue(ex.getMessage().contains("Access denied"));
+    }
+
+    @Test
+    public void noAllowedPaths_deniesEverything() {
+        // No allowedBasePaths provided means that nothing will resolve
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver();
+
+        SAXException ex = assertThrows(SAXException.class,
+                                       () -> resolver.resolveEntity(null, allowedFile.toString()));
+        assertTrue(ex.getMessage().contains("Access denied"));
+    }
+
+    @Test
+    public void multipleAllowedPaths_isResolvedForSecondPath() throws Exception {
+        // Provide multiple allowedBatPaths
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(
+            disallowedFolder.getRoot().toString(), allowedDir.toString());
+
+        // Ensure something in the *second* path will resolve correctly
+        InputSource result = resolver.resolveEntity(null, allowedFile.toString());
+        // resolved successfully!
+        assertNotNull(result);
+    }
+
+    @Test
+    public void withinAllowedDir_butFileDoesNotExist() {
+        PathRestrictedEntityResolver resolver = new PathRestrictedEntityResolver(allowedDir.toString());
+
+        // Specify a file that doesn't exist in an allowed directory
+        Path missing = allowedDir.resolve("does-not-exist.dtd");
+
+        // Resolve should throw a file not found error, even though it was requested from an allowed directory.
+        SAXException ex = assertThrows(SAXException.class,
+                                       () -> resolver.resolveEntity(null, missing.toString()));
+        assertTrue(ex.getMessage().contains("File not found"));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/app/util/XMLUtils_PathRestrictedURIResolverTest.java
+++ b/dspace-api/src/test/java/org/dspace/app/util/XMLUtils_PathRestrictedURIResolverTest.java
@@ -1,0 +1,163 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.util;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+
+import org.dspace.app.util.XMLUtils.PathRestrictedURIResolver;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for {@link XMLUtils.PathRestrictedURIResolver}.
+ *
+ * These unit tests exercise the resolver in isolation without the full application.
+ * Therefore, this PURPOSEFULLY doesn't extend AbstractUnitTest because it doesn't need a database setup.
+ */
+public class XMLUtils_PathRestrictedURIResolverTest {
+
+    @Rule
+    public TemporaryFolder allowedFolder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder disallowedFolder = new TemporaryFolder();
+
+    private Path allowedDir;
+    private Path allowedFile;
+    private final String allowedFileName = "allowed.xsl";
+
+    @Before
+    public void setUp() throws IOException {
+        allowedDir = allowedFolder.getRoot().toPath();
+        allowedFile = allowedFolder.newFile(allowedFileName).toPath();
+    }
+
+    @Test
+    public void absoluteFileHref_withinAllowedDir_isResolved() throws Exception {
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(allowedDir.toString());
+
+        // href is an absolute path via a file:// URI
+        String href = allowedFile.toUri().toString();
+
+        Source source = resolver.resolve(href, null);
+        // resolved successfully!
+        assertNotNull(source);
+
+        // Also ensure an empty base works properly
+        source = resolver.resolve(href, "");
+        // resolved successfully!
+        assertNotNull(source);
+    }
+
+    @Test
+    public void relativeHref_resolvedAgainstBase_withinAllowedDir_isResolved() throws Exception {
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(allowedDir.toString());
+
+        // base points at the allowed directory
+        String base = allowedDir.toUri().toString();
+        // href is a relative URL to file based on the "base" path
+        String href = allowedFileName;
+
+        Source source = resolver.resolve(href, base);
+        // resolved successfully!
+        assertNotNull(source);
+    }
+
+    @Test
+    public void externalResource_isRejected() {
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(allowedDir.toString());
+
+        // href is an HTTP URL
+        TransformerException ex = assertThrows(TransformerException.class,
+                                               () -> resolver.resolve("http://example.com/evil.xsl", null));
+        assertTrue(ex.getMessage().contains("External resources not allowed"));
+
+        // href is an HTTPS URL
+        TransformerException ex2 = assertThrows(TransformerException.class,
+                                               () -> resolver.resolve("https://example.com/evil.xsl", null));
+        assertTrue(ex2.getMessage().contains("External resources not allowed"));
+
+        // href is an FTP URL
+        TransformerException ex3 = assertThrows(TransformerException.class,
+                                                () -> resolver.resolve("ftp://example.com/evil.xsl", null));
+        assertTrue(ex3.getMessage().contains("External resources not allowed"));
+    }
+
+    @Test
+    public void hrefOutsideAllowedDir_isDenied() throws IOException {
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(allowedDir.toString());
+
+        // href points to an existing file in a disallowed folder
+        Path outsideFile = disallowedFolder.newFile("disallowed.xsl").toPath();
+        String href = outsideFile.toUri().toString();
+
+        TransformerException ex = assertThrows(TransformerException.class,
+                                               () -> resolver.resolve(href, null));
+        assertTrue(ex.getMessage().contains("Access denied"));
+    }
+
+    @Test
+    public void relativeHref_traversingOutOfBase_isDenied() {
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(allowedDir.toString());
+
+        // href is an attempt at a directory traversal attack starting from allowed directory
+        String base = allowedDir.toUri().toString();
+        String href = "../../../../etc/passwd";
+
+        TransformerException ex = assertThrows(TransformerException.class,
+                                               () -> resolver.resolve(href, base));
+        assertTrue(ex.getMessage().contains("Access denied"));
+    }
+
+    @Test
+    public void noAllowedPaths_deniesEverything() {
+        // No allowedBasePaths provided means that nothing will resolve
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver();
+
+        String href = allowedFile.toUri().toString();
+
+        TransformerException ex = assertThrows(TransformerException.class,
+                                               () -> resolver.resolve(href, null));
+        assertTrue(ex.getMessage().contains("Access denied"));
+    }
+
+    @Test
+    public void multipleAllowedPaths_isResolvedForSecondPath() throws Exception {
+        // Provide multiple allowedBatPaths
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(
+            disallowedFolder.getRoot().toString(), allowedDir.toString());
+
+        // Ensure something in the *second* path will resolve correctly
+        String href = allowedFile.toUri().toString();
+
+        Source source = resolver.resolve(href, null);
+        assertNotNull(source);
+    }
+
+    @Test
+    public void withinAllowedDir_butFileDoesNotExist() {
+        PathRestrictedURIResolver resolver = new PathRestrictedURIResolver(allowedDir.toString());
+
+        // Specify a file that doesn't exist in an allowed directory
+        String href = allowedDir.resolve("does-not-exist.xsl").toUri().toString();
+
+        // Resolve should throw a file not found error, even though it was requested from an allowed directory.
+        TransformerException ex = assertThrows(TransformerException.class,
+                                               () -> resolver.resolve(href, null));
+        assertTrue(ex.getMessage().contains("File not found"));
+    }
+}


### PR DESCRIPTION
## References
* This is a small bug fix to #11030, specific to Windows machines
* Most of the PR is tests to verify the behavior on both Linux & Windows. These tests pass on Windows

## Description
I've recently run into a scenario on Windows where ITs will sometimes fail to run because errors occur in the initialization of the in-memory database.  The underlying error looks like this:

```
Caused by: java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C://DSpace/dspace-server-webapp/target/testing/dspace/config/registries/dspace-dc-types.dtd
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:204)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:175)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
	at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:231)
	at java.base/java.nio.file.Path.of(Path.java:148)
	at java.base/java.nio.file.Paths.get(Paths.java:69)
	at org.dspace.app.util.XMLUtils$PathRestrictedEntityResolver.resolveEntity(XMLUtils.java:355)
```

After debugging the problem, I found the issue is that `XMLUtils.resolveEntity()` may receive paths from Windows machines that look like this:
```
file:/C:/DSpace/dspace-server-webapp/target/testing/dspace/config/registries/dspace-dc-types.dtd
```

This path is then parsed into an **invalid** path which looks like this:
```
/C:/DSpace/dspace-server-webapp/target/testing/dspace/config/registries/dspace-dc-types.dtd
```

A correctly parsed path would also remove the preceding slash like this:
```
C:/DSpace/dspace-server-webapp/target/testing/dspace/config/registries/dspace-dc-types.dtd
```

### Implementation

This PR refactors the `PathRestrictedEntityResolver.resolveEntity()` method in `XMLUtils` to use the `java.net.URI` and `java.nio.file.Path` classes to parse string paths for proper validation.  This removes the manual string parsing that was previously in this method.

This also required minor updates to hardcoded paths in `DCInputsReader` and `SubmissionConfigReader` to similarly use `java.net.URI` to build URI Strings.  This was necessary because the strings built were not always possible to parse later using `java.net.URI`.

Finally, I added more extensive unit tests for this method in `XMLUtils_PathRestrictedEntityResolverTest` to verify that the path validation is still behaving as expected.  (Though not directly related to this PR, I copied and refactored those unit tests into a `XMLUtils_PathRestrictedURIResolverTest` for the similar `PathRestrictedURIResolver.resolveEntity()` method in `XMLUtils`. This ensures our resolvers have code coverage and are behaving as expected.)

## Instructions for Reviewers
* Review the minor code changes
* Optional: Test on Windows.  However, I can verify this small fix lets me run all ITs again properly without encountering XML parsing errors in some ITs.

## AI Disclosure

I used Claude AI to help scaffold the newly added unit tests in `XMLUtils_PathRestrictedEntityResolverTest`.  The code that Claude scaffolded was not used directly... rather I was looking at the types of tests Claude AI recommended adding to prove the code worked as expected.  I took those suggestions into the code created here...and then copied that model to the `XMLUtils_PathRestrictedURIResolverTest` as well.