### PR TITLE
Fix day table embargo bug

### DIFF
--- a/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
@@ -65,7 +65,7 @@ public class DayTableEmbargoSetter extends DefaultEmbargoSetter {
             if (days != null && days.length() > 0) {
                 long lift = Instant.now().toEpochMilli() +
                     (Long.parseLong(days) * 24 * 60 * 60 * 1000);
-                return new DCDate(ZonedDateTime.ofInstant(Instant.ofEpochSecond(lift), ZoneOffset.UTC));
+                return new DCDate(ZonedDateTime.ofInstant(Instant.ofEpochMilli(lift), ZoneOffset.UTC));
             }
         }
         return null;

--- a/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
+++ b/dspace-api/src/main/java/org/dspace/embargo/DayTableEmbargoSetter.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.DCDate;
@@ -64,7 +65,7 @@ public class DayTableEmbargoSetter extends DefaultEmbargoSetter {
             String days = termProps.getProperty(terms);
             if (days != null && days.length() > 0) {
                 long lift = Instant.now().toEpochMilli() +
-                    (Long.parseLong(days) * 24 * 60 * 60 * 1000);
+                    TimeUnit.DAYS.toMillis(Long.parseLong(days));
                 return new DCDate(ZonedDateTime.ofInstant(Instant.ofEpochMilli(lift), ZoneOffset.UTC));
             }
         }

--- a/dspace-api/src/test/java/org/dspace/embargo/DayTableEmbargoSetterTest.java
+++ b/dspace-api/src/test/java/org/dspace/embargo/DayTableEmbargoSetterTest.java
@@ -1,0 +1,151 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.embargo;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.content.DCDate;
+import org.dspace.services.ConfigurationService;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DayTableEmbargoSetter#parseTerms}. The terms parsing
+ * only depends on configuration ('embargo.terms.open' and 'embargo.terms.days'),
+ * not on the Context or Item, so these tests run against the test kernel
+ * without a database.
+ */
+public class DayTableEmbargoSetterTest extends AbstractUnitTest {
+
+    private static final String TERMS_OPEN_PROPERTY = "embargo.terms.open";
+    private static final String TERMS_DAYS_PROPERTY = "embargo.terms.days";
+
+    /**
+     * Tolerance when comparing computed lift dates against "now + N days",
+     * to absorb the time that passes while the test runs.
+     */
+    private static final Duration TOLERANCE = Duration.ofMinutes(5);
+
+    private ConfigurationService configurationService;
+    private DayTableEmbargoSetter embargoSetter;
+
+    private Object previousTermsOpen;
+    private Object previousTermsDays;
+
+    @Before
+    public void setUp() {
+        configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
+        previousTermsOpen = configurationService.getPropertyValue(TERMS_OPEN_PROPERTY);
+        previousTermsDays = configurationService.getPropertyValue(TERMS_DAYS_PROPERTY);
+
+        configurationService.setProperty(TERMS_OPEN_PROPERTY, "forever");
+        configurationService.setProperty(TERMS_DAYS_PROPERTY,
+                                         new String[] {"90 days:90", "6 months:180", "1 year:365"});
+        embargoSetter = new DayTableEmbargoSetter();
+    }
+
+    @After
+    public void tearDown() {
+        configurationService.setProperty(TERMS_OPEN_PROPERTY, previousTermsOpen);
+        configurationService.setProperty(TERMS_DAYS_PROPERTY, previousTermsDays);
+    }
+
+    /**
+     * Terms matching the configured 'embargo.terms.open' value mean a
+     * permanent embargo: the lift date is the constant FOREVER date rather
+     * than a computed one.
+     */
+    @Test
+    public void parseTermsReturnsForeverForOpenTerms() throws SQLException, AuthorizeException {
+        DCDate result = embargoSetter.parseTerms(null, null, "forever");
+        assertEquals("Open terms should return the FOREVER date",
+                     EmbargoServiceImpl.FOREVER.toString(), result.toString());
+    }
+
+    /**
+     * Terms found in the 'embargo.terms.days' table produce a lift date the
+     * configured number of days from now.
+     */
+    @Test
+    public void parseTermsComputesLiftDateFromDayTable() throws SQLException, AuthorizeException {
+        DCDate result = embargoSetter.parseTerms(null, null, "90 days");
+        assertNotNull("Terms in the day table should produce a lift date", result);
+
+        ZonedDateTime expected = ZonedDateTime.now().plusDays(90);
+        Duration difference = Duration.between(expected, result.toDate()).abs();
+        assertTrue("Lift date should be 90 days from now, but was " + result.toDate()
+                       + " (off by " + difference + ")",
+                   difference.compareTo(TOLERANCE) <= 0);
+    }
+
+    /**
+     * Every entry in the day table maps to its own day count: each configured
+     * terms string yields a lift date that many days from now, independent of
+     * the other entries.
+     */
+    @Test
+    public void parseTermsComputesLiftDateForEachConfiguredEntry() throws SQLException, AuthorizeException {
+        String[][] termsAndDays = {{"6 months", "180"}, {"1 year", "365"}};
+        for (String[] entry : termsAndDays) {
+            DCDate result = embargoSetter.parseTerms(null, null, entry[0]);
+            assertNotNull("Terms '" + entry[0] + "' should produce a lift date", result);
+
+            ZonedDateTime expected = ZonedDateTime.now().plusDays(Long.parseLong(entry[1]));
+            Duration difference = Duration.between(expected, result.toDate()).abs();
+            assertTrue("Lift date for '" + entry[0] + "' should be " + entry[1]
+                           + " days from now, but was " + result.toDate(),
+                       difference.compareTo(TOLERANCE) <= 0);
+        }
+    }
+
+    /**
+     * Terms text absent from the day table produces no lift date.
+     */
+    @Test
+    public void parseTermsReturnsNullForUnknownTerms() throws SQLException, AuthorizeException {
+        assertNull("Terms not in the day table should return null",
+                   embargoSetter.parseTerms(null, null, "3 fortnights"));
+    }
+
+    /**
+     * An item with no embargo terms metadata is not embargoed.
+     */
+    @Test
+    public void parseTermsReturnsNullForNullTerms() throws SQLException, AuthorizeException {
+        assertNull("Null terms should return null",
+                   embargoSetter.parseTerms(null, null, null));
+    }
+
+    /**
+     * Whitespace around the terms or the day count in a configured
+     * 'terms:days' entry is ignored.
+     */
+    @Test
+    public void parseTermsTrimsWhitespaceInDayTableEntries() throws SQLException, AuthorizeException {
+        configurationService.setProperty(TERMS_DAYS_PROPERTY, new String[] {" 2 years : 730 "});
+
+        DCDate result = embargoSetter.parseTerms(null, null, "2 years");
+        assertNotNull("Day table entries with surrounding whitespace should still match", result);
+
+        ZonedDateTime expected = ZonedDateTime.now().plusDays(730);
+        Duration difference = Duration.between(expected, result.toDate()).abs();
+        assertTrue("Lift date should be 730 days from now, but was " + result.toDate(),
+                   difference.compareTo(TOLERANCE) <= 0);
+    }
+}


### PR DESCRIPTION
## References
This fixes issue [#12796](https://github.com/DSpace/DSpace/issues/12796)

## Description
Adds test code DayTableEmbargoSetterTest.java that demonstrates the bug.
Fixes the bug in  DayTableEmbargoSetter.java

## Instructions for Reviewers
This PR consists of 2 commits. The first creates a test that demonstrates the bug. The second contains a fix for the bug.

Execute the test with `mvn test -DskipUnitTests=false -Dtest=org.dspace.embargo.DayTableEmbargoSetterTest -DfailIfNoTests=false`

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
