### PR TITLE
Add Location header to created REST resources

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -439,7 +439,9 @@ public class RestResourceController implements InitializingBean {
         }
         DSpaceResource result = converter.toResource(modelObject);
         //TODO manage HTTPHeader
-        return ControllerUtils.toResponseEntity(HttpStatus.CREATED, new HttpHeaders(), result);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(result.getRequiredLink("self").toUri());
+        return ControllerUtils.toResponseEntity(HttpStatus.CREATED, headers, result);
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EPersonRestRepositoryIT.java
@@ -145,6 +145,8 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                             .param("projection", "full"))
                             .andExpect(status().isCreated())
                             .andExpect(content().contentType(contentType))
+                            .andExpect(header().string("Location",
+                                startsWith(REST_SERVER_URL + "eperson/epersons/")))
                             .andExpect(jsonPath("$", EPersonMatcher.matchFullEmbeds()))
                             .andExpect(jsonPath("$", Matchers.allOf(
                                hasJsonPath("$.uuid", not(empty())),
@@ -160,8 +162,12 @@ public class EPersonRestRepositoryIT extends AbstractControllerIntegrationTest {
                                        matchMetadata("eperson.lastname", "Doe"),
                                        matchMetadataDoesNotExist("dc.identifier.uri")
                                )))))
-                            .andDo(result -> idRef
-                                    .set(UUID.fromString(read(result.getResponse().getContentAsString(), "$.id"))));
+                            .andDo(result -> {
+                                String id = read(result.getResponse().getContentAsString(), "$.id");
+                                assertEquals(REST_SERVER_URL + "eperson/epersons/" + id,
+                                    result.getResponse().getHeader("Location"));
+                                idRef.set(UUID.fromString(id));
+                            });
 
         getClient(authToken).perform(post("/api/eperson/epersons")
                 .content(mapper.writeValueAsBytes(dataFull))


### PR DESCRIPTION
## References

Fixes #8881

Companion contract: DSpace/RestContract#369

## Description

Populate successful JSON create responses with the canonical created-resource URI in the HTTP `Location` header.

## Instructions for Reviewers

List of changes in this PR:
* Set `Location` from the generated resource's required HAL `self` link in the shared JSON-create response path.
* Extend `EPersonRestRepositoryIT#createTest` to verify that the header URI contains the same UUID returned in the response body.

To verify locally:

```bash
mvn -pl dspace-server-webapp,dspace -am verify \
  -DskipUnitTests=true \
  -DskipIntegrationTests=false \
  -Dit.test=EPersonRestRepositoryIT#createTest
```

The focused test passes (1 test), along with the dependent reactor build, license checks, and Checkstyle.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (No public API signatures changed.)
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (No dependencies added.)
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. (No configuration added.)
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
