### PR TITLE
Fix en_US language mapping in OpenAIRE 4 and RIOXX OAI transformers

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/openaire4.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire4.xsl
@@ -35,7 +35,7 @@
             </xsl:call-template>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="$lc_value = 'en_US'">
+            <xsl:when test="$lc_value = 'en_us'">
                 <xsl:text>eng</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'en'">

--- a/dspace/config/crosswalks/oai/transformers/rioxx.xsl
+++ b/dspace/config/crosswalks/oai/transformers/rioxx.xsl
@@ -65,7 +65,7 @@
             </xsl:call-template>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="$lc_value = 'en_US'">
+            <xsl:when test="$lc_value = 'en_us'">
                 <xsl:text>eng</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'en'">


### PR DESCRIPTION
## References

Fixes #12850

## Description

One-character fix in two OAI context transformers.

`dc.language.iso` is normalized from ISO 639-1 to ISO 639-3 by lowercasing the value into `$lc_value` and then running it through an `<xsl:choose>`. The first branch compared that lowercased variable against the mixed-case literal `'en_US'`, so it could never match, and `en_US` fell through to `<xsl:otherwise>` and was emitted verbatim.

`en_US` ("English (United States)") is the first real option in the default `common_iso_languages` value pairs in `submission-forms.xml`, so this hits stock installations.

- `transformers/openaire4.xsl` (OpenAIRE 4 context, feeds `oai_openaire`)
- `transformers/rioxx.xsl` (RIOXX context, identical copy of the template)

## Instructions for Reviewers

The normalization happens in the *context transformer*, which XOAI applies before the metadata format stylesheet; `metadataFormats/oai_openaire.xsl` only copies the value through. So this single change is enough to correct the exported `dc:language`.

Can be verified without a running DSpace, using the sample input from #12850:

```
$ xsltproc dspace/config/crosswalks/oai/transformers/openaire4.xsl lang.xml
```

Before:

```xml
<doc:element name="en_US"><doc:field name="value">en_US</doc:field></doc:element>
<doc:element name="en"><doc:field name="value">eng</doc:field></doc:element>
<doc:element name="ES"><doc:field name="value">spa</doc:field></doc:element>
```

After:

```xml
<doc:element name="en_US"><doc:field name="value">eng</doc:field></doc:element>
<doc:element name="en"><doc:field name="value">eng</doc:field></doc:element>
<doc:element name="ES"><doc:field name="value">spa</doc:field></doc:element>
```

Same result for `transformers/rioxx.xsl`.

In a running instance: harvest an item with `dc.language.iso = en_US` via `[dspace.server.url]/oai/openaire4?verb=GetRecord&metadataPrefix=oai_openaire&identifier=oai:...` and check that `<dc:language>` is `eng`.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests).
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. (n/a, configuration only)
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (n/a, no test harness exists for the OAI XSLTs)
- [x] If my PR includes new libraries/dependencies, I've documented their licenses. (n/a)
- [x] If my PR modifies the REST API, I've linked to the REST Contract page. (n/a)

## Backports

Backports are open: #12852 (`dspace-10_x`), #12853 (`dspace-9_x`), #12854 (`dspace-8_x`). All are clean cherry-picks of this commit. `dspace-7_x` is no longer maintained and is intentionally left out.
