### PR TITLE
[dspace-9_x] Fix en_US language mapping in OpenAIRE 4 and RIOXX OAI transformers

### DIFF
--- a/dspace/config/crosswalks/oai/transformers/openaire4.xsl
+++ b/dspace/config/crosswalks/oai/transformers/openaire4.xsl
@@ -35,7 +35,7 @@
             </xsl:call-template>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="$lc_value = 'en_US'">
+            <xsl:when test="$lc_value = 'en_us'">
                 <xsl:text>eng</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'en'">

--- a/dspace/config/crosswalks/oai/transformers/rioxx.xsl
+++ b/dspace/config/crosswalks/oai/transformers/rioxx.xsl
@@ -65,7 +65,7 @@
             </xsl:call-template>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="$lc_value = 'en_US'">
+            <xsl:when test="$lc_value = 'en_us'">
                 <xsl:text>eng</xsl:text>
             </xsl:when>
             <xsl:when test="$lc_value = 'en'">


### PR DESCRIPTION
## References

Backport of #12851 to `dspace-9_x`. Fixes #12850 on this branch.

## Description

`dc.language.iso` is lowercased into `$lc_value` and then matched in an `<xsl:choose>`, but the first branch compares it against the mixed-case literal `'en_US'`. That branch can never match, so `en_US` falls through to `<xsl:otherwise>` and is exported verbatim instead of being normalized to `eng`.

`en_US` ("English (United States)") is the first real option in the default `common_iso_languages` value pairs in `submission-forms.xml`, so this affects stock installations.

Affects two context transformers, which carry identical copies of the template:

- `dspace/config/crosswalks/oai/transformers/openaire4.xsl` (OpenAIRE 4 context, feeds `oai_openaire`)
- `dspace/config/crosswalks/oai/transformers/rioxx.xsl` (RIOXX context)

Clean cherry-pick, no adaptation needed for this branch.

## Instructions for Reviewers

The normalization lives in the *context transformer*, which XOAI applies before the metadata format stylesheet; `metadataFormats/oai_openaire.xsl` only copies the value through with `<xsl:value-of select="./text()"/>`. So this change alone corrects the exported `dc:language`.

Verified on this branch without a running DSpace, using the sample input from #12850:

```
$ xsltproc dspace/config/crosswalks/oai/transformers/openaire4.xsl lang.xml
```

Before / after for the three sample values:

| stored `dc.language.iso` | before | after |
|---|---|---|
| `en_US` | `en_US` | `eng` |
| `en` | `eng` | `eng` |
| `ES` | `spa` | `spa` |

`ES` -> `spa` confirms the lowercasing itself works; only the `en_US` literal was wrong. Same result for `transformers/rioxx.xsl`.

## Checklist

- [x] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & integration tests).
- [x] My PR passes Checkstyle validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR includes Javadoc for _all new (or modified) public methods and classes_. (n/a, configuration only)
- [x] My PR passes all tests and includes new/updated Unit or Integration Tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (n/a, no test harness exists for the OAI XSLTs)
- [x] If my PR includes new libraries/dependencies, I've documented their licenses. (n/a)
- [x] If my PR modifies the REST API, I've linked to the REST Contract page. (n/a)
