### PR TITLE
[Port dspace-9_x] Fix unit conversion in BitstreamStorageServiceImpl::isRecent method

### DIFF
--- a/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/storage/bitstore/BitstreamStorageServiceImpl.java
@@ -492,12 +492,14 @@ public class BitstreamStorageServiceImpl implements BitstreamStorageService, Ini
     protected boolean isRecent(Long lastModified) {
         long now = Instant.now().toEpochMilli();
 
-        if (lastModified >= now) {
+        if (lastModified == null || lastModified >= now) {
             return true;
         }
 
         // Less than one hour old
-        return (now - lastModified) < (1 * 60 * 1000);
+        long waitHours = 1L;
+        long waitMilli = waitHours * 60 * 60 * 1000;
+        return (now - lastModified) < waitMilli;
     }
 
     protected BitStoreService getStore(int position) throws IOException {


### PR DESCRIPTION
## References

Backport of #12804 to `dspace-9_x`.

## Description

The value used for the wait window was intended to be in hours, but the calculation resulted in minutes (i.e., 1 minute by default).

## Checklist

- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
