### PR TITLE
feat(authentication-saml): implement login.specialgroup configuration option

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authenticate/SamlAuthentication.java
+++ b/dspace-api/src/main/java/org/dspace/authenticate/SamlAuthentication.java
@@ -8,6 +8,7 @@
 package org.dspace.authenticate;
 
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -178,6 +179,26 @@ public class SamlAuthentication implements AuthenticationMethod {
 
     @Override
     public List<Group> getSpecialGroups(Context context, HttpServletRequest request) throws SQLException {
+        // Check if authentication-saml.login.specialgroup config has a group defined
+        try {
+            // without a logged in user, this method should return an empty list
+            if (context.getCurrentUser() == null) {
+                return List.of();
+            }
+            String groupName = configurationService.getProperty("authentication-saml.login.specialgroup");
+            if ((groupName != null) && (!groupName.trim().equals(""))) {
+                Group group = groupService.findByName(context, groupName);
+                if (group == null) {
+                    // Group not found
+                    log.warn("Group defined in authentication-saml.login.specialgroup does not exist");
+                    return List.of();
+                } else {
+                    return Arrays.asList(group);
+                }
+            }
+        } catch (SQLException ex) {
+            // Database error, ignore
+        }
         return List.of();
     }
 

--- a/dspace-api/src/test/java/org/dspace/authenticate/SamlAuthenticationTest.java
+++ b/dspace-api/src/test/java/org/dspace/authenticate/SamlAuthenticationTest.java
@@ -18,8 +18,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.dspace.AbstractUnitTest;
 import org.dspace.builder.AbstractBuilder;
 import org.dspace.builder.EPersonBuilder;
+import org.dspace.builder.GroupBuilder;
 import org.dspace.content.MetadataValue;
 import org.dspace.eperson.EPerson;
+import org.dspace.eperson.Group;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.junit.After;
@@ -35,6 +37,7 @@ public class SamlAuthenticationTest extends AbstractUnitTest {
     private HttpServletRequest request;
     private SamlAuthentication samlAuth;
     private EPerson testUser;
+    private Group testGroup;
 
     @BeforeClass
     public static void beforeAll() {
@@ -51,6 +54,7 @@ public class SamlAuthenticationTest extends AbstractUnitTest {
         request = new MockHttpServletRequest();
         samlAuth = new SamlAuthentication();
         testUser = null;
+        testGroup = null;
     }
 
     @After
@@ -58,6 +62,12 @@ public class SamlAuthenticationTest extends AbstractUnitTest {
         if (testUser != null) {
             EPersonBuilder.deleteEPerson(testUser.getID());
         }
+
+        if (testGroup != null) {
+            GroupBuilder.deleteGroup(testGroup.getID());
+        }
+
+        configurationService.setProperty("authentication-saml.login.specialgroup", null);
     }
 
     @AfterClass
@@ -507,5 +517,78 @@ public class SamlAuthenticationTest extends AbstractUnitTest {
 
         assertEquals(AuthenticationMethod.BAD_ARGS, result);
         assertEquals(originalUser, context.getCurrentUser());
+    }
+
+    @Test
+    public void testGetSpecialGroupsWithoutLoggedInUser() throws Exception {
+        configurationService.setProperty("authentication-saml.login.specialgroup", "saml-users");
+
+        context.setCurrentUser(null);
+
+        List<Group> specialGroups = samlAuth.getSpecialGroups(context, request);
+
+        assertEquals(List.of(), specialGroups);
+    }
+
+    @Test
+    public void testGetSpecialGroupsWithoutConfiguredGroup() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        testUser = EPersonBuilder.createEPerson(context)
+            .withEmail("alyssa@dspace.org")
+            .withCanLogin(true)
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.setCurrentUser(testUser);
+
+        List<Group> specialGroups = samlAuth.getSpecialGroups(context, request);
+
+        assertEquals(List.of(), specialGroups);
+    }
+
+    @Test
+    public void testGetSpecialGroupsWithConfiguredGroupThatDoesNotExist() throws Exception {
+        configurationService.setProperty("authentication-saml.login.specialgroup", "saml-users-that-do-not-exist");
+
+        context.turnOffAuthorisationSystem();
+
+        testUser = EPersonBuilder.createEPerson(context)
+            .withEmail("alyssa@dspace.org")
+            .withCanLogin(true)
+            .build();
+
+        context.restoreAuthSystemState();
+
+        context.setCurrentUser(testUser);
+
+        List<Group> specialGroups = samlAuth.getSpecialGroups(context, request);
+
+        assertEquals(List.of(), specialGroups);
+    }
+
+    @Test
+    public void testGetSpecialGroupsWithConfiguredGroup() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        testGroup = GroupBuilder.createGroup(context)
+            .withName("saml-users")
+            .build();
+
+        testUser = EPersonBuilder.createEPerson(context)
+            .withEmail("alyssa@dspace.org")
+            .withCanLogin(true)
+            .build();
+
+        context.restoreAuthSystemState();
+
+        configurationService.setProperty("authentication-saml.login.specialgroup", "saml-users");
+
+        context.setCurrentUser(testUser);
+
+        List<Group> specialGroups = samlAuth.getSpecialGroups(context, request);
+
+        assertEquals(List.of(testGroup), specialGroups);
     }
 }

--- a/dspace/config/modules/authentication-saml.cfg
+++ b/dspace/config/modules/authentication-saml.cfg
@@ -39,3 +39,7 @@ authentication-saml.authenticate-endpoint = ${authentication-saml.relying-party-
 
 # If the ePerson metadata field is not found, should it be created automatically?
 # authentication-saml.eperson.metadata.autocreate = false
+
+# If required, a group name can be given here, and all users who log in
+# using SAML will automatically become members of this group.
+#authentication-saml.login.specialgroup = group-name


### PR DESCRIPTION
## References
* Fixes #12793

## Description
Implements a new configuration option `authentication-saml.login.specialgroup`, identical to the existing options provided by OIDC, LDAP, and Password authentication plugins. Authenticated SAML users can be automatically mapped into a configured DSpace group.

## Instructions for Reviewers
List of changes in this PR:
* Implements `SamlAuthentication.getSpecialGroups()` (previously returned an empty list) to resolve the group named by `authentication-saml.login.specialgroup`.
* Adds the documented config key to `dspace/config/modules/authentication-saml.cfg`.
* Adds unit tests covering: no logged-in user, no config, missing group, and successful group resolution.

This follows the same pattern as the merged OIDC special group support in #11040.

**How to test:**
1. Enable and configure SAML Authentication.
2. Create an EPerson Group (or choose an existing one) and define a policy related to it (e.g. READ on a collection).
3. Set `authentication-saml.login.specialgroup = <group-name>` in `local.cfg` (or equivalent).
4. Log in with SAML and verify the policy applies (e.g. access the restricted collection).

**Automated tests run:**
```
mvn -pl dspace-api test -Dtest=SamlAuthenticationTest -DskipUnitTests=false
# Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).