### PR TITLE
Excluded dot directories from xml validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,6 +551,7 @@
                             </includes>
                             <excludes>
                                 <exclude>**/target/**</exclude>
+                                <exclude>**/.*/**</exclude>
                             </excludes>
                         </validationSet>
                     </validationSets>

--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,7 @@
                 </executions>
                 <configuration>
                     <validationSets>
-                        <!-- validate ALL XML and XSL files throughout the project (excluding target dirs) -->
+                        <!-- validate ALL XML and XSL files throughout the project (excluding target and dot dirs) -->
                         <validationSet>
                             <dir>${root.basedir}</dir>
                             <includes>


### PR DESCRIPTION
## References
* Fixes #12859 


## Description
This PR adds a line supposed to exclude every directory whose name starts with a dot anywhere in the directory tree from inspection by the xml-maven-plugin.

## Instructions for Reviewers
See above.

To reproduce, follow the steps in the linked issue. Then apply this patch. XML validation should now complete succesfully.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
