### PR TITLE
Speed up large bitstream uploads

### DIFF
--- a/dspace-api/src/main/java/org/dspace/core/Utils.java
+++ b/dspace-api/src/main/java/org/dspace/core/Utils.java
@@ -229,7 +229,7 @@ public final class Utils {
      */
     public static void copy(final InputStream input, final OutputStream output)
         throws IOException {
-        final int BUFFER_SIZE = 1024 * 4;
+        final int BUFFER_SIZE = 1024 * 256;
         final byte[] buffer = new byte[BUFFER_SIZE];
 
         while (true) {

--- a/dspace-api/src/main/java/org/dspace/importer/external/service/ImportService.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/ImportService.java
@@ -296,6 +296,25 @@ public class ImportService implements Destroyable {
         return importSources.keySet();
     }
 
+    /**
+     * Check whether any registered {@link FileSource} can handle a file with the given name, based on
+     * its supported extensions.
+     *
+     * @param originalName the file name (or full path) of the file to check
+     * @return true if at least one registered FileSource declares the file as a valid source
+     */
+    public boolean isValidSourceForFile(String originalName) {
+        for (MetadataSource metadataSource : importSources.values()) {
+            if (metadataSource instanceof FileSource) {
+                FileSource fileSource = (FileSource) metadataSource;
+                if (fileSource.isValidSourceForFile(originalName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /*
      * Get a collection of record from File,
      * The first match will be return.

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -84,23 +84,6 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WorkspaceItemRestRepository.class);
 
-    /**
-     * Configuration key for the maximum size (in bytes) of an uploaded file that is still copied into
-     * a second temp file to probe it for bibliographic metadata. Import formats (BibTeX, RIS, PDF,
-     * XML, ...) are always small text/document files, so larger binaries (video, datasets, disk
-     * images, ...) can skip the probe and be stored directly as a plain bitstream, avoiding an extra
-     * full-file copy. Configurable via local.cfg; defaults to
-     * {@link #IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_DEFAULT}.
-     */
-    private static final String IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_PROPERTY =
-        "submission.import.metadata-lookup.max-file-size";
-
-    /**
-     * Default value (100 MB, in bytes) for {@link #IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_PROPERTY}
-     * when the property is not configured.
-     */
-    private static final long IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_DEFAULT = 100L * 1024 * 1024;
-
     @Autowired
     WorkspaceItemService wis;
 
@@ -281,11 +264,12 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
             submissionConfigService.getSubmissionConfigByCollection(collection);
         List<WorkspaceItem> result = null;
         List<ImportRecord> records = new ArrayList<>();
-        long importMetadataLookupMaxFileSize = configurationService.getLongProperty(
-            IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_PROPERTY, IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_DEFAULT);
         try {
             for (MultipartFile mpFile : uploadfiles) {
-                if (mpFile.getSize() > importMetadataLookupMaxFileSize) {
+                // Only files whose name matches a supported import format (BibTeX, RIS, CSV, ...) can
+                // yield metadata. Check that before writing a temp copy, so unsupported uploads (large
+                // binaries especially) are not copied to disk just to be probed and immediately deleted.
+                if (!importService.isValidSourceForFile(mpFile.getOriginalFilename())) {
                     continue;
                 }
                 File file = Utils.getFile(mpFile, "upload-loader", "filedataloader");

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -84,6 +84,14 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
 
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WorkspaceItemRestRepository.class);
 
+    /**
+     * Files larger than this are not copied into a second temp file to probe them for bibliographic
+     * metadata. Import formats (BibTeX, RIS, PDF, XML, ...) are always small text/document files, so
+     * large binaries (video, datasets, disk images, ...) can skip straight to being stored as a plain
+     * bitstream instead of paying for an extra full-file copy first.
+     */
+    private static final long IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE = 100L * 1024 * 1024;
+
     @Autowired
     WorkspaceItemService wis;
 
@@ -266,6 +274,9 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
         List<ImportRecord> records = new ArrayList<>();
         try {
             for (MultipartFile mpFile : uploadfiles) {
+                if (mpFile.getSize() > IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE) {
+                    continue;
+                }
                 File file = Utils.getFile(mpFile, "upload-loader", "filedataloader");
                 try {
                     ImportRecord record = importService.getRecord(file, mpFile.getOriginalFilename());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/WorkspaceItemRestRepository.java
@@ -85,12 +85,21 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
     private static final Logger log = org.apache.logging.log4j.LogManager.getLogger(WorkspaceItemRestRepository.class);
 
     /**
-     * Files larger than this are not copied into a second temp file to probe them for bibliographic
-     * metadata. Import formats (BibTeX, RIS, PDF, XML, ...) are always small text/document files, so
-     * large binaries (video, datasets, disk images, ...) can skip straight to being stored as a plain
-     * bitstream instead of paying for an extra full-file copy first.
+     * Configuration key for the maximum size (in bytes) of an uploaded file that is still copied into
+     * a second temp file to probe it for bibliographic metadata. Import formats (BibTeX, RIS, PDF,
+     * XML, ...) are always small text/document files, so larger binaries (video, datasets, disk
+     * images, ...) can skip the probe and be stored directly as a plain bitstream, avoiding an extra
+     * full-file copy. Configurable via local.cfg; defaults to
+     * {@link #IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_DEFAULT}.
      */
-    private static final long IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE = 100L * 1024 * 1024;
+    private static final String IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_PROPERTY =
+        "submission.import.metadata-lookup.max-file-size";
+
+    /**
+     * Default value (100 MB, in bytes) for {@link #IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_PROPERTY}
+     * when the property is not configured.
+     */
+    private static final long IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_DEFAULT = 100L * 1024 * 1024;
 
     @Autowired
     WorkspaceItemService wis;
@@ -272,9 +281,11 @@ public class WorkspaceItemRestRepository extends DSpaceRestRepository<WorkspaceI
             submissionConfigService.getSubmissionConfigByCollection(collection);
         List<WorkspaceItem> result = null;
         List<ImportRecord> records = new ArrayList<>();
+        long importMetadataLookupMaxFileSize = configurationService.getLongProperty(
+            IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_PROPERTY, IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE_DEFAULT);
         try {
             for (MultipartFile mpFile : uploadfiles) {
-                if (mpFile.getSize() > IMPORT_METADATA_LOOKUP_MAX_FILE_SIZE) {
+                if (mpFile.getSize() > importMetadataLookupMaxFileSize) {
                     continue;
                 }
                 File file = Utils.getFile(mpFile, "upload-loader", "filedataloader");


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs. These may include:_
* No related issue ticket.
* This PR does **not** modify any REST API endpoint contract (request/response shape is unchanged), so no `DSpace/RestContract` PR is required.

## Description
Speeds up multi-GB bitstream uploads by enlarging the assetstore copy buffer and by skipping an unnecessary full-file temp copy that is only used to probe large uploads for bibliographic import metadata.

## Instructions for Reviewers

List of changes in this PR:
* Increase the `org.dspace.core.Utils#copy` buffer from 4KB to 256KB. This reduces read/write syscall overhead for every internal stream copy (most notably the temp → assetstore copy performed when storing a bitstream). It is a drop-in change with no behavioral difference; the gain is largest on higher-latency storage (e.g. NFS) and modest on local disks.
* During submission (`WorkspaceItemRestRepository#upload`), each uploaded file was first copied into a temporary file and then probed for bibliographic import metadata (BibTeX, RIS, CSV, XML, ...). The probe (`FileSource#isValidSourceForFile`) only matches by **file extension**, yet the temporary copy was created for **every** upload regardless of type — so unsupported files (large binaries especially) were written to disk in full only to be immediately discarded. This PR checks `ImportService#isValidSourceForFile(originalName)` **before** the temporary copy is created, so only files that a `FileSource` can actually parse are copied. The **actual bitstream storage path is unchanged**.
* Add `ImportService#isValidSourceForFile(String originalName)`, which returns `true` if any registered `FileSource` accepts the file name (delegating to the existing `FileSource#isValidSourceForFile`).

> Note: an earlier revision of this PR used a configurable file-size threshold to skip the probe. Following review feedback that has been replaced by the format check above, which is more robust and introduces **no new configuration property**.

**How to test:**
* Normal behavior unchanged: via the submission "upload" step, upload a small file whose extension is a supported import format (e.g. a `.bib` / `.ris` file) and confirm metadata is still extracted / pre-filled as before.
* Unsupported upload: upload a file whose extension is **not** a supported import format (e.g. a large video, disk image, or a `.pdf`) and confirm it is stored as a bitstream successfully, and that no temporary copy is created for the metadata probe (previously such files were copied in full and then deleted).
* Buffer change needs no special testing (it is a drop-in change to the copy loop); it can be observed as reduced syscall overhead when copying large bitstreams.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
