### PR TITLE
DSpaceServiceManager: improve error handling in bean lookup

### DIFF
--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -452,7 +452,12 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
                         // only return the bean if there is exactly one
                         service = (T) map.values().iterator().next();
                     } else {
-                        log.error("Multiple beans of type {} found. Only one was expected!", type.getName());
+                        if (map.isEmpty()) {
+                            log.error("No bean of type {} found. One bean was expected!", type.getName());
+                        } else {
+                            log.error("Multiple beans of type {} found. Only one bean was expected!", type.getName());
+                        }
+                    }
                     }
                 } catch (BeansException e) {
                     // I guess there are no beans of this type

--- a/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
+++ b/dspace-services/src/main/java/org/dspace/servicemanager/DSpaceServiceManager.java
@@ -458,7 +458,6 @@ public final class DSpaceServiceManager implements ServiceManagerSystem {
                             log.error("Multiple beans of type {} found. Only one bean was expected!", type.getName());
                         }
                     }
-                    }
                 } catch (BeansException e) {
                     // I guess there are no beans of this type
                     log.error(e.getMessage(), e);


### PR DESCRIPTION
## Description

This minor PR improves error handling in the `getServiceByName` method of `DSpaceServiceManager` by distinguishing between cases where **no bean or multiple beans of a given type are found**. This makes debugging easier by providing more specific log messages.

Currently, the error message `Multiple beans of type {type} found. Only one was expected!` can be misleading when no bean of the requested type is found.

## Instructions for Reviewers

Not available

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
