### PR TITLE
Fix bug where workflow item would trigger a nullpointer when checked for versionhistory

### DIFF
--- a/dspace-api/src/main/java/org/dspace/versioning/VersionHistory.java
+++ b/dspace-api/src/main/java/org/dspace/versioning/VersionHistory.java
@@ -106,6 +106,9 @@ public class VersionHistory implements ReloadableEntity<Integer> {
         if (this == o) {
             return true;
         }
+        if (o == null) {
+            return false;
+        }
         Class<?> objClass = HibernateProxyHelper.getClassWithoutInitializingProxy(o);
         if (!getClass().equals(objClass)) {
             return false;


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/12865
* Related to https://github.com/DSpace/dspace-angular/pull/6007

## Description
This fixes a bug where an item could be checked against a workflow item regarding their version history, which would then result in a NullPointerException. The null pointer stemmed from an incomplete `equals()` implementation for `VersionHistory`. This PR adds the necessary null check for the `Object` passed into equals. The `equals()` contract for Object states "For any non-null reference value x, x.equals(null) should return false". 

## Instructions for Reviewers
1. Have the duplicates section enabled in the submission form
2. Have a duplicate of the item you'd like to create a new version of in a workflow state
3. Try to create a new version of the item as an admin. Observe that you are able to create and edit the new version.
4. Observe that the response of `/server/api/submission/workspaceitems/<workspace-id>` includes a duplicates section.

### Additional tests
Check that the duplicates section is still populated for items that have duplicates.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

## LLM Disclosure

I used ChatGPT (Model GPT-5.5 Instant) to help me with the investigation of the bug. I wrote the code myself. Additionally no LLM was used in writing the bug report and the PR text.