### PR TITLE
fix(#10107): Replace hard-coded metadata prefix oai_dc with dynamic dropdowns

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +31,9 @@ import javax.xml.transform.stream.StreamSource;
 
 import com.lyncode.xoai.dataprovider.OAIDataProvider;
 import com.lyncode.xoai.dataprovider.OAIRequestParameters;
+import com.lyncode.xoai.dataprovider.core.XOAIContext;
 import com.lyncode.xoai.dataprovider.core.XOAIManager;
+import com.lyncode.xoai.dataprovider.data.internal.MetadataFormat;
 import com.lyncode.xoai.dataprovider.exceptions.InvalidContextException;
 import com.lyncode.xoai.dataprovider.exceptions.OAIException;
 import com.lyncode.xoai.dataprovider.exceptions.WritingXmlException;
@@ -51,6 +54,13 @@ import org.dspace.xoai.services.api.xoai.IdentifyResolver;
 import org.dspace.xoai.services.api.xoai.ItemRepositoryResolver;
 import org.dspace.xoai.services.api.xoai.SetRepositoryResolver;
 import org.dspace.xoai.services.impl.xoai.DSpaceResumptionTokenFormatter;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -142,6 +152,16 @@ public class DSpaceOAIDataProvider {
             context = contextService.getContext();
 
             XOAIManager manager = xoaiManagerResolver.getManager();
+            XOAIContext xoaiContextObj = manager.getContextManager().getOAIContext(xoaiContext);
+            List<String> metadataPrefixes = new ArrayList<>();
+            if (xoaiContextObj != null) {
+                for (MetadataFormat format : xoaiContextObj.getFormats()) {
+                    metadataPrefixes.add(format.getPrefix());
+                }
+            }
+            if (metadataPrefixes.isEmpty()) {
+                metadataPrefixes.add("oai_dc");
+            }
 
             OAIDataProvider dataProvider = new OAIDataProvider(manager, xoaiContext,
                                                                identifyResolver.getIdentify(),
@@ -166,39 +186,46 @@ public class DSpaceOAIDataProvider {
                 }
             }
 
-            if (shouldServeAsHTML) {
-                response.setContentType("text/html");
-                out = new ByteArrayOutputStream();
-            } else {
-                response.setContentType("text/xml");
-            }
-            response.setCharacterEncoding("UTF-8");
-
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
             String identification = xoaiContext + parameters.requestID();
 
             if (cacheService.isActive()) {
                 if (!cacheService.hasCache(identification)) {
                     cacheService.store(identification, dataProvider.handle(parameters));
                 }
-
-                cacheService.handle(identification, out);
+                cacheService.handle(identification, baos);
             } else {
-                dataProvider.handle(parameters, out);
+                dataProvider.handle(parameters, baos);
+            }
+
+            byte[] xmlBytes = baos.toByteArray();
+            byte[] modifiedBytes = xmlBytes;
+            if (shouldServeAsHTML) {
+                try {
+                    modifiedBytes = addMetadataPrefixes(xmlBytes, metadataPrefixes);
+                } catch (JDOMException | IOException e) {
+                    log.warn("Could not add metadata prefixes to XML; using original response.", e);
+                    modifiedBytes = xmlBytes;
+                }
             }
 
             if (shouldServeAsHTML) {
+                response.setContentType("text/html");
                 OutputStream responseOut = response.getOutputStream();
-                Source source = new StreamSource(new ByteArrayInputStream(((ByteArrayOutputStream) out).toByteArray()));
+                Source source = new StreamSource(new ByteArrayInputStream(modifiedBytes));
                 Result result = new StreamResult(responseOut);
                 Transformer htmlTransformer = htmlTransformerFactory.newTransformer(
                         new StreamSource(new ByteArrayInputStream(htmlTransformerSource)));
                 htmlTransformer.transform(source, result);
-                out = responseOut;
+                responseOut.flush();
+                responseOut.close();
+            } else {
+                response.setContentType("text/xml");
+                response.setCharacterEncoding("UTF-8");
+                response.getOutputStream().write(modifiedBytes);
+                response.getOutputStream().flush();
+                response.getOutputStream().close();
             }
-
-            out.flush();
-            out.close();
-
             closeContext(context);
 
         } catch (InvalidContextException e) {
@@ -252,4 +279,29 @@ public class DSpaceOAIDataProvider {
         return map;
     }
 
+    /**
+     * Adds an extension element to the XML response containing the list of supported metadataPrefixes.
+     * This allows style.xsl to create dynamic dropdowns.
+     */
+    private byte[] addMetadataPrefixes(byte[] xmlBytes, List<String> prefixes)
+            throws JDOMException, IOException {
+        if (prefixes == null || prefixes.isEmpty()) {
+            return xmlBytes;
+        }
+        SAXBuilder builder = XMLUtils.getSAXBuilder();
+        Document doc = builder.build(new ByteArrayInputStream(xmlBytes));
+        Element root = doc.getRootElement();
+        Namespace dsNs = Namespace.getNamespace("ds", "http://www.dspace.org/xmlns/oai-extension");
+        Element prefixesElem = new Element("metadataPrefixes", dsNs);
+        for (String prefix : prefixes) {
+            Element p = new Element("metadataPrefix", dsNs);
+            p.setText(prefix);
+            prefixesElem.addContent(p);
+        }
+        root.addContent(prefixesElem);
+        XMLOutputter outputter = new XMLOutputter(Format.getPrettyFormat());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        outputter.output(doc, out);
+        return out.toByteArray();
+    }
 }

--- a/dspace-oai/src/main/resources/static/style.xsl
+++ b/dspace-oai/src/main/resources/static/style.xsl
@@ -12,6 +12,7 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:oai="http://www.openarchives.org/OAI/2.0/"
 	xmlns:lyn="http://www.lyncode.com/fakeNamespace" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
 	xmlns:dc="http://purl.org/dc/doc:elements/1.1/"
+    xmlns:ds="http://www.dspace.org/xmlns/oai-extension"
     xmlns:verb="http://informatik.hu-berlin.de/xmlverbatim"
     xmlns:oai_id="http://www.openarchives.org/OAI/2.0/oai-identifier"
     exclude-result-prefixes="oai lyn oai_dc dc verb oai_id">
@@ -65,28 +66,32 @@
                                     </a>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" title="Listing records (with metadata)">
-                                        <xsl:if test="/oai:OAI-PMH/oai:request/@verb = 'ListRecords'">
-                                            <xsl:attribute name="class">active nav-link</xsl:attribute>
-                                        </xsl:if>
-                                        <xsl:attribute name="href">
-                                            <xsl:value-of
-                                                    select="concat(/oai:OAI-PMH/oai:request/text(), '?verb=ListRecords&amp;metadataPrefix=oai_dc')"></xsl:value-of>
-                                        </xsl:attribute>
-                                        Records
-                                    </a>
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-link nav-link dropdown-toggle" data-toggle="dropdown">
+                                            Records
+                                        </button>
+                                        <div class="dropdown-menu">
+                                            <xsl:for-each select="/oai:OAI-PMH/ds:metadataPrefixes/ds:metadataPrefix">
+                                                <a class="dropdown-item" href="{concat(/oai:OAI-PMH/oai:request/text(), '?verb=ListRecords&amp;metadataPrefix=', .)}">
+                                                    <xsl:value-of select="."/>
+                                                </a>
+                                            </xsl:for-each>
+                                        </div>
+                                    </div>
                                 </li>
                                 <li class="nav-item">
-                                    <a class="nav-link" title="Listing identifiers only">
-                                        <xsl:if test="/oai:OAI-PMH/oai:request/@verb = 'ListIdentifiers'">
-                                            <xsl:attribute name="class">active nav-link</xsl:attribute>
-                                        </xsl:if>
-                                        <xsl:attribute name="href">
-                                            <xsl:value-of
-                                                    select="concat(/oai:OAI-PMH/oai:request/text(), '?verb=ListIdentifiers&amp;metadataPrefix=oai_dc')"></xsl:value-of>
-                                        </xsl:attribute>
-                                        Identifiers
-                                    </a>
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-link nav-link dropdown-toggle" data-toggle="dropdown">
+                                            Identifiers
+                                        </button>
+                                        <div class="dropdown-menu">
+                                            <xsl:for-each select="/oai:OAI-PMH/ds:metadataPrefixes/ds:metadataPrefix">
+                                                <a class="dropdown-item" href="{concat(/oai:OAI-PMH/oai:request/text(), '?verb=ListIdentifiers&amp;metadataPrefix=', .)}">
+                                                    <xsl:value-of select="."/>
+                                                </a>
+                                            </xsl:for-each>
+                                        </div>
+                                    </div>
                                 </li>
                                 <li class="nav-item">
                                     <a class="nav-link" title="Metadata Formats available">


### PR DESCRIPTION
## References
* Fixes #10107
* Fixes #9770

## Description
This PR replaces the hard-coded `oai_dc` metadata prefix in the OAI-PMH HTML interface (style.xsl) with dynamic dropdown menus. The dropdowns are populated with the actual metadata prefixes supported by the current OAI context, eliminating "Unknown metadata format" errors when a context does not support `oai_dc` (e.g., the `openaire4` context which only supports `oai_openaire`).

## Instructions for Reviewers

1. Build the module: `mvn clean package`
2. Deploy the updated dspace-oai module.
3. Access the OAI-PMH HTML interface:
- For the default context: http://localhost:8080/server/oai/request?verb=Identify
- For the OpenAIRE 4 context: http://localhost:8080/server/oai/openaire4?verb=Identify

4. Verify that the "Records" and "Identifiers" buttons are now dropdowns listing the correct prefixes for each context:
<img width="481" height="58" alt="image" src="https://github.com/user-attachments/assets/4d9912cb-e511-48f2-b6e2-e1d9567aab68" />

- Default context: shows all formats (didl, mods, oai_dc, etc.) 
- OpenAIRE 4: shows only oai_openaire
- RI OXX: shows qdc, oai_dc, rioxx


5. Click each dropdown option and confirm that the resulting URL works without `Unknown metadata format` errors.
6. Verify the dropdowns are styled consistently with the rest of the navbar.

## List of changes in this PR:
In `DSpaceOAIDataProvider`, the XML response is now augmented with an extension element `<ds:metadataPrefixes>` that lists all metadata formats supported by the context.

In `style.xsl` now consumes the new element and generates dropdown menus for the "Records" and "Identifiers" navbar links. This replaces the hard-coded oai_dc links and makes the interface fully dynamic.
<img width="1266" height="794" alt="20260731-2205-34 3828637" src="https://github.com/user-attachments/assets/0c235a7a-bcce-40be-8c2a-1d0036595972" />

The solution works for any context (default, openaire4, rioxx, etc.) and automatically adapts to custom metadata prefixes (e.g., `oai_capes`) without additional configuration.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
