### PR TITLE
Creative Commons Licenses

### DIFF
--- a/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorService.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorService.java
@@ -28,19 +28,6 @@ public interface CCLicenseConnectorService {
     public Map<String, CCLicense> retrieveLicenses(String language);
 
     /**
-     * Retrieve the CC License URI based on the provided license id, language and answers to the field questions from
-     * the CC License API
-     *
-     * @param licenseId - the ID of the license
-     * @param language  - the language for which to retrieve the full answerMap
-     * @param answerMap - the answers to the different field questions
-     * @return the CC License URI
-     */
-    public String retrieveRightsByQuestion(String licenseId,
-                                           String language,
-                                           Map<String, String> answerMap);
-
-    /**
      * Retrieve the license RDF document based on the license URI
      *
      * @param licenseURI    - The license URI for which to retrieve the license RDF document
@@ -56,5 +43,13 @@ public interface CCLicenseConnectorService {
      * @return the license name
      */
     public String retrieveLicenseName(final Document doc);
+
+    /**
+     * Retrieve the license rights from the license document
+     *
+     * @param doc   - The license document from which to retrieve the license name
+     * @return the license rights
+     */
+    public String retrieveLicenseRights(final Document doc);
 
 }

--- a/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLicenseConnectorServiceImpl.java
@@ -10,20 +10,19 @@ package org.dspace.license;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
-import java.text.MessageFormat;
-import java.util.Collections;
-import java.util.HashMap;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.Logger;
@@ -87,19 +86,13 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
         String uri = ccLicenseUrl + "/?locale=" + language;
         HttpGet httpGet = new HttpGet(uri);
 
-        List<String> licenses;
-        try (CloseableHttpResponse response = client.execute(httpGet)) {
-            licenses = retrieveLicenses(response);
-        } catch (JDOMException | IOException e) {
-            log.error("Error while retrieving the license details using url: " + uri, e);
-            licenses = Collections.emptyList();
-        }
-
-        Map<String, CCLicense> ccLicenses = new HashMap<>();
+        String[] licenseclasses = configurationService.getArrayProperty("cc.license.classes");
+        List<String> licenses = Arrays.asList(licenseclasses);
+        Map<String, CCLicense> ccLicenses = new LinkedHashMap<>();
 
         for (String license : licenses) {
 
-            String licenseUri = ccLicenseUrl + "/license/" + license + "?locale=" + language;
+            String licenseUri = ccLicenseUrl + "/license/" + license +".xml";
             HttpGet licenseHttpGet = new HttpGet(licenseUri);
             try (CloseableHttpResponse response = client.execute(licenseHttpGet)) {
                 CCLicense ccLicense = retrieveLicenseObject(license, response);
@@ -108,7 +101,6 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
                 log.error("Error while retrieving the license details using url: " + licenseUri, e);
             }
         }
-
         return ccLicenses;
     }
 
@@ -161,7 +153,6 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
             throws IOException, JDOMException {
 
         String responseString = EntityUtils.toString(response.getEntity());
-
         XPathExpression<Object> licenseClassXpath =
             XPathFactory.instance().compile("//licenseclass", Filters.fpassthrough());
         XPathExpression<Element> licenseFieldXpath =
@@ -202,8 +193,9 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
             CCLicenseFieldEnum ccLicenseFieldEnum = parseEnum(enumElement);
             ccLicenseFieldEnumList.add(ccLicenseFieldEnum);
         }
+        String type = getSingleNodeValue(licenseField, "type");
 
-        return new CCLicenseField(id, label, description, ccLicenseFieldEnumList);
+        return new CCLicenseField(id, label, description, ccLicenseFieldEnumList, type);
 
     }
 
@@ -211,8 +203,9 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
         String id = getSingleNodeValue(enumElement, "@id");
         String label = getSingleNodeValue(enumElement, "label");
         String description = getSingleNodeValue(enumElement, "description");
+        Boolean isdefault = Boolean.valueOf(getSingleNodeValue(enumElement, "@default"));
 
-        return new CCLicenseFieldEnum(id, label, description);
+        return new CCLicenseFieldEnum(id, label, description, isdefault);
     }
 
 
@@ -237,86 +230,6 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
     }
 
     /**
-     * Retrieve the CC License URI based on the provided license id, language and answers to the field questions from
-     * the CC License API
-     *
-     * @param licenseId - the ID of the license
-     * @param language  - the language for which to retrieve the full answerMap
-     * @param answerMap - the answers to the different field questions
-     * @return the CC License URI
-     */
-    public String retrieveRightsByQuestion(String licenseId,
-                                           String language,
-                                           Map<String, String> answerMap) {
-
-        String ccLicenseUrl = configurationService.getProperty("cc.api.rooturl");
-
-
-        HttpPost httpPost = new HttpPost(ccLicenseUrl + "/license/" + licenseId + "/issue");
-
-
-        String answers = createAnswerString(answerMap);
-        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-        String text = MessageFormat.format(postAnswerFormat, licenseId, language, answers);
-        builder.addTextBody(postArgument, text);
-
-        HttpEntity multipart = builder.build();
-
-        httpPost.setEntity(multipart);
-
-        try (CloseableHttpResponse response = client.execute(httpPost)) {
-            return retrieveLicenseUri(response);
-        } catch (JDOMException | IOException e) {
-            log.error("Error while retrieving the license uri for license : " + licenseId + " with answers "
-                              + answerMap.toString(), e);
-        }
-        return null;
-    }
-
-    /**
-     * Parse the response for the CC License URI request and return the corresponding CC License URI
-     *
-     * @param response for a specific CC License URI response
-     * @return the corresponding CC License URI as a string
-     * @throws IOException
-     * @throws JDOMException
-     */
-    private String retrieveLicenseUri(final CloseableHttpResponse response)
-            throws IOException, JDOMException {
-
-        String responseString = EntityUtils.toString(response.getEntity());
-        XPathExpression<Object> licenseClassXpath =
-            XPathFactory.instance().compile("//result/license-uri", Filters.fpassthrough());
-
-        try (StringReader stringReader = new StringReader(responseString)) {
-            InputSource is = new InputSource(stringReader);
-            org.jdom2.Document classDoc = this.parser.build(is);
-
-            Object node = licenseClassXpath.evaluateFirst(classDoc);
-            String nodeValue = getNodeValue(node);
-
-            if (StringUtils.isNotBlank(nodeValue)) {
-                return nodeValue;
-            }
-        }
-        return null;
-    }
-
-    private String createAnswerString(final Map<String, String> parameterMap) {
-        StringBuilder sb = new StringBuilder();
-        for (String key : parameterMap.keySet()) {
-            sb.append("<");
-            sb.append(key);
-            sb.append(">");
-            sb.append(parameterMap.get(key));
-            sb.append("</");
-            sb.append(key);
-            sb.append(">");
-        }
-        return sb.toString();
-    }
-
-    /**
      * Retrieve the license RDF document based on the license URI
      *
      * @param licenseURI - The license URI for which to retrieve the license RDF document
@@ -326,15 +239,25 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
     @Override
     public Document retrieveLicenseRDFDoc(String licenseURI) throws IOException {
         String ccLicenseUrl = configurationService.getProperty("cc.api.rooturl");
-        String issueUrl = ccLicenseUrl + "/details?license-uri=" + licenseURI;
-        try (CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build()) {
-            CloseableHttpResponse httpResponse = httpClient.execute(new HttpPost(issueUrl));
+
+        String issueUrl = ccLicenseUrl +  licenseURI.replace("http://creativecommons.org","") + "rdf";
+
+        URL request_url;
+        try {
+            request_url = new URL(issueUrl);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+        URLConnection connection = request_url.openConnection();
+        connection.setDoOutput(true);
+        try {
             // parsing document from input stream
-            InputStream stream = httpResponse.getEntity().getContent();
+            InputStream stream = connection.getInputStream();
             Document doc = parser.build(stream);
             return doc;
+
         } catch (Exception e) {
-            log.error("Error while retrieving the license document for URI: " + licenseURI, e);
+            log.error("Error while retrieving the license document for URI: " + issueUrl, e);
         }
         return null;
     }
@@ -347,6 +270,16 @@ public class CCLicenseConnectorServiceImpl implements CCLicenseConnectorService,
      */
     public String retrieveLicenseName(final Document doc) {
         return getSingleNodeValue(doc, "//result/license-name");
+    }
+
+    /**
+     * Retrieve the license Rights from the license document
+     *
+     * @param doc - The license document from which to retrieve the license rights
+     * @return the license rights
+     */
+    public String retrieveLicenseRights(final Document doc) {
+        return getSingleNodeValue(doc, "//result/license-rights");
     }
 
 }

--- a/dspace-api/src/main/java/org/dspace/license/CCLicenseField.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLicenseField.java
@@ -29,12 +29,15 @@ public class CCLicenseField {
      *
      * @param id    The unique identifier for this field; this value will be used in constructing the answers XML.
      * @param label The label to use when generating the user interface.
+     * @param fieldEnum A list of yes/no answers to questions with labels
+     * @param type  The type of input if not a yes/no question
      */
-    public CCLicenseField(String id, String label, String description, List<CCLicenseFieldEnum> fieldEnum) {
+    public CCLicenseField(String id, String label, String description, List<CCLicenseFieldEnum> fieldEnum, String type) {
         this.id = id;
         this.label = label;
         this.description = description;
         this.fieldEnum = fieldEnum;
+        this.type = type;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/license/CCLicenseFieldEnum.java
+++ b/dspace-api/src/main/java/org/dspace/license/CCLicenseFieldEnum.java
@@ -18,8 +18,9 @@ public class CCLicenseFieldEnum {
     private String id = "";
     private String label = "";
     private String description = "";
+    private Boolean isdefault = false;
 
-    public CCLicenseFieldEnum(String id, String label, String description) {
+    public CCLicenseFieldEnum(String id, String label, String description, Boolean isdefault) {
         if (StringUtils.isNotBlank(id)) {
             this.id = id;
         }
@@ -29,6 +30,7 @@ public class CCLicenseFieldEnum {
         if (StringUtils.isNotBlank(description)) {
             this.description = description;
         }
+        this.isdefault = isdefault;
 
     }
 
@@ -78,5 +80,22 @@ public class CCLicenseFieldEnum {
      */
     public void setDescription(final String description) {
         this.description = description;
+    }
+
+    /**
+     * Get the default answer of this enum
+     *
+     * @return the default answer of this enum
+     */
+    public Boolean getDefault() {
+        return isdefault;
+    }
+
+    /**
+     * Set the default answer of this enum
+     * @param isdefault
+     */
+    public void setDefault(final Boolean isdefault) {
+        this.isdefault = isdefault;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/license/CreativeCommonsServiceImpl.java
@@ -121,7 +121,7 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
         try {
             templates = XMLUtils.getTransformerFactory().newTemplates(
                     new StreamSource(CreativeCommonsServiceImpl.class
-                                             .getResourceAsStream("CreativeCommons.xsl")));
+                            .getResourceAsStream("CreativeCommons.xsl")));
         } catch (TransformerConfigurationException e) {
             throw new RuntimeException(e.getMessage(), e);
         }
@@ -183,8 +183,8 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * Removes the license file from the item
      *
-     * @param context   - The relevant DSpace Context
-     * @param item      - The item from which the license file needs to be removed
+     * @param context - The relevant DSpace Context
+     * @param item    - The item from which the license file needs to be removed
      * @throws SQLException
      * @throws IOException
      * @throws AuthorizeException
@@ -227,7 +227,7 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * Returns the stored license uri of the item
      *
-     * @param item  - The item for which to retrieve the stored license uri
+     * @param item - The item for which to retrieve the stored license uri
      * @return the stored license uri of the item
      */
     @Override
@@ -245,14 +245,32 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * Returns the stored license name of the item
      *
-     * @param item  - The item for which to retrieve the stored license name
+     * @param item - The item for which to retrieve the stored license name
      * @return the stored license name of the item
      */
     @Override
-    public String getLicenseName( Item item) {
+    public String getLicenseName(Item item) {
         String licenseNameField = getCCField("name");
         if (StringUtils.isNotBlank(licenseNameField)) {
             String metadata = itemService.getMetadata(item, licenseNameField);
+            if (StringUtils.isNotBlank(metadata)) {
+                return metadata;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the stored license rights of the item
+     *
+     * @param item - The item for which to retrieve the stored license rights
+     * @return the stored license rights of the item
+     */
+    @Override
+    public String getLicenseRights(Item item) {
+        String licenseRightsField = getCCField("name");
+        if (StringUtils.isNotBlank(licenseRightsField)) {
+            String metadata = itemService.getMetadata(item, licenseRightsField);
             if (StringUtils.isNotBlank(metadata)) {
                 return metadata;
             }
@@ -279,7 +297,7 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * This helper method takes some bytes and stores them as a bitstream for an
      * item, under the CC bundle, with the given bitstream name
-     *
+     * <p>
      * Note: This helper method assumes that the CC
      * bitstreams are short and easily expressed as byte arrays in RAM
      *
@@ -311,7 +329,7 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * This helper method wraps a String around a byte array returned from the
      * bitstream method further down
-     *
+     * <p>
      * Note: This helper method assumes that the CC
      * bitstreams are short and easily expressed as byte arrays in RAM
      *
@@ -397,8 +415,8 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * Remove license information, delete also the bitstream
      *
-     * @param context   - DSpace Context
-     * @param item      - the item
+     * @param context - DSpace Context
+     * @param item    - the item
      * @throws AuthorizeException Exception indicating the current user of the context does not have permission
      *                            to perform a particular action.
      * @throws IOException        A general class of exceptions produced by failed or interrupted I/O operations.
@@ -410,18 +428,17 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
 
         String uriField = getCCField("uri");
         String nameField = getCCField("name");
+        String rightsField = getCCField("rights");
 
-        String licenseUri = itemService.getMetadata(item, uriField);
-
-        // only remove any previous licenses
-        if (licenseUri != null) {
-            removeLicenseField(context, item, uriField);
-            if (configurationService.getBooleanProperty("cc.submit.setname")) {
-                removeLicenseField(context, item, nameField);
-            }
-            if (configurationService.getBooleanProperty("cc.submit.addbitstream")) {
-                removeLicenseFile(context, item);
-            }
+        removeLicenseField(context, item, uriField);
+        if (configurationService.getBooleanProperty("cc.submit.setname")) {
+            removeLicenseField(context, item, nameField);
+        }
+        if (configurationService.getBooleanProperty("cc.submit.setrights")) {
+            removeLicenseField(context, item, rightsField);
+        }
+        if (configurationService.getBooleanProperty("cc.submit.addbitstream")) {
+            removeLicenseFile(context, item);
         }
     }
 
@@ -432,7 +449,7 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     }
 
     private void addLicenseField(Context context, Item item, String field, String language, String value)
-        throws SQLException {
+            throws SQLException {
         String[] params = splitField(field);
         itemService.addMetadata(context, item, params[0], params[1], params[2], language, value);
 
@@ -527,8 +544,40 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
      */
     @Override
     public String retrieveLicenseUri(String licenseId, String language, Map<String, String> answerMap) {
-        return ccLicenseConnectorService.retrieveRightsByQuestion(licenseId, language, answerMap);
-
+        if (licenseId.equals("publicdomain") || licenseId.equals("zero")) {
+            return "http://creativecommons.org/publicdomain/zero/1.0/";
+        } else if (licenseId.equals("none")) {
+            return "All Rights Reserved";
+        } else if (licenseId.equals("standard")) {
+            String sa = "", nc = "", nd = "";
+            if (answerMap.get("commercial").equals("n")) {
+                nc = "-nc";
+            }
+            if (answerMap.get("derivatives").equals("n")) {
+                nd = "-nd";
+            } else if (answerMap.get("sharealike").equals("y")) {
+                sa = "-sa";
+            }
+            return "http://creativecommons.org/licenses/by" + nc + nd + sa + "/4.0/";
+        } else if (licenseId.equals("known")) {
+            String answer = answerMap.get("knownlicense");
+            if (answer.equals("by")) {
+                return "http://creativecommons.org/licenses/by/4.0/";
+            } else if (answer.equals("by-sa")) {
+                return "http://creativecommons.org/licenses/by-sa/4.0/";
+            } else if (answer.equals("by-nd")) {
+                return "http://creativecommons.org/licenses/by-nd/4.0/";
+            } else if (answer.equals("by-nc")) {
+                return "http://creativecommons.org/licenses/by-nc/4.0/";
+            } else if (answer.equals("by-nc-sa")) {
+                return "http://creativecommons.org/licenses/by-nc-sa/4.0/";
+            } else if (answer.equals("by-nc-nd")) {
+                return "http://creativecommons.org/licenses/by-nc-nd/4.0/";
+            }
+        } else {
+            log.error("Error while retrieving the license uri for license : " + licenseId + " with answers " + answerMap.toString());
+        }
+        return null;
     }
 
     /**
@@ -644,9 +693,9 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     /**
      * Update the license of the item with a new one based on the provided license URI
      *
-     * @param context       - The relevant DSpace context
-     * @param licenseUri    - The license URI to be used in the update
-     * @param item          - The item for which to update the license
+     * @param context    - The relevant DSpace context
+     * @param licenseUri - The license URI to be used in the update
+     * @param item       - The item for which to update the license
      * @return true when the update was successful, false when not
      * @throws AuthorizeException
      * @throws SQLException
@@ -654,21 +703,29 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
     @Override
     public boolean updateLicense(final Context context, final String licenseUri, final Item item)
             throws AuthorizeException, SQLException {
+        return updateLicense(context, licenseUri, "", item);
+    }
+
+    @Override
+    public boolean updateLicense(final Context context, final String licenseUri, final String licenseRights, final Item item)
+            throws AuthorizeException, SQLException {
         try {
-            Document doc = ccLicenseConnectorService.retrieveLicenseRDFDoc(licenseUri);
-            if (doc == null) {
-                return false;
-            }
-            String licenseName = ccLicenseConnectorService.retrieveLicenseName(doc);
-            if (StringUtils.isBlank(licenseName)) {
-                return false;
-            }
-
+            //if (licenseUri.equals("All Rights Reserved")) {
+            String licenseName = "";
+            String rights = licenseRights;
             removeLicense(context, item);
-            addLicense(context, item, licenseUri, licenseName, doc);
-
+            if (StringUtils.isBlank(licenseUri) && StringUtils.isBlank(rights)) { return false; }
+            Document doc = null;
+            if (licenseUri.contains("http://creativecommons.org")) {
+                doc = ccLicenseConnectorService.retrieveLicenseRDFDoc(licenseUri);
+                if (doc != null) {
+                    licenseName = ccLicenseConnectorService.retrieveLicenseName(doc);
+                    rights = ccLicenseConnectorService.retrieveLicenseRights(doc);
+                    if (StringUtils.isBlank(licenseName)) { return false; }
+                }
+            }
+            addLicense(context, item, licenseUri, licenseName, rights, doc);
             return true;
-
         } catch (IOException e) {
             log.error("Error while updating the license of item: " + item.getID(), e);
         }
@@ -682,23 +739,28 @@ public class CreativeCommonsServiceImpl implements CreativeCommonsService, Initi
      * @param item          - The item to which the license will be added
      * @param licenseUri    - The license URI to add
      * @param licenseName   - The license name to add
+     * @param licenseRights - The license rights to add
      * @param doc           - The license to document to add
      * @throws SQLException
      * @throws IOException
      * @throws AuthorizeException
      */
     @Override
-    public void addLicense(Context context, Item item, String licenseUri, String licenseName, Document doc)
+    public void addLicense(Context context, Item item, String licenseUri, String licenseName, String licenseRights, Document doc)
             throws SQLException, IOException, AuthorizeException {
         String uriField = getCCField("uri");
         String nameField = getCCField("name");
+        String rightsField = getCCField("rights");
 
         addLicenseField(context, item, uriField, null, licenseUri);
-        if (configurationService.getBooleanProperty("cc.submit.addbitstream")) {
+        if (configurationService.getBooleanProperty("cc.submit.addbitstream") && doc != null) {
             setLicenseRDF(context, item, fetchLicenseRDF(doc));
         }
         if (configurationService.getBooleanProperty("cc.submit.setname")) {
-            addLicenseField(context, item, nameField, "en", licenseName);
+            addLicenseField(context, item, nameField, null, licenseName);
+        }
+        if (configurationService.getBooleanProperty("cc.submit.setrights")) {
+            addLicenseField(context, item, rightsField, null, licenseRights);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/license/service/CreativeCommonsService.java
+++ b/dspace-api/src/main/java/org/dspace/license/service/CreativeCommonsService.java
@@ -102,6 +102,15 @@ public interface CreativeCommonsService {
      */
     public String getLicenseName(Item item);
 
+
+    /**
+     * Returns the stored license rights of the item
+     *
+     * @param item  - The item for which to retrieve the stored license rights
+     * @return the stored license rights of the item
+     */
+    public String getLicenseRights(Item item);
+
     /**
      * Get Creative Commons license RDF, returning Bitstream object.
      *
@@ -272,17 +281,32 @@ public interface CreativeCommonsService {
             throws AuthorizeException, SQLException;
 
     /**
+     * Update the license of the item with a new one based on the provided license URI
+     *
+     * @param context       - The relevant DSpace context
+     * @param licenseUri    - The license URI to be used in the update
+     * @param licenseRights - The license rights statement to be used in the update
+     * @param item          - The item for which to update the license
+     * @return true when the update was successful, false when not
+     * @throws AuthorizeException
+     * @throws SQLException
+     */
+    public boolean updateLicense(final Context context, String licenseUri, String licenseRights, final Item item)
+            throws AuthorizeException, SQLException;
+
+    /**
      * Add a new license to the item
      *
      * @param context       - The relevant Dspace context
      * @param item          - The item to which the license will be added
      * @param licenseUri    - The license URI to add
      * @param licenseName   - The license name to add
+     * @param licenseRights - The license rights to add
      * @param doc           - The license to document to add
      * @throws SQLException
      * @throws IOException
      * @throws AuthorizeException
      */
-    public void addLicense(Context context, Item item, String licenseUri, String licenseName, Document doc)
+    public void addLicense(Context context, Item item, String licenseUri, String licenseName, String licenseRights, Document doc)
             throws SQLException, IOException, AuthorizeException;
 }

--- a/dspace-api/src/test/java/org/dspace/license/MockCCLicenseConnectorServiceImpl.java
+++ b/dspace-api/src/test/java/org/dspace/license/MockCCLicenseConnectorServiceImpl.java
@@ -62,7 +62,8 @@ public class MockCCLicenseConnectorServiceImpl extends CCLicenseConnectorService
             ccLicenseFields.add(new CCLicenseField(licenseFieldId,
                                                    licenseFieldLabel,
                                                    licenseFieldDescription,
-                                                   mockLicenseFields));
+                                                   mockLicenseFields,
+                                                   ""));
 
         }
 
@@ -76,26 +77,10 @@ public class MockCCLicenseConnectorServiceImpl extends CCLicenseConnectorService
             String enumLabel = "License " + count + " - Field " + index + " - Enum " + i + " - Label";
             String enumDescription = "License " + count + " - Field " + index + " - Enum " + i + " - " +
                     "Description";
-            ccLicenseFieldEnumList.add(new CCLicenseFieldEnum(enumId, enumLabel, enumDescription));
+            ccLicenseFieldEnumList.add(new CCLicenseFieldEnum(enumId, enumLabel, enumDescription, false));
         }
         return ccLicenseFieldEnumList;
 
-    }
-
-    /**
-     * Retrieve a mock CC License URI
-     *
-     * @param licenseId - the ID of the license
-     * @param language  - the language for which to retrieve the full answerMap
-     * @param answerMap - the answers to the different field questions
-     * @return the CC License URI
-     */
-    @Override
-    public String retrieveRightsByQuestion(final String licenseId,
-                                           final String language,
-                                           final Map<String, String> answerMap) {
-
-        return "mock-license-uri";
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionCCLicenseFieldConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionCCLicenseFieldConverter.java
@@ -54,6 +54,7 @@ public class SubmissionCCLicenseFieldConverter
             }
         }
         submissionCCLicenseFieldRest.setEnums(submissionCCLicenseFieldEnumRests);
+        submissionCCLicenseFieldRest.setType(modelObject.getType());
         return submissionCCLicenseFieldRest;
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionCCLicenseFieldEnumConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SubmissionCCLicenseFieldEnumConverter.java
@@ -34,6 +34,7 @@ public class SubmissionCCLicenseFieldEnumConverter
         submissionCCLicenseFieldEnumRest.setId(modelObject.getId());
         submissionCCLicenseFieldEnumRest.setLabel(modelObject.getLabel());
         submissionCCLicenseFieldEnumRest.setDescription(modelObject.getDescription());
+        submissionCCLicenseFieldEnumRest.setDefault(modelObject.getDefault());
 
         return submissionCCLicenseFieldEnumRest;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionCCLicenseFieldEnumRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionCCLicenseFieldEnumRest.java
@@ -17,6 +17,7 @@ public class SubmissionCCLicenseFieldEnumRest {
     private String id;
     private String label;
     private String description;
+    private Boolean isdefault;
 
     public String getId() {
         return id;
@@ -40,5 +41,13 @@ public class SubmissionCCLicenseFieldEnumRest {
 
     public void setDescription(final String description) {
         this.description = description;
+    }
+
+    public Boolean getDefault() {
+        return isdefault;
+    }
+
+    public void setDefault(final Boolean isdefault) {
+        this.isdefault = isdefault;
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionCCLicenseFieldRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SubmissionCCLicenseFieldRest.java
@@ -24,6 +24,7 @@ public class SubmissionCCLicenseFieldRest {
 
     private List<SubmissionCCLicenseFieldEnumRest> enums;
 
+    private String type;
 
     public String getId() {
         return id;
@@ -56,4 +57,13 @@ public class SubmissionCCLicenseFieldRest {
     public void setEnums(final List<SubmissionCCLicenseFieldEnumRest> enums) {
         this.enums = enums;
     }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/CCLicenseAddPatchOperation.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/factory/impl/CCLicenseAddPatchOperation.java
@@ -6,12 +6,16 @@
  * http://www.dspace.org/license/
  */
 package org.dspace.app.rest.submit.factory.impl;
-
+import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.atlas.json.JsonValue;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.model.patch.JsonValueEvaluator;
 import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.license.CreativeCommonsServiceImpl;
 import org.dspace.license.service.CreativeCommonsService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -30,6 +34,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class CCLicenseAddPatchOperation extends AddPatchOperation<String> {
 
+    private static Logger log = org.apache.logging.log4j.LogManager.getLogger(CreativeCommonsServiceImpl.class);
+
     @Autowired
     CreativeCommonsService creativeCommonsService;
 
@@ -44,20 +50,23 @@ public class CCLicenseAddPatchOperation extends AddPatchOperation<String> {
     }
 
     @Override
-    void add(Context context, HttpServletRequest currentRequest, InProgressSubmission source, String path, Object value)
+    void add(Context context, HttpServletRequest currentRequest, InProgressSubmission source, String path, Object licensemap)
             throws Exception {
-        String licenseUri = null;
-        if (value instanceof String) {
-            licenseUri = (String) value;
+        String licenseRights = "";
+        String licenseUri = "";
+        if (licensemap instanceof String){
+            licenseUri = (String) licensemap;
         }
-
-        if (StringUtils.isBlank(licenseUri)) {
-            throw new IllegalArgumentException(
-                    "Value is not a valid license URI");
+        else if (licensemap instanceof JsonValueEvaluator) {
+            JsonNode cclicense = ((JsonValueEvaluator) licensemap).getValueNode();
+            licenseUri = cclicense.get("uri").asText();
+            licenseRights = cclicense.get("rights").asText();
         }
-
+        if (StringUtils.isBlank(licenseUri) && StringUtils.isBlank(licenseRights)) {
+            throw new IllegalArgumentException("Values for dc.rights and dc.rights.uri cannot both be empty.");
+        }
         Item item = source.getItem();
-        boolean updateLicense = creativeCommonsService.updateLicense(context, licenseUri, item);
+        boolean updateLicense = creativeCommonsService.updateLicense(context, licenseUri, licenseRights, item);
         if (!updateLicense) {
             throw new IllegalArgumentException("The license uri: " + licenseUri + ", could not be resolved to a " +
                                                        "CC license");

--- a/dspace-server-webapp/src/main/resources/static/cc/license/known.xml
+++ b/dspace-server-webapp/src/main/resources/static/cc/license/known.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8'?>
+<licenseclass id="known">
+  <label xml:lang="en">I know my CC license...</label>
+  <field id="knownlicense">
+    <label xml:lang="en">Select your CC license:</label>
+    <description xml:lang="en">Help me text.</description>
+    <type>enum</type>
+    <enum id="by">
+      <label xml:lang="en">CC BY 4.0 (Attribution 4.0 International)</label>
+      <description xml:lang="en">
+        This work is licensed under CC BY: You are free to copy and redistribute the material in any format, as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made.
+      </description>
+    </enum>
+    <enum id="by-sa">
+      <label xml:lang="en">CC BY-SA 4.0 (Attribution-ShareAlike 4.0 International)</label>
+      <description xml:lang="en">
+        This work is licensed under CC BY-SA: You are free to copy and redistribute the material in any format as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made. You must distribute any contributions under an identical license.
+      </description>
+    </enum>
+    <enum id="by-nc" default="true">
+      <label xml:lang="en">CC BY-NC 4.0 (Attribution-NonCommercial 4.0 International)</label>
+      <description xml:lang="en">
+        This work is licensed under CC BY-NC: You are free to copy and redistribute the material in any format, as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made. You may not use this work for commercial purpose.
+      </description>
+    </enum>
+    <enum id="by-nc-sa">
+      <label xml:lang="en">CC BY-NC-SA 4.0 (Attribution-NonCommercial-ShareAlike 4.0 International)</label>
+      <description xml:lang="en">
+        This work is licensed under CC BY-NC-SA: You are free to copy and redistribute the material in any format as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made. You may not use this work for commercial purpose and must distribute any contributions under an identical license.
+      </description>
+    </enum>
+    <enum id="by-nd">
+      <label xml:lang="en">CC BY-ND 4.0 (Attribution-NoDerivatives 4.0 International)</label>
+      <description xml:lang="en">
+        This work is licensed under CC BY-ND: You are free to copy and redistribute the material in any format, as long as you give appropriate credit to the original creator and provide a link to the license. If you remix, transform, or build upon the material, you may not distribute the modified material.
+      </description>
+    </enum>
+    <enum id="by-nc-nd">
+      <label xml:lang="en">CC BY-NC-ND 4.0 (Attribution-NonCommercial-NoDerivatives 4.0 International)</label>
+      <description xml:lang="en">
+        This work is licensed under CC BY-NC-ND: You are free to copy and redistribute the material in any format, as long as you give appropriate credit to the original creator and provide a link to the license. You may not use this work for commercial purpose. If you remix, transform, or build upon the material, you may not distribute the modified material.
+      </description>
+    </enum>
+  </field>
+</licenseclass>

--- a/dspace-server-webapp/src/main/resources/static/cc/license/none.xml
+++ b/dspace-server-webapp/src/main/resources/static/cc/license/none.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<licenseclass id="none">
+  <label xml:lang="en">All Rights Reserved</label>
+</licenseclass>

--- a/dspace-server-webapp/src/main/resources/static/cc/license/other.xml
+++ b/dspace-server-webapp/src/main/resources/static/cc/license/other.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='utf-8'?>
+<licenseclass id="other">
+  <label xml:lang="en">Other</label>
+  <field id="dc.rights">
+    <label xml:lang="en">Rights</label>
+    <description xml:lang="en">Provide a copyright statement and/or reuse rights.</description>
+    <type>textarea</type>
+  </field>
+  <field id="dc.rights.uri">
+    <label xml:lang="en">Rights URI</label>
+    <description xml:lang="en">Enter the link or URL for a rights or license statement.</description>
+    <type>input</type>
+  </field>
+</licenseclass>

--- a/dspace-server-webapp/src/main/resources/static/cc/license/standard.xml
+++ b/dspace-server-webapp/src/main/resources/static/cc/license/standard.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='utf-8'?>
+<licenseclass id="standard">
+  <label xml:lang="en">Help me choose a CC license...</label>
+  <field id="commercial">
+    <label xml:lang="en">Allow commercial uses of your work?</label>
+    <description xml:lang="en"></description>
+    <type>enum</type>
+    <enum id="y">
+      <label xml:lang="en">Yes</label>
+      <description xml:lang="en">Commercial use of your work is permitted.</description>
+    </enum>
+    <enum id="n" default="true">
+      <label xml:lang="en">No</label>
+      <description xml:lang="en">Only noncommercial use of your work is permitted. <em>Noncommercial means not primarily intended for or directed towards commercial advantage or monetary compensation.</em></description>
+    </enum>
+  </field>
+  <field id="derivatives">
+    <label xml:lang="en">Allow derivative works?</label>
+    <description xml:lang="en"></description>
+    <type>enum</type>
+    <enum id="y" default="true">
+      <label xml:lang="en">Yes</label>
+      <description xml:lang="en">Derivatives or adaptations of your work are permitted.</description>
+    </enum>
+    <enum id="n">
+      <label xml:lang="en">No</label>
+      <description xml:lang="en">No derivatives or adaptations of your work are permitted.</description>
+    </enum>
+  </field>
+  <field id="sharealike">
+    <label xml:lang="en">Require ShareAlike?</label>
+    <description xml:lang="en">If derivatives or adaptations of your work are permitted, must they be shared under the same terms?.</description>
+    <type>enum</type>
+    <enum id="y">
+      <label xml:lang="en">Yes</label>
+      <description xml:lang="en">Adaptations must be shared under the same terms.</description>
+    </enum>
+    <enum id="n" default="true">
+      <label xml:lang="en">No</label>
+      <description xml:lang="en">Adaptations may be shared under different terms. </description>
+    </enum>
+  </field>
+</licenseclass>

--- a/dspace-server-webapp/src/main/resources/static/cc/license/zero.xml
+++ b/dspace-server-webapp/src/main/resources/static/cc/license/zero.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
+<licenseclass id="zero">
+  <label xml:lang="en">Public Domain</label>
+</licenseclass>

--- a/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nc-nd/4.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nc-nd/4.0/rdf
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/licenses/by-nc-nd/4.0/</license-uri>
+  <license-name>Attribution-NonCommercial-NoDerivatives 4.0 International</license-name>
+  <license-rights>This work is licensed under CC BY-NC-ND: You are free to copy and redistribute the material in any format, as long as you give appropriate credit to the original creator and provide a link to the license. You may not use this work for commercial purpose. If you remix, transform, or build upon the material, you may not distribute the modified material.</license-rights>
+   <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by-nc-nd/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by-nc-nd/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/licenses/by-nc-nd/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html><a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-nd/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-nd/4.0/">Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License</a>.</html>
+</result>

--- a/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nc-sa/4.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nc-sa/4.0/rdf
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/licenses/by-nc-sa/4.0/</license-uri>
+  <license-name>Attribution-NonCommercial-ShareAlike 4.0 International</license-name>
+  <license-rights>This work is licensed under CC BY-NC-SA: You are free to copy and redistribute the material in any format as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made. You may not use this work for commercial purpose and must distribute any contributions under an identical license.</license-rights>
+   <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by-nc-sa/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by-nc-sa/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+    <requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/licenses/by-nc-sa/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+    <requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html><a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.</html>
+</result>

--- a/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nc/4.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nc/4.0/rdf
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/licenses/by-nc/4.0/</license-uri>
+  <license-name>Attribution-NonCommercial 4.0 International</license-name>
+  <license-rights>This work is licensed under CC BY-NC: You are free to copy and redistribute the material in any format, as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made. You may not use this work for commercial purpose.</license-rights>
+   <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by-nc/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/licenses/by-nc/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html><a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.</html>
+</result>

--- a/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nd/4.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/licenses/by-nd/4.0/rdf
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/licenses/by-nd/4.0/</license-uri>
+  <license-name>Attribution-NoDerivatives 4.0 International</license-name>
+  <license-rights>This work is licensed under CC BY-ND: You are free to copy and redistribute the material in any format, as long as you give appropriate credit to the original creator and provide a link to the license. If you remix, transform, or build upon the material, you may not distribute the modified material.</license-rights>
+   <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by-nd/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by-nd/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/licenses/by-nd/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html><a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nd/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.</html>
+</result>

--- a/dspace-server-webapp/src/main/resources/static/cc/licenses/by-sa/4.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/licenses/by-sa/4.0/rdf
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/licenses/by-sa/4.0/</license-uri>
+  <license-name>Attribution-ShareAlike 4.0 International</license-name>
+  <license-rights>This work is licensed under CC BY-SA: You are free to copy and redistribute the material in any format as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made. You must distribute any contributions under an identical license.</license-rights>
+  <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+    <requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+    <requires rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html><a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-sa/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.</html>
+</result>

--- a/dspace-server-webapp/src/main/resources/static/cc/licenses/by/4.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/licenses/by/4.0/rdf
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/licenses/by/4.0/</license-uri>
+  <license-name>Attribution 4.0 International</license-name>
+  <license-rights>This work is licensed under CC BY: You are free to copy and redistribute the material in any format, as well as remix, transform, and build upon the material as long as you give appropriate credit to the original creator, provide a link to the license, and indicate any changes made.</license-rights>
+  <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/></Work><License rdf:about="http://creativecommons.org/licenses/by/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/licenses/by/4.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Attribution"/>
+    <requires rdf:resource="http://creativecommons.org/ns#Notice"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by/4.0/88x31.png"/></a><br/>This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</html>
+</result>

--- a/dspace-server-webapp/src/main/resources/static/cc/publicdomain/zero/1.0/rdf
+++ b/dspace-server-webapp/src/main/resources/static/cc/publicdomain/zero/1.0/rdf
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='utf-8'?>
+<result>
+  <license-uri>http://creativecommons.org/publicdomain/zero/1.0/</license-uri>
+  <license-name>CC0 1.0 Universal</license-name>
+  <license-rights>This work has been marked as dedicated to the public domain.</license-rights>
+   <deprecated>false</deprecated>
+  <rdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <Work xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:about=""><license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/></Work><License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+  </License>
+</rdf:RDF>
+  </rdf>
+  <licenserdf>
+    <rdf:RDF xmlns="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+    <permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+  </License>
+</rdf:RDF>
+  </licenserdf>
+  <html>
+    <p xmlns:dct="http://purl.org/dc/terms/">
+  <a rel="license" href="http://creativecommons.org/publicdomain/zero/1.0/">
+    <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0"/>
+  </a>
+  <br/>
+  To the extent possible under law,
+  <span rel="dct:publisher" resource="[_:publisher]">the person who associated CC0</span>
+  with this work has waived all copyright and related or neighboring
+  rights to this work.
+</p>
+  </html>
+</result>

--- a/dspace-server-webapp/src/test/java/org/dspace/license/MockCCLicenseConnectorServiceImpl.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/license/MockCCLicenseConnectorServiceImpl.java
@@ -61,7 +61,8 @@ public class MockCCLicenseConnectorServiceImpl extends CCLicenseConnectorService
             ccLicenseFields.add(new CCLicenseField(licenseFieldId,
                                                    licenseFieldLabel,
                                                    licenseFieldDescription,
-                                                   mockLicenseFields));
+                                                   mockLicenseFields,
+                                                   ""));
 
         }
 
@@ -75,7 +76,7 @@ public class MockCCLicenseConnectorServiceImpl extends CCLicenseConnectorService
             String enumLabel = "License " + count + " - Field " + index + " - Enum " + i + " - Label";
             String enumDescription = "License " + count + " - Field " + index + " - Enum " + i + " - " +
                     "Description";
-            ccLicenseFieldEnumList.add(new CCLicenseFieldEnum(enumId, enumLabel, enumDescription));
+            ccLicenseFieldEnumList.add(new CCLicenseFieldEnum(enumId, enumLabel, enumDescription, false));
         }
         return ccLicenseFieldEnumList;
 

--- a/dspace/config/item-submission.xml
+++ b/dspace/config/item-submission.xml
@@ -321,7 +321,7 @@
             <!-- <step id="extractionstep"/> -->
 
             <!-- Uncomment this step to allow the user to select a Creative Commons License -->
-            <!-- <step id="cclicense"/> -->
+            <step id="cclicense"/>
 
             <!--Step will be to Sign off on the required DSpace License agreement -->
             <step id="license"/>


### PR DESCRIPTION
This is a draft PR to assess interest in this work.
It is working well as-is and is in production at Indiana University on DSpace version 7.x. 
Tests will fail until it is determined that finishing this PR is worthwhile.

## References
* Fixes https://github.com/DSpace/DSpace/issues/11808
* Alternative to https://github.com/DSpace/DSpace/pull/12424
* Requires https://github.com/DSpace/dspace-angular/pull/6067 (a UI PR is required to test this)

## Description
Replaces legacy CC API dependence with locally served resources.

## List of changes in this PR:
* Removes reliance on CC API, replaces with local logic and resources
* Adds new choices to CC License chooser to facilitate setting correct values for dc.rights and dc.rights.url: 

1. Help me choose (legacy style chooser)
2. I know my license (simple selection)
3. All rights reserved (protected by copyright)
4. Public Domain (apply cc0)
5. Other (manually enter values for dc.rights and dc.rights.uri)

* Each option in the chooser is configured via XML
* Chooser form logic now resides in DSpace.

## Testing instructions

1. Merge this PR and the related DSpace backend PR
2. Turn on CC License Chooser by uncommenting  <step id="cclicense"/> in config/item-submission.xml
3. There are also a number of configuration settings to be applied in local.cfg:
```
###############################
#  Creative Commons settings  #
###############################

# The url to the web service API
cc.api.rooturl = ${dspace.server.url}/cc

# Metadata field to hold CC license URI of selected license
cc.license.uri = dc.rights.uri

# Metadata field to hold CC license name of selected license (if defined)
cc.license.name = dc.rights

# Metadata field to hold CC license rights of selected license (if defined)
cc.license.rights = dc.rights

# Assign license name during web submission
cc.submit.setname = false

# Assign license rights during web submission
cc.submit.setrights = true

# Store license bitstream (RDF license text) during web submission
cc.submit.addbitstream = true

# A list of license classes that should be included in the selection process
# class names - comma-separated list -  must exactly match what service returns.
cc.license.classes = standard,known,none,zero,other
```

4. Restart back end server, then restart front end
5. Add a new item in the UI and scroll down to the Rights section.
6. Explore the chooser options and make selections.
7. Finish adding the item and then check it's metadata to ensure expected values are in the dc.rights and dc.rights.uri fields.

## Screenshots
<img width="669" height="645" alt="Screenshot from 2026-07-29 14-46-21" src="https://github.com/user-attachments/assets/0b66ad53-a8bd-4189-a1a5-f2a1bcb87b5d" />
<img width="669" height="791" alt="Screenshot from 2026-07-29 14-44-01" src="https://github.com/user-attachments/assets/1b47fd83-bce3-4f9e-b698-9023c0dd0204" />
<img width="669" height="609" alt="Screenshot from 2026-07-29 14-44-28" src="https://github.com/user-attachments/assets/f111fc6b-33a3-4fcd-b77f-d406322d5943" />
<img width="669" height="435" alt="Screenshot from 2026-07-29 14-44-41" src="https://github.com/user-attachments/assets/8fe2574c-1ca3-4c6c-a737-907051484d03" />
<img width="669" height="551" alt="Screenshot from 2026-07-29 14-45-03" src="https://github.com/user-attachments/assets/2403d01a-62e9-41f8-b75a-82ee98f775c2" />
<img width="669" height="645" alt="Screenshot from 2026-07-29 14-45-15" src="https://github.com/user-attachments/assets/37f824f9-4e78-4f58-9dff-bb0cf930a872" />
