### PR TITLE
Minor dependabot rule updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -120,7 +120,7 @@ updates:
         update-types:
         - "minor"
         - "patch"
-      # Group Tika, bouncycastle, and asm because they are tightly integrated
+      # Group Tika, bouncycastle, asm, and jackcess because they are tightly integrated
       # and we theoretically want to keep them in sync.
       tika:
         applies-to: version-updates
@@ -128,6 +128,7 @@ updates:
         - "org.apache.tika:*:*"
         - "org.bouncycastle:*:*"
         - "org.ow2.asm:*:*"
+        - "com.healthmarketscience.jackcess:*:*"
         update-types:
         - "minor"
         - "patch"
@@ -172,11 +173,13 @@ updates:
           - "actions/*"
           - "github/*"
     ignore:
-        # For official GitHub actions, ignore minor & patch releases because we reference these actions
+        # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
         # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
         - dependency-name: "actions/*"
           update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
         - dependency-name: "github/*"
+          update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+        - dependency-name: "docker/*"
           update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   ######################
   ## dspace-10_x branch
@@ -293,7 +296,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Group Tika, bouncycastle, and asm because they are tightly integrated
+      # Group Tika, bouncycastle, asm, and jackcess because they are tightly integrated
       # and we theoretically want to keep them in sync.
       tika:
         applies-to: version-updates
@@ -301,6 +304,7 @@ updates:
           - "org.apache.tika:*:*"
           - "org.bouncycastle:*:*"
           - "org.ow2.asm:*:*"
+          - "com.healthmarketscience.jackcess:*:*"
         update-types:
           - "minor"
           - "patch"
@@ -346,11 +350,13 @@ updates:
           - "actions/*"
           - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
       - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "docker/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   ######################
   ## dspace-9_x branch
@@ -466,7 +472,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Group Tika, bouncycastle, and asm because they are tightly integrated
+      # Group Tika, bouncycastle, asm, and jackcess because they are tightly integrated
       # and we theoretically want to keep them in sync.
       tika:
         applies-to: version-updates
@@ -474,6 +480,7 @@ updates:
         - "org.apache.tika:*:*"
         - "org.bouncycastle:*:*"
         - "org.ow2.asm:*:*"
+        - "com.healthmarketscience.jackcess:*:*"
         update-types:
         - "minor"
         - "patch"
@@ -522,11 +529,13 @@ updates:
           - "actions/*"
           - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
       - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "docker/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   ######################
   ## dspace-8_x branch
@@ -642,7 +651,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Group Tika, bouncycastle, and asm because they are tightly integrated
+      # Group Tika, bouncycastle, asm, and jackcess because they are tightly integrated
       # and we theoretically want to keep them in sync.
       tika:
         applies-to: version-updates
@@ -650,6 +659,7 @@ updates:
         - "org.apache.tika:*:*"
         - "org.bouncycastle:*:*"
         - "org.ow2.asm:*:*"
+        - "com.healthmarketscience.jackcess:*:*"
         update-types:
         - "minor"
         - "patch"
@@ -698,9 +708,11 @@ updates:
           - "actions/*"
           - "github/*"
     ignore:
-      # For official GitHub actions, ignore minor & patch releases because we reference these actions
+      # For official GitHub & Docker actions, ignore minor & patch releases because we reference these actions
       # via a major version tag which automatically uses the latest minor/patch version (e.g. "actions/checkout@v6")
       - dependency-name: "actions/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
       - dependency-name: "github/*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
+      - dependency-name: "docker/*"
         update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]


### PR DESCRIPTION

## Description
This PR includes two minor updates to existing Dependabot rules (Based on recent PRs created by Dependabot):

1. Add `jackcess` to Tika group. This dependency isn't used directly and is brought in by Tika.  So, it should be upgraded alongside Tika.
2. Add `docker/**` GitHub actions to the list of actions which we *ignore* minor/patch updates for.  This is because we reference these actions by a major version tag which automatically uses the latest minor/patch version (e.g. "v5" references latest v5.x.x release)


## Instructions for Reviewers
* This can only be tested by merging as it's just updates to dependabot rules.