### PR TITLE
Fix CSV import whitespace change detection

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1257,7 +1257,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
         }
 
         // Remove newlines as different operating systems sometimes use different formats
-        return in.replaceAll("\r\n", "").replaceAll("\n", "").trim();
+        return in.replaceAll("\r\n", "").replaceAll("\n", "");
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -740,11 +740,14 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                 fromCSV[v] = value;
             }
 
-            if ((value != null) && (!"".equals(value)) && (!contains(value, dcvalues))) {
+            String existingValue = findMatchingValue(value, dcvalues);
+            if ((value != null) && (!"".equals(value)) && (existingValue == null)) {
                 changes.registerAdd(dcv);
             } else {
-                // Keep it
-                changes.registerConstant(dcv);
+                // Keep the exact stored value so rebuilding the field cannot normalize untouched metadata.
+                BulkEditMetadataValue constant = existingValue == null ? dcv
+                    : getBulkEditValueFromCSV(c, language, schema, element, qualifier, existingValue, null);
+                changes.registerConstant(constant);
             }
         }
 
@@ -786,6 +789,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             List<String> values = new ArrayList<String>();
             List<String> authorities = new ArrayList<String>();
             List<Integer> confidences = new ArrayList<Integer>();
+            List<Boolean> constants = new ArrayList<Boolean>();
             for (BulkEditMetadataValue value : list) {
                 if ((qualifier == null) && (language == null)) {
                     if ((schema.equals(value.getSchema())) &&
@@ -795,6 +799,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
+                        constants.add(changes.getConstant().contains(value));
                     }
                 } else if (qualifier == null) {
                     if ((schema.equals(value.getSchema())) &&
@@ -804,6 +809,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
+                        constants.add(changes.getConstant().contains(value));
                     }
                 } else if (language == null) {
                     if ((schema.equals(value.getSchema())) &&
@@ -813,6 +819,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
+                        constants.add(changes.getConstant().contains(value));
                     }
                 } else {
                     if ((schema.equals(value.getSchema())) &&
@@ -822,6 +829,7 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
+                        constants.add(changes.getConstant().contains(value));
                     }
                 }
             }
@@ -840,8 +848,13 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             } else {
                 itemService.clearMetadata(c, item, schema, element, qualifier, language);
                 if (!values.isEmpty()) {
-                    itemService.addMetadata(c, item, schema, element, qualifier,
-                                            language, values, authorities, confidences);
+                    List<MetadataValue> added = itemService.addMetadata(c, item, schema, element, qualifier,
+                                                                       language, values, authorities, confidences);
+                    for (int i = 0; i < added.size(); i++) {
+                        if (constants.get(i)) {
+                            added.get(i).setValue(values.get(i));
+                        }
+                    }
                 }
                 itemService.update(c, item);
             }
@@ -1235,13 +1248,24 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
      * @return Whether or not it is contained
      */
     protected boolean contains(String needle, String[] haystack) {
+        return findMatchingValue(needle, haystack) != null;
+    }
+
+    /**
+     * Find the exact stored value which is equivalent to the supplied value for import comparison.
+     *
+     * @param needle   The String to look for
+     * @param haystack The array of Strings to search through
+     * @return The matching stored value, or null when no value matches
+     */
+    protected String findMatchingValue(String needle, String[] haystack) {
         // Look for the needle in the haystack
         for (String examine : haystack) {
             if (clean(examine).equals(clean(needle))) {
-                return true;
+                return examine;
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -789,7 +789,6 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             List<String> values = new ArrayList<String>();
             List<String> authorities = new ArrayList<String>();
             List<Integer> confidences = new ArrayList<Integer>();
-            List<Boolean> constants = new ArrayList<Boolean>();
             for (BulkEditMetadataValue value : list) {
                 if ((qualifier == null) && (language == null)) {
                     if ((schema.equals(value.getSchema())) &&
@@ -799,7 +798,6 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
-                        constants.add(changes.getConstant().contains(value));
                     }
                 } else if (qualifier == null) {
                     if ((schema.equals(value.getSchema())) &&
@@ -809,7 +807,6 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
-                        constants.add(changes.getConstant().contains(value));
                     }
                 } else if (language == null) {
                     if ((schema.equals(value.getSchema())) &&
@@ -819,7 +816,6 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
-                        constants.add(changes.getConstant().contains(value));
                     }
                 } else {
                     if ((schema.equals(value.getSchema())) &&
@@ -829,7 +825,6 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                         values.add(value.getValue());
                         authorities.add(value.getAuthority());
                         confidences.add(value.getConfidence());
-                        constants.add(changes.getConstant().contains(value));
                     }
                 }
             }
@@ -851,9 +846,9 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
                     List<MetadataValue> added = itemService.addMetadata(c, item, schema, element, qualifier,
                                                                        language, values, authorities, confidences);
                     for (int i = 0; i < added.size(); i++) {
-                        if (constants.get(i)) {
-                            added.get(i).setValue(values.get(i));
-                        }
+                        // DSpaceObjectService trims values before persisting them. Restore the exact imported
+                        // representation so meaningful newlines are not lost when a sibling value changes.
+                        added.get(i).setValue(values.get(i));
                     }
                 }
                 itemService.update(c, item);

--- a/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/bulkedit/MetadataImport.java
@@ -1256,8 +1256,8 @@ public class MetadataImport extends DSpaceRunnable<MetadataImportScriptConfigura
             return null;
         }
 
-        // Remove newlines as different operating systems sometimes use different formats
-        return in.replaceAll("\r\n", "").replaceAll("\n", "");
+        // Normalize line endings across operating systems without discarding meaningful newlines
+        return in.replace("\r\n", "\n").replace('\r', '\n');
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -347,6 +347,32 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
+    public void metadataImportPreservesNewlineOnUnchangedValueTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        String itemTitle = "Testing unchanged newline preservation";
+        Item item = ItemBuilder.createItem(context, personCollection)
+                               .withTitle(itemTitle)
+                               .withMetadata("dc", "contributor", "other", "First Author")
+                               .withMetadata("dc", "contributor", "other", "Second Author")
+                               .build();
+        List<MetadataValue> existing = itemService.getMetadata(
+            item, "dc", "contributor", "other", Item.ANY);
+        existing.get(1).setValue("Second Author\n");
+        metadataValueService.update(context, existing.get(1));
+        context.restoreAuthSystemState();
+
+        String[] csv = {"id,collection,dc.title,dc.contributor.other",
+            item.getID() + "," + personCollection.getHandle() + "," + itemTitle +
+                ",\"first Author||Second Author\n\""};
+        performImportScript(csv);
+
+        item = findItemByName(itemTitle);
+        assertEquals(List.of("first Author", "Second Author\n"),
+            itemService.getMetadata(item, "dc", "contributor", "other", Item.ANY)
+                       .stream().map(MetadataValue::getValue).toList());
+    }
+
+    @Test
     public void cleanNormalizesLineEndingsWithoutRemovingNewlinesTest() {
         MetadataImport metadataImport = new MetadataImport();
 

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -36,9 +36,11 @@ import org.dspace.content.Collection;
 import org.dspace.content.Community;
 import org.dspace.content.EntityType;
 import org.dspace.content.Item;
+import org.dspace.content.MetadataValue;
 import org.dspace.content.Relationship;
 import org.dspace.content.factory.ContentServiceFactory;
 import org.dspace.content.service.ItemService;
+import org.dspace.content.service.MetadataValueService;
 import org.dspace.content.service.RelationshipService;
 import org.dspace.eperson.EPerson;
 import org.dspace.eperson.factory.EPersonServiceFactory;
@@ -57,6 +59,8 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
 
     private final ItemService itemService
             = ContentServiceFactory.getInstance().getItemService();
+    private final MetadataValueService metadataValueService
+            = ContentServiceFactory.getInstance().getMetadataValueService();
     private final EPersonService ePersonService
             = EPersonServiceFactory.getInstance().getEPersonService();
     private final RelationshipService relationshipService
@@ -279,6 +283,32 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
         performImportScript(csv);
         item = findItemByName(itemTitle);
         assertEquals(0, itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).size());
+    }
+
+    @Test
+    public void metadataImportDetectsTrailingWhitespaceChangeTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        String itemTitle = "Testing trailing whitespace change";
+        Item item = ItemBuilder.createItem(context, personCollection)
+                               .withAuthor("Gopalan, Deepa")
+                               .withTitle(itemTitle)
+                               .build();
+        // Simulate an existing value from a submission path that preserved trailing whitespace.
+        MetadataValue author = itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).get(0);
+        author.setValue("Gopalan, Deepa ");
+        metadataValueService.update(context, author);
+        context.restoreAuthSystemState();
+
+        assertEquals("Gopalan, Deepa ",
+            itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).get(0).getValue());
+
+        String[] csv = {"id,collection,dc.title,dc.contributor.author",
+            item.getID() + "," + personCollection.getHandle() + "," + itemTitle + ",\"Gopalan, Deepa\""};
+        performImportScript(csv);
+
+        item = findItemByName(itemTitle);
+        assertEquals("Gopalan, Deepa",
+            itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).get(0).getValue());
     }
 
     private Item findItemByName(String name) throws Exception {

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -311,6 +311,48 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
             itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY).get(0).getValue());
     }
 
+    @Test
+    public void metadataImportReportsNewlineRemovalAlongsideOtherChangesTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        String itemTitle = "Testing newline removal";
+        Item item = ItemBuilder.createItem(context, personCollection)
+                               .withTitle(itemTitle)
+                               .withMetadata("dc", "contributor", "other", "Name with space at the end")
+                               .withMetadata("dc", "contributor", "other", "Name with newline at the end")
+                               .withMetadata("dc", "contributor", "other", "Name with nothing at the end")
+                               .build();
+        List<MetadataValue> existing = itemService.getMetadata(
+            item, "dc", "contributor", "other", Item.ANY);
+        existing.get(0).setValue("Name with space at the end ");
+        metadataValueService.update(context, existing.get(0));
+        existing.get(1).setValue("Name with newline at the end\n");
+        metadataValueService.update(context, existing.get(1));
+        context.restoreAuthSystemState();
+
+        assertEquals("Name with space at the end ", existing.get(0).getValue());
+        assertEquals("Name with newline at the end\n", existing.get(1).getValue());
+
+        String[] csv = {"id,collection,dc.title,dc.contributor.other",
+            item.getID() + "," + personCollection.getHandle() + "," + itemTitle +
+                ",\"Name with space at the end||Name with newline at the end||Name with nothing at the end\""};
+        TestDSpaceRunnableHandler handler = performImportScript(csv, false);
+
+        assertTrue("The import summary must report removal of the value containing a newline",
+            handler.getInfoMessages().contains("Name with newline at the end\n"));
+        item = findItemByName(itemTitle);
+        assertEquals(List.of("Name with space at the end", "Name with newline at the end",
+                "Name with nothing at the end"),
+            itemService.getMetadata(item, "dc", "contributor", "other", Item.ANY)
+                       .stream().map(MetadataValue::getValue).toList());
+    }
+
+    @Test
+    public void cleanNormalizesLineEndingsWithoutRemovingNewlinesTest() {
+        MetadataImport metadataImport = new MetadataImport();
+
+        assertEquals("First line\nSecond line\n", metadataImport.clean("First line\r\nSecond line\r"));
+    }
+
     private Item findItemByName(String name) throws Exception {
         List<Item> items =
             IteratorUtils.toList(itemService.findArchivedByMetadataField(context, "dc", "title", null, name));
@@ -333,7 +375,7 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
      * @param csv content for test file.
      * @throws java.lang.Exception passed through.
      */
-    public void performImportScript(String[] csv, boolean useTemplate) throws Exception {
+    public TestDSpaceRunnableHandler performImportScript(String[] csv, boolean useTemplate) throws Exception {
         File csvFile = File.createTempFile("dspace-test-import", "csv");
         BufferedWriter out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(csvFile), "UTF-8"));
         for (String csvLine : csv) {
@@ -342,17 +384,18 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
         out.flush();
         out.close();
         String fileLocation = csvFile.getAbsolutePath();
+        TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
         try {
             String[] args = new String[] {"metadata-import", "-f", fileLocation, "-e", admin.getEmail(), "-s"};
             if (useTemplate) {
                 args = ArrayUtils.add(args, "-t");
             }
-            TestDSpaceRunnableHandler testDSpaceRunnableHandler = new TestDSpaceRunnableHandler();
             ScriptLauncher
                 .handleScript(args, ScriptLauncher.getConfig(kernelImpl), testDSpaceRunnableHandler, kernelImpl);
         } finally {
             csvFile.delete();
         }
+        return testDSpaceRunnableHandler;
     }
 
     @Test

--- a/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/bulkedit/MetadataImportIT.java
@@ -373,6 +373,37 @@ public class MetadataImportIT extends AbstractIntegrationTestWithDatabase {
     }
 
     @Test
+    public void metadataImportPreservesNewlinesForChangedAndUnchangedAuthorValuesTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        String itemTitle = "Testing unchanged author newlines";
+        Item item = ItemBuilder.createItem(context, personCollection)
+                               .withTitle(itemTitle)
+                               .withAuthor("Orth, Alan")
+                               .withAuthor("Donohue, Tim")
+                               .withAuthor("Goyal, Sakshamm")
+                               .build();
+        List<MetadataValue> existing = itemService.getMetadata(
+            item, "dc", "contributor", "author", Item.ANY);
+        existing.get(0).setValue("Orth, Alan\n");
+        metadataValueService.update(context, existing.get(0));
+        existing.get(1).setValue("Donohue, Tim\n");
+        metadataValueService.update(context, existing.get(1));
+        existing.get(2).setValue("Goyal, Sakshamm\n");
+        metadataValueService.update(context, existing.get(2));
+        context.restoreAuthSystemState();
+
+        String[] csv = {"id,collection,dc.title,dc.contributor.author",
+            item.getID() + "," + personCollection.getHandle() + "," + itemTitle +
+                ",\"Oorth, Alan\n||Donohue, Tim\n||Goyal, Sakshamm\n\""};
+        performImportScript(csv);
+
+        item = findItemByName(itemTitle);
+        assertEquals(List.of("Oorth, Alan\n", "Donohue, Tim\n", "Goyal, Sakshamm\n"),
+            itemService.getMetadata(item, "dc", "contributor", "author", Item.ANY)
+                       .stream().map(MetadataValue::getValue).toList());
+    }
+
+    @Test
     public void cleanNormalizesLineEndingsWithoutRemovingNewlinesTest() {
         MetadataImport metadataImport = new MetadataImport();
 


### PR DESCRIPTION
## References

* Fixes #12923

## Description

Preserve meaningful leading and trailing whitespace when comparing existing metadata with CSV values, while normalizing line-ending formats only for comparison. When one value in a multi-value field changes, retain the exact stored representation of unchanged sibling values during the field rebuild. This lets CSV imports apply intended whitespace-only changes without silently normalizing untouched metadata.

## Instructions for Reviewers

List of changes in this PR:
* Remove comparison-time trimming from `MetadataImport.clean()` so surrounding whitespace differences are not treated as equal.
* Normalize CRLF and CR to LF for comparison without discarding meaningful newlines.
* Reuse the exact stored value for unchanged entries and restore it after the metadata field is rebuilt, avoiding normalization by the generic add-metadata path.
* Add integration regressions for whitespace-only cleanup, newline comparison/reporting, and the exact multi-value case where editing the first author must preserve a trailing newline on the second author.

To review manually:
1. Give a multi-value `dc.contributor.other` field the values `First Author` and `Second Author\n`.
2. Export the item as CSV and change only `First Author` to `first Author`.
3. Re-import the CSV and confirm that the first value changes while the trailing newline on the second value is retained.

Validation run on Java 21:
* The new exact maintainer regression first failed with `expected:<[first Author, Second Author\n]> but was:<[first Author, Second Author]>`.
* After the repair, the exact regression passed.
* `mvn -pl dspace-api -DskipIntegrationTests=false -Dit.test=MetadataImportIT verify` (18 tests passed; zero Checkstyle violations; license check passed)
* `git diff --check`

AI assistance disclosure: Codex assisted with issue discovery, implementation, and validation. I reviewed the resulting diff and test evidence before publication.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). (The full relevant integration class passes locally; the complete repository suite is left to CI.)
- [x] My PR **includes details on how to test it**. I have provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I have made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I have opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I have provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I have [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-from-a-fork).