### PR TITLE
DINI open access set

### DIFF
--- a/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/AccessStatusHelper.java
@@ -20,6 +20,27 @@ import org.dspace.core.Context;
  */
 public interface AccessStatusHelper {
     /**
+     * Defines the String value for an embargo state. Cannot be overwritten in plugins.
+     */
+    public static final String EMBARGO = "embargo";
+    /**
+     * Defines the String value for a metadata only state. Cannot be overwritten in plugins.
+     */
+    public static final String METADATA_ONLY = "metadata.only";
+    /**
+     * Defines the String value for an open access state. Cannot be overwritten in plugins.
+     */
+    public static final String OPEN_ACCESS = "open.access";
+    /**
+     * Defines the String value for a restricted state. Cannot be overwritten in plugins.
+     */
+    public static final String RESTRICTED = "restricted";
+    /**
+     * Defines the String value for an unknown state. Cannot be overwritten in plugins.
+     */
+    public static final String UNKNOWN = "unknown";
+
+    /**
      * Calculate the access status for the item.
      *
      * @param context the DSpace context

--- a/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
+++ b/dspace-api/src/main/java/org/dspace/access/status/DefaultAccessStatusHelper.java
@@ -45,12 +45,6 @@ public class DefaultAccessStatusHelper implements AccessStatusHelper {
     public static final String STATUS_FOR_CURRENT_USER  = "current";
     public static final String STATUS_FOR_ANONYMOUS  = "anonymous";
 
-    public static final String EMBARGO = "embargo";
-    public static final String METADATA_ONLY = "metadata.only";
-    public static final String OPEN_ACCESS = "open.access";
-    public static final String RESTRICTED = "restricted";
-    public static final String UNKNOWN = "unknown";
-
     protected ItemService itemService =
             ContentServiceFactory.getInstance().getItemService();
     protected ResourcePolicyService resourcePolicyService =

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceIndexAccessStatusPlugin.java
@@ -10,7 +10,7 @@ package org.dspace.discovery;
 import java.sql.SQLException;
 
 import org.apache.solr.common.SolrInputDocument;
-import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.access.status.AccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.content.AccessStatus;
@@ -38,7 +38,7 @@ public class SolrServiceIndexAccessStatusPlugin implements SolrServiceIndexPlugi
             try {
                 accessStatus = retrieveItemAccessStatus(context,item);
             } catch (SQLException e) {
-                accessStatus = DefaultAccessStatusHelper.UNKNOWN;
+                accessStatus = AccessStatusHelper.UNKNOWN;
             }
 
             // _keyword and _filter because

--- a/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
+++ b/dspace-api/src/test/java/org/dspace/access/status/DefaultAccessStatusHelperTest.java
@@ -213,7 +213,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithNullItem 0", status, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        assertThat("testWithNullItem 0", status, equalTo(AccessStatusHelper.UNKNOWN));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithNullItem 1", availabilityDate);
     }
@@ -228,7 +228,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutBundle, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithoutBundle 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        assertThat("testWithoutBundle 0", status, equalTo(AccessStatusHelper.METADATA_ONLY));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutBundle 1", availabilityDate);
     }
@@ -246,14 +246,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithoutBitstream 0", status, equalTo(DefaultAccessStatusHelper.METADATA_ONLY));
+        assertThat("testWithoutBitstream 0", status, equalTo(AccessStatusHelper.METADATA_ONLY));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutBitstream 1", availabilityDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 null, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.UNKNOWN));
+        assertThat("testWithoutBitstream 3", bitstreamStatus, equalTo(AccessStatusHelper.UNKNOWN));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithoutBitstream 4", bitstreamAvailabilityDate);
     }
@@ -275,14 +275,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        assertThat("testWithBitstream 0", status, equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithBitstream 1", availabilityDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        assertThat("testWithBitstream 3", bitstreamStatus, equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithBitstream 4", bitstreamAvailabilityDate);
     }
@@ -314,14 +314,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithEmbargo 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        assertThat("testWithEmbargo 0", status, equalTo(AccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargo 1", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        assertThat("testWithEmbargo 3", bitstreamStatus, equalTo(AccessStatusHelper.EMBARGO));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargo 4", bitstreamAvailabilityDate, equalTo(startDate));
     }
@@ -353,14 +353,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithDateRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithDateRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        assertThat("testWithDateRestriction 0", status, equalTo(AccessStatusHelper.RESTRICTED));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithDateRestriction 1", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        assertThat("testWithDateRestriction 3", bitstreamStatus, equalTo(AccessStatusHelper.RESTRICTED));
         LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithDateRestriction 4", bistreamAvailabilityDate, equalTo(startDate));
     }
@@ -390,14 +390,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithGroupRestriction, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithGroupRestriction 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        assertThat("testWithGroupRestriction 0", status, equalTo(AccessStatusHelper.RESTRICTED));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithGroupRestriction 1", availabilityDate, equalTo(threshold));
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        assertThat("testWithGroupRestriction 3", bitstreamStatus, equalTo(AccessStatusHelper.RESTRICTED));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithGroupRestriction 4", bitstreamAvailabilityDate, equalTo(threshold));
     }
@@ -420,14 +420,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPolicy, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithoutPolicy 0", status, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        assertThat("testWithoutPolicy 0", status, equalTo(AccessStatusHelper.RESTRICTED));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithoutPolicy 1", availabilityDate, equalTo(threshold));
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.RESTRICTED));
+        assertThat("testWithoutPolicy 3", bitstreamStatus, equalTo(AccessStatusHelper.RESTRICTED));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithoutPolicy 4", bitstreamAvailabilityDate, equalTo(threshold));
     }
@@ -448,14 +448,14 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithoutPrimaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithoutPrimaryBitstream 0", status, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        assertThat("testWithoutPrimaryBitstream 0", status, equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithoutPrimaryBitstream 1", availabilityDate);
         // getAccessStatusFromBitstream
         AccessStatus accessStatusBitstream = helper.getAccessStatusFromBitstream(context,
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
-        assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+        assertThat("testWithoutPrimaryBitstream 3", bitstreamStatus, equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithoutPrimaryBitstream 4", bitstreamAvailabilityDate);
     }
@@ -490,7 +490,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
         AccessStatus accessStatus = helper.getAccessStatusFromItem(context,
                 itemWithPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
-        assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(DefaultAccessStatusHelper.EMBARGO));
+        assertThat("testWithPrimaryAndMultipleBitstreams 0", status, equalTo(AccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithPrimaryAndMultipleBitstreams 1", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream -> primary
@@ -498,7 +498,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 primaryBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String primaryBitstreamStatus = accessStatusPrimaryBitstream.getStatus();
         assertThat("testWithPrimaryAndMultipleBitstreams 3", primaryBitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         LocalDate primaryAvailabilityDate = accessStatusPrimaryBitstream.getAvailabilityDate();
         assertThat("testWithPrimaryAndMultipleBitstreams 4", primaryAvailabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream -> other
@@ -506,7 +506,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 otherBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String otherBitstreamStatus = accessStatusOtherBitstream.getStatus();
         assertThat("testWithPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+                equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getAvailabilityDate();
         assertNull("testWithPrimaryAndMultipleBitstreams 6", otherAvailabilityDate);
     }
@@ -541,7 +541,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 itemWithoutPrimaryAndMultipleBitstreams, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 0", status,
-                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+                equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithNoPrimaryAndMultipleBitstreams 1", availabilityDate);
         // getAccessStatusFromBitstream -> first
@@ -549,7 +549,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 firstBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String firstBitstreamStatus = accessStatusFirstBitstream.getStatus();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 3", firstBitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+                equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate firstAvailabilityDate = accessStatusFirstBitstream.getAvailabilityDate();
         assertNull("testWithNoPrimaryAndMultipleBitstreams 4", firstAvailabilityDate);
         // getAccessStatusFromBitstream -> other
@@ -557,7 +557,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 anotherBitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String otherBitstreamStatus = accessStatusOtherBitstream.getStatus();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 5", otherBitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         LocalDate otherAvailabilityDate = accessStatusOtherBitstream.getAvailabilityDate();
         assertThat("testWithNoPrimaryAndMultipleBitstreams 6", otherAvailabilityDate, equalTo(startDate));
     }
@@ -597,7 +597,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 1", status,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 2", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
@@ -605,7 +605,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 3", bitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         LocalDate bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 4", bistreamAvailabilityDate, equalTo(startDate));
         // Configuration: anonymous
@@ -614,7 +614,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
         status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 5", status,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 6", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
@@ -622,7 +622,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
         bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 7", bitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         bistreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsGuest 8", bistreamAvailabilityDate, equalTo(startDate));
     }
@@ -664,7 +664,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 1", status,
-                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+                equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate availabilityDate = accessStatus.getAvailabilityDate();
         assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 2", availabilityDate);
         // getAccessStatusFromBitstream
@@ -672,7 +672,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_CURRENT_USER);
         String bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 3", bitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.OPEN_ACCESS));
+                equalTo(AccessStatusHelper.OPEN_ACCESS));
         LocalDate bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertNull("testWithEmbargoForCurrentOrAnonymousAsAdmin 4", bitstreamAvailabilityDate);
         // Configuration: anonymous
@@ -680,7 +680,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 itemWithEmbargo, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
         status = accessStatus.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 5", status,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         availabilityDate = accessStatus.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 6", availabilityDate, equalTo(startDate));
         // getAccessStatusFromBitstream
@@ -688,7 +688,7 @@ public class DefaultAccessStatusHelperTest  extends AbstractUnitTest {
                 bitstream, threshold, DefaultAccessStatusHelper.STATUS_FOR_ANONYMOUS);
         bitstreamStatus = accessStatusBitstream.getStatus();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 7", bitstreamStatus,
-                equalTo(DefaultAccessStatusHelper.EMBARGO));
+                equalTo(AccessStatusHelper.EMBARGO));
         bitstreamAvailabilityDate = accessStatusBitstream.getAvailabilityDate();
         assertThat("testWithEmbargoForCurrentOrAnonymousAsAdmin 8", bitstreamAvailabilityDate, equalTo(startDate));
         context.setCurrentUser(currentUser);

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -48,6 +48,8 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
+import org.dspace.access.status.factory.AccessStatusServiceFactory;
+import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.authorize.ResourcePolicy;
 import org.dspace.authorize.factory.AuthorizeServiceFactory;
 import org.dspace.authorize.service.AuthorizeService;
@@ -83,6 +85,10 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
  */
 @SuppressWarnings("deprecation")
 public class XOAI {
+    private static final String ACCESS_STATUS_OPEN_ACCESS = "open.access";
+    private static final String ACCESS_STATUS_EMBARGO = "embargo";
+    private static final String ACCESS_STATUS_RESTRICTED = "restricted";
+
     private static Logger log = LogManager.getLogger(XOAI.class);
 
     // needed because the solr query only returns 10 rows by default
@@ -101,6 +107,8 @@ public class XOAI {
 
     private final AuthorizeService authorizeService;
     private final ItemService itemService;
+    private final AccessStatusService accessStatusService;
+
 
     private final static ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
             .getConfigurationService();
@@ -131,6 +139,7 @@ public class XOAI {
         // Load necessary DSpace services
         this.authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
         this.itemService = ContentServiceFactory.getInstance().getItemService();
+        this.accessStatusService = AccessStatusServiceFactory.getInstance().getAccessStatusService();
         this.extensionPlugins = new DSpace().getServiceManager()
                 .getServicesByType(XOAIExtensionItemCompilePlugin.class);
     }
@@ -142,6 +151,7 @@ public class XOAI {
         // Load necessary DSpace services
         this.authorizeService = AuthorizeServiceFactory.getInstance().getAuthorizeService();
         this.itemService = ContentServiceFactory.getInstance().getItemService();
+        this.accessStatusService = AccessStatusServiceFactory.getInstance().getAccessStatusService();
         this.extensionPlugins = new DSpace().getServiceManager()
                 .getServicesByType(XOAIExtensionItemCompilePlugin.class);
     }
@@ -424,6 +434,9 @@ public class XOAI {
         boolean isPublic = isEmbargoed ? (isIndexed ? isCurrentlyVisible : false) : true;
         doc.addField("item.public", isPublic);
 
+        boolean isOpenAccess = this.isOpenAccess(item);
+        doc.addField("item.isOpenAccess", isOpenAccess);
+
         // if the visibility of the item will change in the future due to an
         // embargo, mark it as such.
 
@@ -528,6 +541,11 @@ public class XOAI {
             }
             context.uncacheEntity(policy);
         }
+        // check for bitstream access status
+        String accessStatus = accessStatusService.getAnonymousAccessStatus(context, item).getStatus();
+        if (accessStatus.equals(ACCESS_STATUS_EMBARGO) || accessStatus.equals(ACCESS_STATUS_RESTRICTED)) {
+            return true;
+        }
         return false;
     }
 
@@ -540,6 +558,16 @@ public class XOAI {
             log.error(ex.getMessage());
         }
         return pub;
+    }
+
+    private boolean isOpenAccess(Item item) {
+        try {
+            String accessStatus = accessStatusService.getAnonymousAccessStatus(context, item).getStatus();
+            return accessStatus.equals(ACCESS_STATUS_OPEN_ACCESS);
+        } catch (SQLException e) {
+            log.error(e.getMessage());
+        }
+        return false;
     }
 
     private static boolean getKnownExplanation(Throwable t) {

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/XOAI.java
@@ -48,6 +48,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
+import org.dspace.access.status.AccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.authorize.ResourcePolicy;
@@ -85,10 +86,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
  */
 @SuppressWarnings("deprecation")
 public class XOAI {
-    private static final String ACCESS_STATUS_OPEN_ACCESS = "open.access";
-    private static final String ACCESS_STATUS_EMBARGO = "embargo";
-    private static final String ACCESS_STATUS_RESTRICTED = "restricted";
-
     private static Logger log = LogManager.getLogger(XOAI.class);
 
     // needed because the solr query only returns 10 rows by default
@@ -543,7 +540,7 @@ public class XOAI {
         }
         // check for bitstream access status
         String accessStatus = accessStatusService.getAnonymousAccessStatus(context, item).getStatus();
-        if (accessStatus.equals(ACCESS_STATUS_EMBARGO) || accessStatus.equals(ACCESS_STATUS_RESTRICTED)) {
+        if (accessStatus.equals(AccessStatusHelper.EMBARGO) || accessStatus.equals(AccessStatusHelper.RESTRICTED)) {
             return true;
         }
         return false;
@@ -563,7 +560,7 @@ public class XOAI {
     private boolean isOpenAccess(Item item) {
         try {
             String accessStatus = accessStatusService.getAnonymousAccessStatus(context, item).getStatus();
-            return accessStatus.equals(ACCESS_STATUS_OPEN_ACCESS);
+            return accessStatus.equals(AccessStatusHelper.OPEN_ACCESS);
         } catch (SQLException e) {
             log.error(e.getMessage());
         }

--- a/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/app/plugins/AccessStatusElementItemCompilePlugin.java
@@ -14,7 +14,7 @@ import java.util.List;
 import com.lyncode.xoai.dataprovider.xml.xoai.Element;
 import com.lyncode.xoai.dataprovider.xml.xoai.Metadata;
 import org.apache.commons.lang3.StringUtils;
-import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.access.status.AccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.content.AccessStatus;
@@ -45,7 +45,7 @@ import org.dspace.xoai.util.ItemUtils;
  * }
  * </pre>
  * Returning Values are based on:
- * @see org.dspace.access.status.DefaultAccessStatusHelper  DefaultAccessStatusHelper
+ * @see org.dspace.access.status.AccessStatusHelper  AccessStatusHelper
  */
 public class AccessStatusElementItemCompilePlugin implements XOAIExtensionItemCompilePlugin {
 
@@ -58,7 +58,7 @@ public class AccessStatusElementItemCompilePlugin implements XOAIExtensionItemCo
             String accessStatusType = accessStatusResult.getStatus();
             LocalDate availabilityDate = accessStatusResult.getAvailabilityDate();
             String embargoFromItem = null;
-            if (accessStatusType == DefaultAccessStatusHelper.EMBARGO && availabilityDate != null) {
+            if (accessStatusType == AccessStatusHelper.EMBARGO && availabilityDate != null) {
                 embargoFromItem = availabilityDate.toString();
             }
 

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceOpenAccessFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceOpenAccessFilter.java
@@ -1,0 +1,59 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.filter;
+
+import java.sql.SQLException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.access.status.factory.AccessStatusServiceFactory;
+import org.dspace.access.status.service.AccessStatusService;
+import org.dspace.content.Item;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.xoai.data.DSpaceItem;
+import org.dspace.xoai.filter.results.SolrFilterResult;
+
+/**
+ * @author Tina Schoenborn (schoenborn at tu-berlin dot de)
+ */
+public class DSpaceOpenAccessFilter extends DSpaceFilter {
+
+    private static final Logger log = LogManager.getLogger(DSpaceOpenAccessFilter.class);
+
+    private static final AccessStatusService accessStatusService =
+        AccessStatusServiceFactory.getInstance().getAccessStatusService();
+
+    private static final HandleService handleService
+        = HandleServiceFactory.getInstance().getHandleService();
+
+    @Override
+    public boolean isShown(DSpaceItem dSpaceItem) {
+        boolean shown = false;
+        try {
+            // If Handle or Item are not found, return false
+            String handle = DSpaceItem.parseHandle(dSpaceItem.getIdentifier());
+            if (handle == null) {
+                return false;
+            }
+            Item item = (Item) handleService.resolveToObject(context, handle);
+            if (item == null) {
+                return false;
+            }
+            shown = accessStatusService.getAnonymousAccessStatus(context, item).getStatus().equals("open.access");
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+        }
+        return shown;
+    }
+
+    @Override
+    public SolrFilterResult buildSolrQuery() {
+        return new SolrFilterResult("item.isOpenAccess:true");
+    }
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceOpenAccessFilter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/filter/DSpaceOpenAccessFilter.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.access.status.AccessStatusHelper;
 import org.dspace.access.status.factory.AccessStatusServiceFactory;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.content.Item;
@@ -45,7 +46,10 @@ public class DSpaceOpenAccessFilter extends DSpaceFilter {
             if (item == null) {
                 return false;
             }
-            shown = accessStatusService.getAnonymousAccessStatus(context, item).getStatus().equals("open.access");
+            shown = accessStatusService
+                .getAnonymousAccessStatus(context, item)
+                .getStatus()
+                .equals(AccessStatusHelper.OPEN_ACCESS);
         } catch (SQLException e) {
             log.error(e.getMessage(), e);
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamAccessStatusLinkRepository.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.access.status.AccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
 import org.dspace.app.rest.model.BitstreamRest;
@@ -57,7 +57,7 @@ public class BitstreamAccessStatusLinkRepository extends AbstractDSpaceRestRepos
             AccessStatusRest accessStatusRest = new AccessStatusRest();
             AccessStatus accessStatus = accessStatusService.getAccessStatus(context, bitstream);
             String status = accessStatus.getStatus();
-            if (status == DefaultAccessStatusHelper.EMBARGO) {
+            if (status == AccessStatusHelper.EMBARGO) {
                 LocalDate availabilityDate = accessStatus.getAvailabilityDate();
                 String embargoDate = availabilityDate.toString();
                 accessStatusRest.setEmbargoDate(embargoDate);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ItemAccessStatusLinkRepository.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
-import org.dspace.access.status.DefaultAccessStatusHelper;
+import org.dspace.access.status.AccessStatusHelper;
 import org.dspace.access.status.service.AccessStatusService;
 import org.dspace.app.rest.model.AccessStatusRest;
 import org.dspace.app.rest.model.ItemRest;
@@ -56,7 +56,7 @@ public class ItemAccessStatusLinkRepository extends AbstractDSpaceRestRepository
             AccessStatusRest accessStatusRest = new AccessStatusRest();
             AccessStatus accessStatus = accessStatusService.getAccessStatus(context, item);
             String status = accessStatus.getStatus();
-            if (status == DefaultAccessStatusHelper.EMBARGO) {
+            if (status == AccessStatusHelper.EMBARGO) {
                 LocalDate availabilityDate = accessStatus.getAvailabilityDate();
                 String embargoDate = availabilityDate.toString();
                 accessStatusRest.setEmbargoDate(embargoDate);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -192,16 +192,16 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
                    .andExpect(status().isOk())
                    .andExpect(xpath("OAI-PMH/responseDate").exists())
                    .andExpect(xpath("OAI-PMH/request/@verb").string("ListSets"))
-                   // Expect two Sets to be returned
-                   .andExpect(xpath("//set").nodeCount(2))
+                   // Expect three Sets to be returned, because open access set should also be present
+                   .andExpect(xpath("//set").nodeCount(3))
                    // First setSpec should start with "com_" (Community)
-                   .andExpect(xpath("(//set/setSpec)[1]").string(startsWith("com_")))
+                   .andExpect(xpath("(//set/setSpec)[2]").string(startsWith("com_")))
                    // First set name should be Community name
-                   .andExpect(xpath("(//set/setName)[1]").string("Parent Community"))
+                   .andExpect(xpath("(//set/setName)[2]").string("Parent Community"))
                    // Second setSpec should start with "col_" (Collection)
-                   .andExpect(xpath("(//set/setSpec)[2]").string(startsWith("col_")))
+                   .andExpect(xpath("(//set/setSpec)[3]").string(startsWith("col_")))
                    // Second set name should be Collection name
-                   .andExpect(xpath("(//set/setName)[2]").string("Child Collection"))
+                   .andExpect(xpath("(//set/setName)[3]").string("Child Collection"))
                    // No resumption token should be returned
                    .andExpect(xpath("//resumptionToken").doesNotExist())
         ;

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -7,6 +7,8 @@
             <!-- Restrict access to hidden items by default -->
             <Filter ref="defaultFilter"/>
 
+            <Set ref="openAccess"/>
+
             <Format ref="oaidc"/>
             <Format ref="mets"/>
             <Format ref="xoai"/>
@@ -502,6 +504,12 @@
             </Definition>
         </Filter>
 
+        <Filter id="openAccessFilter">
+            <Definition>
+                <Custom ref="openAccessCondition"/>
+            </Definition>
+        </Filter>
+
         <!-- This condition determines if an Item has a "dc.type" field
              which contains "Thesis". -->
         <CustomCondition id="thesisDocumentTypeCondition">
@@ -643,6 +651,11 @@
             </Configuration>
         </CustomCondition>
 
+        <!-- This condition determines if an item is an open access publication -->
+        <CustomCondition id="openAccessCondition">
+            <Class>org.dspace.xoai.filter.DSpaceOpenAccessFilter</Class>
+        </CustomCondition>
+
     </Filters>
 
     <Sets>
@@ -660,6 +673,11 @@
             <Spec>rioxx</Spec>
             <Name>Rioxx set</Name>
             <!-- Just an alias -->
+        </Set>
+        <Set id="openAccess">
+            <Spec>open_access</Spec>
+            <Name>Open Access</Name>
+            <Filter ref="openAccessFilter"/>
         </Set>
     </Sets>
 </Configuration>

--- a/dspace/solr/oai/conf/schema.xml
+++ b/dspace/solr/oai/conf/schema.xml
@@ -125,6 +125,8 @@
    <field name="item.lastmodified" type="date" indexed="true" stored="true" multiValued="false" />
    <field name="item.submitter" type="string" indexed="true" stored="true" multiValued="false" />
    <field name="item.deleted" type="boolean" indexed="true" stored="true" multiValued="false" />
+   <!-- items can be public but not open access, eg if primary bitstreams are embargoed or access restricted -->
+   <field name="item.isOpenAccess" type="boolean" indexed="true" stored="true" multiValued="false" />
    <!-- if true, item.public will change in the future due to an embargo being set/lifted -->
    <field name="item.willChangeStatus" type="boolean" indexed="true" stored="true" multiValued="false" />
    <!-- Used in RIOXX OAI context to determine whether an item has files in ORIGINAL Bundle -->


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/13053
* Addresses part of https://github.com/DSpace/DSpace/issues/12858

## Description
This PR adds an open access set on the OAI interface, which is part of the DINI certificate 2025 specification. The DINI spec states "A setSpec set exists that states “open_access” and contains all metadata records of Open Access documents, i.e. the full text is freely available worldwide via a hyperlink." (https://edoc.hu-berlin.de/server/api/core/bitstreams/ff2e9f90-6ddb-4539-906f-2228df6f3960/content, p. 52)

## Instructions for Reviewers
The implementation is based on the usage of `AccessStatusService` which calculates the access status based on bitstream access status policies, so that only those items are considered open access, which have (primary) bitstreams that are open access. 

For the implementation to work, I needed to refactor `DefaultAccessStatusHelper` and `AccessStatusHelper`. I moved the constants that define the String values for `EMBARGO, METADATA_ONLY, OPEN_ACCESS, RESTRICTED, UNKNOWN` one level up. This means they can no longer be overwritten in plugins. The change was needed to be able to easily access these values. It was also a deliberate decision to move them, because I think there is no need to freely define these constants in plugin implementations. Moreover, the values in `DefaultAccessStatusHelper` where accessed before directly in some classes, without checks for the configured plugin. This means there were bugs present in the code for users who picked a different `AccessStatusHelper` plugin. This issue was also addressed in this PR.

### Test this PR:
1. Have several items in your database. Some would need to have an embargo on their (primary or first) bitstreams.
2. Run `dspace oai import -c`
3. Check that there is an open access set in the list http://localhost:8080/server/oai/request?verb=ListSets
4. Make sure the open access set contains only true open access items, where the (primary or first) bitstream is open access.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
