### PR TITLE
[Docker] Update dspace-10_x branch to use the dspace-10_x Docker tags in all Docker scripts (Backend version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # This image will be published as dspace/dspace
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# - note: default tag for branch: dspace/dspace: dspace/dspace:latest
+# - note: default tag for branch: dspace/dspace: dspace/dspace:dspace-10_x
 
 # This Dockerfile uses JDK21 by default.
 # To build with other versions, use "--build-arg JDK_VERSION=[value]"
 ARG JDK_VERSION=21
 # The Docker version tag to build from
-ARG DSPACE_VERSION=latest
+ARG DSPACE_VERSION=dspace-10_x
 # The Docker registry to use for DSpace images. Defaults to "docker.io"
 # NOTE: non-DSpace images are hardcoded to use "docker.io" and are not impacted by this build argument
 ARG DOCKER_REGISTRY=docker.io

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,13 +1,13 @@
 # This image will be published as dspace/dspace-cli
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# - note: default tag for branch: dspace/dspace-cli: dspace/dspace-cli:latest
+# - note: default tag for branch: dspace/dspace-cli: dspace/dspace-cli:dspace-10_x
 
 # This Dockerfile uses JDK21 by default.
 # To build with other versions, use "--build-arg JDK_VERSION=[value]"
 ARG JDK_VERSION=21
 # The Docker version tag to build from
-ARG DSPACE_VERSION=latest
+ARG DSPACE_VERSION=dspace-10_x
 # The Docker registry to use for DSpace images. Defaults to "docker.io"
 # NOTE: non-DSpace images are hardcoded to use "docker.io" and are not impacted by this build argument
 ARG DOCKER_REGISTRY=docker.io

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,7 @@
 # This image will be published as dspace/dspace
 # See https://github.com/DSpace/DSpace/tree/main/dspace/src/main/docker for usage details
 #
-# - note: default tag for branch: dspace/dspace: dspace/dspace:latest-test
+# - note: default tag for branch: dspace/dspace: dspace/dspace:dspace-10_x-test
 #
 # This image is meant for TESTING/DEVELOPMENT ONLY as it deploys the old v6 REST API under HTTP (not HTTPS)
 
@@ -9,7 +9,7 @@
 # To build with other versions, use "--build-arg JDK_VERSION=[value]"
 ARG JDK_VERSION=21
 # The Docker version tag to build from
-ARG DSPACE_VERSION=latest
+ARG DSPACE_VERSION=dspace-10_x
 # The Docker registry to use for DSpace images. Defaults to "docker.io"
 # NOTE: non-DSpace images are hardcoded to use "docker.io" and are not impacted by this build argument
 ARG DOCKER_REGISTRY=docker.io

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -6,7 +6,7 @@ networks:
     external: true
 services:
   dspace-cli:
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-cli:${DSPACE_VER:-dspace-10_x}"
     container_name: dspace-cli
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       # from the host machine. This IP range MUST correspond to the 'dspacenet' subnet defined above.
       proxies__P__trusted__P__ipranges: ${proxies__P__trusted__P__ipranges:-172.23.0}
       LOGGING_CONFIG: ${LOGGING_CONFIG:-/dspace/config/log4j2-container.xml}
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-latest-test}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace:${DSPACE_VER:-dspace-10_x-test}"
     build:
       context: .
       dockerfile: Dockerfile.test
@@ -85,7 +85,7 @@ services:
   # DSpace Solr container
   dspacesolr:
     container_name: dspacesolr
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-solr:${DSPACE_VER:-dspace-10_x}"
     build:
       context: ./dspace/src/main/docker/dspace-solr/
       # Provide path to Solr configs necessary to build Docker image

--- a/dspace/src/main/docker-compose/db.entities.yml
+++ b/dspace/src/main/docker-compose/db.entities.yml
@@ -8,7 +8,7 @@
 
 services:
   dspacedb:
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-dspace-10_x}"
     environment:
       # This SQL is available from https://github.com/DSpace-Labs/AIP-Files/releases/tag/demo-entities-data
       - LOADSQL=${LOADSQL:-https://github.com/DSpace-Labs/AIP-Files/releases/download/demo-entities-data/dspace7-entities-data.sql}

--- a/dspace/src/main/docker-compose/db.restore.yml
+++ b/dspace/src/main/docker-compose/db.restore.yml
@@ -12,7 +12,7 @@
 # This can be used to restore a "dspacedb" container from a pg_dump, or during upgrade to a new version of PostgreSQL.
 services:
   dspacedb:
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-latest}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-postgres-loadsql:${DSPACE_VER:-dspace-10_x}"
     environment:
       # Location where the dump SQL file will be available on the running container
       - LOCALSQL=${LOCALSQL:-/tmp/pgdump.sql}

--- a/dspace/src/main/docker-compose/docker-compose-angular.yml
+++ b/dspace/src/main/docker-compose/docker-compose-angular.yml
@@ -29,7 +29,7 @@ services:
       DSPACE_REST_NAMESPACE: ${DSPACE_REST_NAMESPACE:-/server}
       # Ensure SSR can use the 'dspace' Docker image directly (see docker-compose-rest.yml)
       DSPACE_REST_SSRBASEURL: ${DSPACE_REST_SSRBASEURL:-http://dspace:8080/server}
-    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-latest-dist}"
+    image: "${DOCKER_REGISTRY:-docker.io}/${DOCKER_OWNER:-dspace}/dspace-angular:${DSPACE_VER:-dspace-10_x-dist}"
     ports:
     - published: 4000
       target: 4000

--- a/dspace/src/main/docker/README.md
+++ b/dspace/src/main/docker/README.md
@@ -16,14 +16,14 @@ Caching these Maven dependencies provides a speed increase to all later builds b
 are only downloaded once.
 
 ```
-docker build -t dspace/dspace-dependencies:latest -f Dockerfile.dependencies .
+docker build -t dspace/dspace-dependencies:dspace-10_x -f Dockerfile.dependencies .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
 Admins to our DockerHub repo can manually publish with the following command.
 ```
-docker push dspace/dspace-dependencies:latest
+docker push dspace/dspace-dependencies:dspace-10_x
 ```
 
 ## Dockerfile.test (in root folder)
@@ -34,14 +34,14 @@ This image deploys one webapp to Tomcat running in Docker:
 This image also sets up debugging in Tomcat for development.
 
 ```
-docker build -t dspace/dspace:latest-test -f Dockerfile.test .
+docker build -t dspace/dspace:dspace-10_x-test -f Dockerfile.test .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
 Admins to our DockerHub repo can manually publish with the following command.
 ```
-docker push dspace/dspace:latest-test
+docker push dspace/dspace:dspace-10_x-test
 ```
 
 ## Dockerfile (in root folder)
@@ -51,28 +51,28 @@ This image deploys one DSpace webapp to Tomcat running in Docker:
 1. The DSpace REST API (at `http://localhost:8080/server`)
 
 ```
-docker build -t dspace/dspace:latest -f Dockerfile .
+docker build -t dspace/dspace:dspace-10_x -f Dockerfile .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
 Admins to our DockerHub repo can publish with the following command.
 ```
-docker push dspace/dspace:latest
+docker push dspace/dspace:dspace-10_x
 ```
 
 ## Dockerfile.cli (in root folder)
 
 This Dockerfile builds a DSpace CLI (command line interface) image, which can be used to run DSpace's commandline tools via Docker.
 ```
-docker build -t dspace/dspace-cli:latest -f Dockerfile.cli .
+docker build -t dspace/dspace-cli:dspace-10_x -f Dockerfile.cli .
 ```
 
 This image is built *automatically* after each commit is made to the `main` branch.
 
 Admins to our DockerHub repo can publish with the following command.
 ```
-docker push dspace/dspace-cli:latest
+docker push dspace/dspace-cli:dspace-10_x
 ```
 
 ## ./dspace-postgres-loadsql/Dockerfile
@@ -87,18 +87,18 @@ This image is built *automatically* after each commit is made to the `main` bran
 How to build manually:
 ```
 cd dspace/src/main/docker/dspace-postgres-loadsql
-docker build -t dspace/dspace-postgres-loadsql:latest .
+docker build -t dspace/dspace-postgres-loadsql:dspace-10_x .
 ```
 
 It is also possible to change the version of PostgreSQL or the PostgreSQL user's password during the build:
 ```
 cd dspace/src/main/docker/dspace-postgres-loadsql
-docker build -t dspace/dspace-postgres-loadsql:latest --build-arg POSTGRES_VERSION=17 --build-arg POSTGRES_PASSWORD=mypass .
+docker build -t dspace/dspace-postgres-loadsql:dspace-10_x --build-arg POSTGRES_VERSION=17 --build-arg POSTGRES_PASSWORD=mypass .
 ```
 
 Admins to our DockerHub repo can (manually) publish with the following command.
 ```
-docker push dspace/dspace-postgres-loadsql:latest
+docker push dspace/dspace-postgres-loadsql:dspace-10_x
 ```
 
 ## ./dspace-shibboleth/Dockerfile


### PR DESCRIPTION
## References
* Backend equivalent of https://github.com/DSpace/dspace-angular/pull/6072

## Description
Similar to https://github.com/DSpace/dspace-angular/pull/6072, this PR updates the Docker scripts in our `dspace-10_x` branch to use the appropriate `dspace-10_x` Docker images.  Currently, all these scripts still use the `latest` Docker tag, which references `main`.

(We likely haven't noticed this until now because `main` and `dspace-10_x` are still quite similar)

## Instructions for Reviewers
* Assuming all tests pass, this will be merged immediately.  This is an obvious flaw in our Docker scripts that should have been fixed as soon as we created the `dspace-10_x` maintenance branch.