### PR TITLE
Codestyle: cleanup @Autowired from single constructors

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/service/impl/ItemReferenceResolverServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/service/impl/ItemReferenceResolverServiceImpl.java
@@ -13,7 +13,6 @@ import org.dspace.authority.service.ItemReferenceResolver;
 import org.dspace.authority.service.ItemReferenceResolverService;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Implementation of {@link ItemReferenceResolverService} that delegate the
@@ -25,10 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public record ItemReferenceResolverServiceImpl(List<ItemReferenceResolver> resolvers)
     implements ItemReferenceResolverService {
-
-    @Autowired
-    public ItemReferenceResolverServiceImpl {
-    }
 
     @Override
     public void resolveReferences(Context context, Item item) {

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefConnector.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefConnector.java
@@ -34,7 +34,6 @@ import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -61,7 +60,6 @@ public class CrossRefConnector implements DOIConnector {
     private String depositorEmail;
     private String SCHEME = "https";
 
-    @Autowired
     public CrossRefConnector(ItemService itemService,
             DOIService doiService,
             DOIResolverClient doiResolverClient,

--- a/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefPayloadService.java
+++ b/dspace-api/src/main/java/org/dspace/identifier/doi/crossref/CrossRefPayloadService.java
@@ -27,7 +27,6 @@ import org.dspace.services.ConfigurationService;
 import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +44,6 @@ public class CrossRefPayloadService {
     private final String crosswalkName;
     private final String institution;
 
-    @Autowired
     CrossRefPayloadService(PluginService pluginService,
                            ConfigurationService configurationService,
                            @Value("${identifier.doi.crossref.crosswalkname:Crossref}") String crosswalkName) {

--- a/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/ClientInfoServiceImpl.java
@@ -22,7 +22,6 @@ import org.dspace.core.Utils;
 import org.dspace.service.ClientInfoService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.statistics.util.IPTable;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Implementation of {@link ClientInfoService} that can provide information on DSpace client requests
@@ -44,7 +43,6 @@ public class ClientInfoServiceImpl implements ClientInfoService {
      */
     private final IPTable trustedProxies;
 
-    @Autowired(required = true)
     public ClientInfoServiceImpl(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.trustedProxies = parseTrustedProxyRanges();

--- a/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/SpiderDetectorServiceImpl.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.service.ClientInfoService;
 import org.dspace.services.ConfigurationService;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * SpiderDetectorServiceImpl is used to find IP's that are spiders...
@@ -58,7 +57,6 @@ public class SpiderDetectorServiceImpl implements SpiderDetectorService {
      */
     private IPTable table = null;
 
-    @Autowired(required = true)
     public SpiderDetectorServiceImpl(ConfigurationService configurationService, ClientInfoService clientInfoService) {
         this.configurationService = configurationService;
         this.clientInfoService = clientInfoService;

--- a/dspace-api/src/main/java/org/dspace/validation/service/impl/ValidationServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/validation/service/impl/ValidationServiceImpl.java
@@ -22,7 +22,6 @@ import org.dspace.validation.GlobalSubmissionValidator;
 import org.dspace.validation.SubmissionStepValidator;
 import org.dspace.validation.model.ValidationError;
 import org.dspace.validation.service.ValidationService;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Implementation of {@link ValidationService} that cycle on all the
@@ -40,7 +39,6 @@ public class ValidationServiceImpl implements ValidationService {
 
     private SubmissionConfigReader submissionConfigReader;
 
-    @Autowired
     public ValidationServiceImpl(List<SubmissionStepValidator> stepValidators,
                                  List<GlobalSubmissionValidator> globalValidators) {
         this.stepValidators = stepValidators;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/BitstreamRestRepository.java
@@ -83,7 +83,6 @@ public class BitstreamRestRepository extends DSpaceObjectRestRepository<Bitstrea
     @Autowired
     private ObjectMapper mapper;
 
-    @Autowired
     public BitstreamRestRepository(BitstreamService dsoService) {
         super(dsoService);
         this.bs = dsoService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ConfigurationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ConfigurationRestRepository.java
@@ -14,7 +14,6 @@ import org.dspace.app.rest.exception.RepositoryMethodNotImplementedException;
 import org.dspace.app.rest.model.PropertyRest;
 import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -30,7 +29,6 @@ public class ConfigurationRestRepository extends DSpaceRestRepository<PropertyRe
     private ConfigurationService configurationService;
     private List<String> exposedProperties;
 
-    @Autowired
     public ConfigurationRestRepository(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.exposedProperties = Arrays.asList(configurationService.getArrayProperty("rest.properties.exposed"));

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/GroupRestRepository.java
@@ -50,7 +50,6 @@ public class GroupRestRepository extends DSpaceObjectRestRepository<Group, Group
     @Autowired
     private ObjectMapper mapper;
 
-    @Autowired
     GroupRestRepository(GroupService dsoService) {
         super(dsoService);
         this.gs = dsoService;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SiteRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SiteRestRepository.java
@@ -19,7 +19,6 @@ import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Site;
 import org.dspace.content.service.SiteService;
 import org.dspace.core.Context;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -36,7 +35,6 @@ public class SiteRestRepository extends DSpaceObjectRestRepository<Site, SiteRes
 
     private final SiteService sitesv;
 
-    @Autowired
     public SiteRestRepository(SiteService dsoService) {
         super(dsoService);
         this.sitesv = dsoService;

--- a/dspace-services/src/main/java/org/dspace/services/events/SystemEventService.java
+++ b/dspace-services/src/main/java/org/dspace/services/events/SystemEventService.java
@@ -22,7 +22,6 @@ import org.dspace.services.model.Event;
 import org.dspace.services.model.Event.Scope;
 import org.dspace.services.model.EventListener;
 import org.dspace.services.model.RequestInterceptor;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * This is a placeholder until we get a real event service going.
@@ -43,7 +42,6 @@ public final class SystemEventService implements EventService {
     private final RequestService requestService;
     private EventRequestInterceptor requestInterceptor;
 
-    @Autowired(required = true)
     public SystemEventService(RequestService requestService) {
         if (requestService == null) {
             throw new IllegalArgumentException("requestService and all inputs must not be null");


### PR DESCRIPTION
## References
* _Partially_ improves #9766

## Description
Spring 4.3+ automatically handles `@Autowired` annotations on beans with a single constructor

See also: https://error-prone.picnic.tech/bugpatterns/AutowiredConstructor/

This PR was inspired by testing some PRs--I noticed that sometimes contributors are adding unnecessary @Autowired. Per [Spring Framework 4.3 documentation](https://docs.spring.io/spring-framework/docs/4.3.0.RELEASE/spring-framework-reference/html/new-in-4.3.html):
> It is no longer necessary to specify the @Autowired annotation if the target bean only defines one constructor.

## Instructions for Reviewers
**Changes in this PR:**
- Removed `@Autowired` from all single-constructor beans
- Removed no-arg constructor from `ItemReferenceResolverServiceImpl` as Records do not require one

**Testing:** Build, tests passes. **No behavior changes expected**

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
