### PR TITLE
OrcidRestConnector: fix correct HTTP success status code validation #11674

### DIFF
--- a/dspace-api/src/main/java/org/dspace/external/OrcidRestConnector.java
+++ b/dspace-api/src/main/java/org/dspace/external/OrcidRestConnector.java
@@ -76,7 +76,7 @@ public class OrcidRestConnector {
 
     private boolean isSuccessful(HttpResponse response) {
         int statusCode = getStatusCode(response);
-        return statusCode >= 200 || statusCode <= 299;
+        return statusCode >= 200 && statusCode <= 299;
     }
 
     private int getStatusCode(HttpResponse response) {


### PR DESCRIPTION
## References
* Follow-up fix to #11674 

## Description

This PR fixes the [Import a person from an external source](https://demo.dspace.org/import-external?entity=Person&sourceId=orcid&query=) error message:

Before
<img width="2318" height="527" alt="screenshot_20260810141249" src="https://github.com/user-attachments/assets/f4a43262-3b47-47c4-b091-d318a9f1ffc8" />

After
<img width="1991" height="338" alt="screenshot_20260810141336" src="https://github.com/user-attachments/assets/9c059583-5cbd-4a97-add9-3c5a05cd68a1" />

---

Currently, the `OrcidRestConnector#isSuccessful` returns **true** for **all** HTTP status codes. Error responses were incorrectly treated as successful, causing `UnmarshalException` when the connector tried to parse error responses as XML

I changed OR to AND to correctly return true only for 2xx responses

## Instructions for Reviewers
This is perfectly safe to merge as-is

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
