### PR TITLE
Return consistent 404 responses for unknown Items and Bitstreams

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -51,6 +51,7 @@ import org.dspace.app.rest.model.hateoas.HALResource;
 import org.dspace.app.rest.model.patch.Patch;
 import org.dspace.app.rest.repository.DSpaceRestRepository;
 import org.dspace.app.rest.repository.LinkRestRepository;
+import org.dspace.app.rest.repository.ReloadableEntityObjectRepository;
 import org.dspace.app.rest.utils.RestRepositoryUtils;
 import org.dspace.app.rest.utils.Utils;
 import org.dspace.authorize.AuthorizeException;
@@ -217,6 +218,10 @@ public class RestResourceController implements InitializingBean {
     private <ID extends Serializable> HALResource<RestAddressableModel> findOneInternal(String apiCategory,
                                                                                            String model, ID id) {
         DSpaceRestRepository<RestAddressableModel, ID> repository = utils.getResourceRepository(apiCategory, model);
+        if (repository instanceof ReloadableEntityObjectRepository<?, ?> reloadableRepository &&
+            !reloadableRepository.getPKClass().isInstance(id)) {
+            throw new ResourceNotFoundException(apiCategory + "." + model + " with id: " + id + " not found");
+        }
         Optional<RestAddressableModel> modelObject = Optional.empty();
         try {
             modelObject = repository.findById(id);

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/security/BitstreamMetadataReadPermissionEvaluatorPlugin.java
@@ -55,16 +55,18 @@ public class BitstreamMetadataReadPermissionEvaluatorPlugin extends RestObjectPe
     @Override
     public boolean hasPermission(Authentication authentication, Serializable targetId, String targetType,
                                  Object permission) {
-        if (permission.toString().equalsIgnoreCase(METADATA_READ_PERMISSION) && targetId != null) {
+        if (permission.toString().equalsIgnoreCase(METADATA_READ_PERMISSION) && targetId != null &&
+            Constants.typeText[Constants.BITSTREAM].equalsIgnoreCase(targetType)) {
             Request request = requestService.getCurrentRequest();
             Context context = ContextUtil.obtainContext(request.getHttpServletRequest());
 
             try {
                 UUID dsoUuid = UUID.fromString(targetId.toString());
                 DSpaceObject dso = dspaceObjectUtil.findDSpaceObject(context, dsoUuid);
-                if (dso instanceof Bitstream) {
-                    return this.metadataReadPermissionOnBitstream(context, (Bitstream) dso);
+                if (!(dso instanceof Bitstream)) {
+                    return true; // Let downstream REST layer handle with 404
                 }
+                return this.metadataReadPermissionOnBitstream(context, (Bitstream) dso);
             } catch (SQLException e) {
                 log.error(e::getMessage, e);
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestRepositoryIT.java
@@ -1014,6 +1014,38 @@ public class BitstreamRestRepositoryIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void findOneNonexistentUuidAnonymousReturnsNotFound() throws Exception {
+        getClient().perform(get("/api/core/bitstreams/" + UUID.randomUUID()))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findOneMalformedUuidAnonymousReturnsNotFound() throws Exception {
+        getClient().perform(get("/api/core/bitstreams/not-a-uuid"))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findOneItemUuidAnonymousReturnsNotFound() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+                                                 .withName("Collection")
+                                                 .build();
+        Item item = ItemBuilder.createItem(context, collection)
+                               .withTitle("Item")
+                               .build();
+
+        context.restoreAuthSystemState();
+
+        getClient().perform(get("/api/core/bitstreams/" + item.getID()))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
     public void deleteOne() throws Exception {
 
         //We turn off the authorization system in order to create the structure as defined below

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ItemRestRepositoryIT.java
@@ -641,6 +641,18 @@ public class ItemRestRepositoryIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void findOneNonexistentUuidAnonymousReturnsNotFound() throws Exception {
+        getClient().perform(get("/api/core/items/" + UUID.randomUUID()))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findOneMalformedUuidAnonymousReturnsNotFound() throws Exception {
+        getClient().perform(get("/api/core/items/not-a-uuid"))
+                   .andExpect(status().isNotFound());
+    }
+
+    @Test
     public void withdrawPatchTest() throws Exception {
         context.turnOffAuthorisationSystem();
 


### PR DESCRIPTION
## References

Fixes #10099

Related to DSpace/RestContract#375

## Description

This PR makes the Item and Bitstream endpoints return `404 Not Found` consistently when:

- the identifier is not a valid UUID, for example `not-a-uuid`;
- the identifier is a valid UUID, but no object with that UUID exists;
- an Item UUID is requested from the Bitstream endpoint.

The identifier type is checked before calling the security-proxied repository. The Bitstream metadata permission evaluator also lets missing or non-Bitstream objects reach the repository, where they are handled as `404 Not Found`.

Integration tests were added for these cases.

## Instructions for Reviewers

The following anonymous requests should return `404 Not Found`:

| Endpoint | Identifier |
|---|---|
| `/api/core/items/{id}` | a syntactically valid UUID that does not identify an existing object |
| `/api/core/items/{id}` | a malformed identifier such as `not-a-uuid` |
| `/api/core/bitstreams/{id}` | a syntactically valid UUID that does not identify an existing object |
| `/api/core/bitstreams/{id}` | a malformed identifier such as `not-a-uuid` |
| `/api/core/bitstreams/{id}` | the UUID of an existing Item |

For an existing Item or Bitstream whose metadata is access-restricted by DSpace resource policies or an embargo, verify that:

- an anonymous request returns `401 Unauthorized`;
- an authenticated user without sufficient permissions receives `403 Forbidden`;
- an authorized user can still retrieve the resource.

## Checklist

- [x] My PR is created against the `main` branch.
- [x] My PR is small in size.
- [x] My PR follows the existing DSpace coding conventions.
- [x] My PR passes Checkstyle validation.
- [x] No new or modified public API requires additional Javadoc.
- [x] My PR includes integration tests covering the reported bug and relevant security regressions.
- [x] My PR includes instructions and expected responses for reviewers.
- [x] This PR adds no libraries or dependencies.
- [x] A separate REST Contract PR has been opened and linked above.
- [x] This PR adds no configuration.
- [x] This PR links and closes the corresponding issue.