### PR TITLE
Improvements for Solr query syntax in AuthorityValueService

### DIFF
--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -206,7 +206,8 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
         List<AuthorityValue> findings = new ArrayList<AuthorityValue>();
         try {
             SolrQuery solrQuery = new SolrQuery();
-            solrQuery.setQuery(filtered(queryString));
+            solrQuery.setQuery(queryString);
+            solrQuery.addFilterQuery("-deleted:true");
             log.debug("AuthorityValueFinder makes the query: " + queryString);
             QueryResponse queryResponse = SolrAuthority.getSearchService().search(solrQuery);
             if (queryResponse != null && queryResponse.getResults() != null && 0 < queryResponse.getResults()
@@ -222,14 +223,6 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
         }
 
         return findings;
-    }
-
-    protected String filtered(String queryString) throws InstantiationException, IllegalAccessException {
-        String instanceFilter = "-deleted:true";
-        if (StringUtils.isNotBlank(instanceFilter)) {
-            queryString += " AND " + instanceFilter;
-        }
-        return queryString;
     }
 
     protected String fieldParameter(String schema, String element, String qualifier) {

--- a/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/authority/AuthorityValueServiceImpl.java
@@ -130,7 +130,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
 
     @Override
     public List<AuthorityValue> findByValue(String field, String value) {
-        String queryString = "value:" + value + " AND field:" + field;
+        String queryString = "value:(" + value + ") AND field:" + field;
         return find(queryString);
     }
 
@@ -158,7 +158,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
     public List<AuthorityValue> findByName(String schema, String element, String qualifier,
                                            String name) {
         String field = fieldParameter(schema, element, qualifier);
-        String queryString = "first_name:" + name + " OR last_name:" + name + " OR name_variant:" + name + " AND " +
+        String queryString = "(first_name:" + name + " OR last_name:" + name + " OR name_variant:" + name + ") AND " +
             "field:" + field;
         return find(queryString);
     }
@@ -167,7 +167,7 @@ public class AuthorityValueServiceImpl implements AuthorityValueService {
     public List<AuthorityValue> findByAuthorityMetadata(String schema, String element,
                                                         String qualifier, String value) {
         String field = fieldParameter(schema, element, qualifier);
-        String queryString = "all_Labels:" + value + " AND field:" + field;
+        String queryString = "all_labels:(" + value + ") AND field:" + field;
         return find(queryString);
     }
 


### PR DESCRIPTION
## References
None

## Description
This PR fixes Solr query syntax with additional parentheses to ensure proper query grouping and operator precedence. Additionally, it moves part of the query to the filterQuery for better performance.

## Instructions for Reviewers

Summary of changes in this PR:

1. `findByValue()`
  - How Solr saw it before: `value:John OR all_labels:Doe AND field:dc_contributor_author`  
    - a OR (b AND c)
    - so it matched either all Johns, or Does having field dc.contributor.author
  - After: `value:(John Doe) AND field:dc_contributor_author`
    - a AND b
2. `findByName()`
  - How Solr saw it before: `first_name:John OR last_name:Smith OR name_variant:Johnny AND field:dc_contributor_author`
    - a OR b OR C
    - so it could match all Johns from any field, or Johnny from the dc_contributor_author field
  - After: `(first_name:John OR last_name:Smith OR name_variant:Johnny) AND field:dc_contributor_author`
    - a AND b
    - so it matches only from field:dc_contributor_author
3. `findByAuthorityMetadata()`
  - How Solr saw it before: `undefined field all_Labels`
  - After: `correctly executes query`
4. `find()`
  - Moved `-deleted:true` from query to a filterQuery for performance improvement 

### How to Test

It is advised to test the changes with knowledge of how authorities work in DSpace and where they are used

The query changes can also be tested directly in Solr in the `authority` core

The method `findByValue()` is used in the `metadata-import` script (CSV import). Both `findByName()` and `findByAuthorityMetadata()` are currently unused. Their common method, `find()`, is utilized in multiple places:
- `index-authority` script
- `update-authorities` script
- `metadata-import` script

The fastest way to test would be to increase the log level to DEBUG for `org.dspace.authority.AuthorityValueServiceImpl` and look for messages starting with `AuthorityValueFinder`

## Checklist
- [X] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [X] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [X] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [X] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [X] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [X] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [X] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [X] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [X] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [X] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [X] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
