### PR TITLE
Fix Europe PMC keyword metadata mapping

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/PubmedEuropeMetadataSourceServiceIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/PubmedEuropeMetadataSourceServiceIT.java
@@ -117,6 +117,8 @@ public class PubmedEuropeMetadataSourceServiceIT extends AbstractLiveImportInteg
         MetadatumDTO type = createMetadatumDTO("dc", "type", null, "Research Support, Non-U.S. Gov't");
         MetadatumDTO type2 = createMetadatumDTO("dc", "type", null, "research-article");
         MetadatumDTO type3 = createMetadatumDTO("dc", "type", null, "Journal Article");
+        MetadatumDTO subject = createMetadatumDTO("dc", "subject", null, "Ostracoda");
+        MetadatumDTO subject2 = createMetadatumDTO("dc", "subject", null, "Paleontology");
 
         MetadatumDTO issn = createMetadatumDTO("dc", "identifier", "issn", "0962-8452");
         MetadatumDTO pmid = createMetadatumDTO("dc", "identifier", "other", "21733903");
@@ -147,6 +149,8 @@ public class PubmedEuropeMetadataSourceServiceIT extends AbstractLiveImportInteg
         metadatums.add(type);
         metadatums.add(type2);
         metadatums.add(type3);
+        metadatums.add(subject);
+        metadatums.add(subject2);
         metadatums.add(description);
         metadatums.add(issn);
         metadatums.add(pmid);

--- a/dspace-server-webapp/src/test/resources/org/dspace/app/rest/pubmedeurope-test.xml
+++ b/dspace-server-webapp/src/test/resources/org/dspace/app/rest/pubmedeurope-test.xml
@@ -82,6 +82,10 @@
                 <pubType>research-article</pubType>
                 <pubType>Journal Article</pubType>
             </pubTypeList>
+            <keywordList>
+                <keyword>Ostracoda</keyword>
+                <keyword>Paleontology</keyword>
+            </keywordList>
             <meshHeadingList>
                 <meshHeading>
                     <majorTopic_YN>N</majorTopic_YN>

--- a/dspace/config/spring/api/pubmedeurope-integration.xml
+++ b/dspace/config/spring/api/pubmedeurope-integration.xml
@@ -78,7 +78,7 @@
     </bean>
 
     <bean id="pubEuKeywordContrib" class="org.dspace.importer.external.metadatamapping.contributor.SimpleXpathMetadatumContributor">
-        <property name="field" ref="pubeu.type"/>
+        <property name="field" ref="pubeu.keyword"/>
         <property name="query" value="keywordList/keyword"/>
         <property name="prefixToNamespaceMapping" ref="pubEuPrefixToNamespaceMapping"/>
     </bean>        


### PR DESCRIPTION
## References

Fixes #12946

## Description

Europe PMC keywords were routed through `pubeu.type`, which stored them as `dc.type`. This changes the contributor mapping to use the existing `pubeu.keyword` field so imported keywords are stored as `dc.subject`.

## Instructions for Reviewers

Changes in this PR:

* Route `pubEuKeywordContrib` through `pubeu.keyword`.
* Extend the integration fixture with two keywords and verify that both are imported as `dc.subject`.

To test the change, run:

```sh
mvn install -DskipIntegrationTests=false -Dit.test=org.dspace.app.rest.PubmedEuropeMetadataSourceServiceIT -DfailIfNoTests=false
```

Before the mapping change, the regression failed because `Ostracoda` was imported as `dc.type`. With the fix applied, both integration tests pass and the 15-module reactor completes with `BUILD SUCCESS`, including XML, license, and Checkstyle validation.

## Checklist

- [x] This PR targets the `main` branch.
- [x] The change is small and focused.
- [x] Checkstyle validation passes.
- [x] The fix includes an updated integration test.
- [x] Testing instructions and results are included above.
- [x] No dependencies or REST API endpoints are changed.
- [x] The related issue is linked.