### PR TITLE
Fix #12245: ISO 639-1 language codes unsearchable due to stopwords

### DIFF
--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -6914,4 +6914,61 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 "$._embedded.searchResult._embedded.objects[0].hitHighlights['dc.title']",
                 contains("This is a <a>test</a> <em>title</em>")));
     }
+
+    /**
+     * Regression test for DSpace/DSpace#12245: ISO 639-1 language codes that are also English stopwords
+     * ("it", "no", ...) must stay findable through fielded queries on dc.language.iso and dcterms.language,
+     * which the search schema routes past the stopword-filtered "text" chain. Unfielded search keeps its
+     * stopword filtering.
+     */
+    @Test
+    public void discoverSearchObjectsDontUseStopWordsForCertainFields() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity)
+                .withName("Collection 1")
+                .build();
+        ItemBuilder.createItem(context, col1)
+                .withTitle("Public item is it ?")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald")
+                .withSubject("ExtraEntry")
+                .withLanguage("it")
+                .build();
+        ItemBuilder.createItem(context, col1)
+                .withTitle("Public item with a dcterms language")
+                .withIssueDate("2017-10-18")
+                .withMetadata("dcterms", "language", null, "no")
+                .build();
+        context.restoreAuthSystemState();
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // A normal / full-text search will not find the item if you just give a stop-word query value
+        getClient(adminToken)
+                .perform(get("/api/discover/search/objects").param("query", "it"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type", is("discover")))
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 0, 0)
+                )));
+
+        // dc.language.iso and dcterms.language are configured differently to other dynamic fields, to not
+        // use stop words as they themselves contain abbreviations or identifiers and not large searchable text entries
+        getClient(adminToken)
+                .perform(get("/api/discover/search/objects").param("query", "dc.language.iso:it"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type", is("discover")))
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 1)
+                )));
+        getClient(adminToken)
+                .perform(get("/api/discover/search/objects").param("query", "dcterms.language:no"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.type", is("discover")))
+                .andExpect(jsonPath("$._embedded.searchResult.page", is(
+                        PageMatcher.pageEntryWithTotalPagesAndElements(0, 20, 1, 1)
+                )));
+    }
 }

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -69,8 +69,14 @@
          These fields must NOT pass through the stopword-filtered "text" chain:
          eight valid ISO 639-1 codes (an, as, be, is, it, no, or, to) are
          English stopwords, so values like dc.language.iso=it are dropped at
-         index AND query time (DSpace/DSpace#12245). -->
-    <fieldType name="text_identifier" class="solr.TextField" omitNorms="true" positionIncrementGap="100">
+         index AND query time (DSpace/DSpace#12245).
+         Norms are kept on purpose (the TextField default): these fields used to
+         fall through the "*" dynamicField, so existing cores already hold them
+         with norms, and Lucene 9 refuses to change omitNorms for an existing
+         field at index time. Keeping the default lets an existing core keep
+         indexing after this change; a reindex is only needed to make the
+         affected codes searchable. -->
+    <fieldType name="text_identifier" class="solr.TextField" positionIncrementGap="100">
         <analyzer>
             <tokenizer class="solr.KeywordTokenizerFactory"/>
             <filter class="solr.TrimFilterFactory"/>

--- a/dspace/solr/search/conf/schema.xml
+++ b/dspace/solr/search/conf/schema.xml
@@ -65,6 +65,19 @@
         Duplicate tokens at the same position (which may result from Stemmed Synonyms or
         WordDelim parts) are removed.
         -->
+    <!-- Analysis chain for coded metadata values (language codes, identifiers).
+         These fields must NOT pass through the stopword-filtered "text" chain:
+         eight valid ISO 639-1 codes (an, as, be, is, it, no, or, to) are
+         English stopwords, so values like dc.language.iso=it are dropped at
+         index AND query time (DSpace/DSpace#12245). -->
+    <fieldType name="text_identifier" class="solr.TextField" omitNorms="true" positionIncrementGap="100">
+        <analyzer>
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.TrimFilterFactory"/>
+            <filter class="org.apache.lucene.analysis.icu.ICUFoldingFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
    	<fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
@@ -345,6 +358,11 @@
     <dynamicField name="*_dt" type="date" indexed="true" stored="true" multiValued="false" omitNorms="true"  docValues="true"/>
 
     <!--Used for matching on all other fields -->
+    <!-- Coded fields routed away from the stopword-filtered catch-all (#12245).
+         Explicit declarations take precedence over the dynamicField below. -->
+    <field name="dc.language.iso" type="text_identifier" indexed="true" stored="true" multiValued="true"/>
+    <field name="dcterms.language" type="text_identifier" indexed="true" stored="true" multiValued="true"/>
+
     <dynamicField name="*" type="text" multiValued="true"/>
 
     <!-- Leftovers from sample schema.  Are these used? -->


### PR DESCRIPTION
## References
* Fixes #12245

## Description
Fielded search on `dc.language.iso` / `dcterms.language` returns zero results for the eight ISO 639-1 codes that are also English stopwords (`an`, `as`, `be`, `is`, `it`, `no`, `or`, `to`). These fields fall through the catch-all `*` dynamicField into the stopword-filtered `text` type, so the value is dropped at index and query time.

## Instructions for Reviewers
List of changes in this PR:
* new `text_identifier` field type in the search core schema: KeywordTokenizer + TrimFilter + ICUFoldingFilter, no stopwords, no stemming
* explicit `<field>` declarations for `dc.language.iso` and `dcterms.language`, which take precedence over the `*` dynamicField

This follows @kshepherd's suggestion in the issue thread: a dedicated type for coded fields rather than changing the shared `text` chain. Unfielded search is unchanged, since `copyField * -> search_text` still receives these values. A discovery reindex is required to pick up the type change.

To verify:
1. index an item with `dc.language.iso = it`
2. before this change: the query `dc.language.iso:it` finds nothing, while `dc.language.iso:en` works
3. after this change and a reindex: all eight codes match their items, `dc.language.iso:IT` also matches (ICU folding), and a title search for "the" still returns nothing, so stopword filtering for text fields is intact

I verified this on a standalone Solr 8.11.4 core loaded with this exact schema: each of the eight codes went from 0 hits to 1 with one test item per code, and the checks above all pass. I can add a discovery integration test if you'd like one for this; happy to follow whatever pattern you prefer for schema-level regressions.

The same mechanism affects any other coded metadata values that collide with stopwords; this PR deliberately only routes the two language fields from the issue. Extending the list (e.g. `dc.identifier.issn`, `dcterms.spatial`) could be a follow-up if there's interest.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. (No Java code changes; schema-only.)
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests**. (Manual verification described above; will add an integration test on request.)
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
