### PR TITLE
fix(#11201) Sort Community/Collection findAll(limit, offset) by title and UUID

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CollectionDAOImpl.java
@@ -87,7 +87,7 @@ public class CollectionDAOImpl extends AbstractHibernateDSODAO<Collection> imple
                                 "from c.metadata internal " +
                                 "where internal.metadataField = :sortField and" +
                                 " internal.dSpaceObject = c)" +
-                                " ORDER BY LOWER(CAST(title.value as string))");
+                                " ORDER BY LOWER(CAST(title.value as string)), c.id");
         Query hibernateQuery = createQuery(context, query.toString());
         if (offset != null) {
             hibernateQuery.setFirstResult(offset);

--- a/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
+++ b/dspace-api/src/main/java/org/dspace/content/dao/impl/CommunityDAOImpl.java
@@ -73,7 +73,7 @@ public class CommunityDAOImpl extends AbstractHibernateDSODAO<Community> impleme
                                                 "from c.metadata internal " +
                                                 "where internal.metadataField = :sortField and" +
                                                     " internal.dSpaceObject = c)" +
-                                " ORDER BY LOWER(CAST(title.value as string))");
+                                " ORDER BY LOWER(CAST(title.value as string)), c.id");
         Query query = createQuery(context, queryBuilder.toString());
         if (offset != null) {
             query.setFirstResult(offset);

--- a/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/oai/OAIpmhIT.java
@@ -9,6 +9,7 @@
 package org.dspace.app.oai;
 
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -19,8 +20,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
 
+import java.io.StringReader;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
 
 import com.lyncode.xoai.dataprovider.core.XOAIManager;
 import com.lyncode.xoai.dataprovider.exceptions.ConfigurationException;
@@ -29,6 +38,7 @@ import com.lyncode.xoai.dataprovider.services.impl.BaseDateProvider;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.Configuration;
 import com.lyncode.xoai.dataprovider.xml.xoaiconfig.ContextConfiguration;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.util.XMLUtils;
 import org.dspace.builder.CollectionBuilder;
 import org.dspace.builder.CommunityBuilder;
 import org.dspace.content.Community;
@@ -44,6 +54,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
 
 /**
  * Integration test to verify the /oai endpoint is responding as a valid OAI-PMH endpoint.
@@ -277,5 +293,74 @@ public class OAIpmhIT extends AbstractControllerIntegrationTest {
      */
     private XOAIManager createMockXOAIManager(Configuration xoaiConfig) throws ConfigurationException {
         return new XOAIManager(filterResolver, resourceResolver, xoaiConfig);
+    }
+
+    /**
+     * Calls ListSets repeatedly, following the resumptionToken across every page, and returns
+     * every setSpec returned (in the order received). Used to verify pagination correctness
+     * when many Sets share the same title (see DSpace/DSpace#11201).
+     */
+    private List<String> listAllSetSpecsAcrossPages(Configuration xoaiConfig) throws Exception {
+        doReturn(createMockXOAIManager(xoaiConfig)).when(xoaiManagerResolver).getManager();
+
+        List<String> allSetSpecs = new ArrayList<>();
+        String resumptionToken = null;
+
+        DocumentBuilderFactory factory = XMLUtils.getDocumentBuilderFactory();
+        factory.setNamespaceAware(true);
+        XPath xpath = XPathFactory.newInstance().newXPath();
+
+        do {
+            MockHttpServletRequestBuilder request = get(DEFAULT_CONTEXT).param("verb", "ListSets");
+            if (resumptionToken != null && !resumptionToken.isEmpty()) {
+                request = get(DEFAULT_CONTEXT).param("verb", "ListSets")
+                                            .param("resumptionToken", resumptionToken);
+            }
+
+            String xml = getClient().perform(request)
+                                    .andExpect(status().isOk())
+                                    .andReturn().getResponse().getContentAsString();
+
+            Document doc = factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+
+            NodeList setSpecNodes = (NodeList) xpath.evaluate(
+                "//*[local-name()='set']/*[local-name()='setSpec']", doc, XPathConstants.NODESET);
+            for (int i = 0; i < setSpecNodes.getLength(); i++) {
+                allSetSpecs.add(setSpecNodes.item(i).getTextContent());
+            }
+
+            Node tokenNode = (Node) xpath.evaluate(
+                "//*[local-name()='resumptionToken']", doc, XPathConstants.NODE);
+            resumptionToken = (tokenNode != null) ? tokenNode.getTextContent() : null;
+        } while (resumptionToken != null && !resumptionToken.isEmpty());
+
+        return allSetSpecs;
+    }
+
+    @Test
+    public void listSetsWithDuplicateTitlesShouldNotDuplicateOrOmitSets() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community parentCommunity = CommunityBuilder.createCommunity(context)
+                                                    .withName("Parent Community")
+                                                    .build();
+
+        int totalCollections = 8;
+        for (int i = 0; i < totalCollections; i++) {
+            CollectionBuilder.createCollection(context, parentCommunity)
+                            .withName("Duplicate Title Collection")
+                            .build();
+        }
+        context.restoreAuthSystemState();
+        int totalSets = totalCollections + 1;
+        Configuration xoaiConfig =
+            new Configuration().withMaxListSetsSize(3)
+                            .withContextConfigurations(new ContextConfiguration(DEFAULT_CONTEXT_PATH));
+
+        List<String> allSetSpecs = listAllSetSpecsAcrossPages(xoaiConfig);
+
+        assertEquals("ListSets returned the wrong number of set entries across all resumptionToken pages",
+            totalSets, allSetSpecs.size());
+        assertEquals("ListSets returned duplicate and/or omitted sets across pages",
+            totalSets, new HashSet<>(allSetSpecs).size());
     }
 }


### PR DESCRIPTION
## References
* Fixes #11201

## Description
OAI-PMH's `ListSets` could return duplicate entries for some Communities/Collections while silently omitting others when paginating results, whenever two or more of them shared the exact same title. This PR adds the object's UUID as a secondary sort key so pagination order is deterministic.

## Instructions for Reviewers
**List of changes in this PR:**
* `CommunityDAOImpl findAll(Context, MetadataField, Integer, Integer)` and `CollectionDAOImpl findAll(Context, MetadataField, Integer, Integer)` now order by `LOWER(CAST(title.value as string)), c.id` instead of **by title alone**. Sorting only by title is not a total order when several objects share the same title, so PostgreSQL is not guaranteed to return `LIMIT`/`OFFSET` pages in a stable order across separate `ListSets` requests. The same row could appear on two different resumptionToken pages while another silently fell between them.
* Added `OAIpmhIT listSetsWithDuplicateTitlesShouldNotDuplicateOrOmitSets`, which creates a Community with several Collections sharing an identical title, forces a small `maxListSetsSize` so `ListSets` must paginate across multiple `resumptionToken` calls, follows every page, and asserts the full set of returned `setSpec` is complete and contains no duplicates.

**How to test:**
* Run `mvn -DskipUnitTests=false -Dtest=OAIpmhIT test` from `dspace-server-webapp`, all tests should pass.
* To see the bug this fixes, temporarily revert the `ORDER BY` change in `CommunityDAOImpl`/`CollectionDAOImpl` back to sorting on title only, rebuild (`mvn clean install -DskipTests`), and re-run  `mvn -DskipUnitTests=false -Dtest=OAIpmhIT test` from `dspace-server-webapp`, it fails intermittently with an assertion like `expected:<9> but was:<7>`, confirming the pagination instability.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [ ] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [ ] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [ ] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [ ] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
