### PR TITLE
Fix #12965: Has Files facet in Workspace/Workflow search

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceContentInOriginalBundleFilterPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceContentInOriginalBundleFilterPlugin.java
@@ -14,7 +14,10 @@ import org.dspace.content.Bitstream;
 import org.dspace.content.Bundle;
 import org.dspace.content.Item;
 import org.dspace.core.Context;
+import org.dspace.discovery.indexobject.IndexableClaimedTask;
+import org.dspace.discovery.indexobject.IndexableInProgressSubmission;
 import org.dspace.discovery.indexobject.IndexableItem;
+import org.dspace.discovery.indexobject.IndexablePoolTask;
 
 /**
  * This plugin adds three fields to the solr index to make a facet with/without
@@ -31,8 +34,8 @@ public class SolrServiceContentInOriginalBundleFilterPlugin implements SolrServi
 
     @Override
     public void additionalIndex(Context context, IndexableObject indexableObject, SolrInputDocument document) {
-        if (indexableObject instanceof IndexableItem) {
-            Item item = ((IndexableItem) indexableObject).getIndexedObject();
+        Item item = this.getIndexedItemDerivedObject(indexableObject);
+        if (item != null) {
             boolean hasOriginalBundleWithContent = hasOriginalBundleWithContent(item);
 
             // _keyword and _filter because
@@ -48,6 +51,25 @@ public class SolrServiceContentInOriginalBundleFilterPlugin implements SolrServi
                 document.addField("has_content_in_original_bundle_filter", true);
             }
         }
+    }
+
+    /**
+     * Retrieve the item object from a given IndexableObject if it is an item, workspace item or workflow item
+     * @param indexableObject The IndexableObject to get the indexed object from
+     * @return The indexed item object or null
+     */
+    private Item getIndexedItemDerivedObject(IndexableObject indexableObject) {
+        Item item = null;
+        if (indexableObject instanceof IndexableItem) {
+            item = ((IndexableItem) indexableObject).getIndexedObject();
+        } else if (indexableObject instanceof IndexableInProgressSubmission) {
+            item = ((IndexableInProgressSubmission<?>) indexableObject).getIndexedObject().getItem();
+        } else if (indexableObject instanceof IndexablePoolTask) {
+            item = ((IndexablePoolTask) indexableObject).getIndexedObject().getWorkflowItem().getItem();
+        } else if (indexableObject instanceof IndexableClaimedTask) {
+            item = ((IndexableClaimedTask) indexableObject).getIndexedObject().getWorkflowItem().getItem();
+        }
+        return item;
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -4456,7 +4456,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.resourceTypeFacet(false),
                         FacetEntryMatcher.typeFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false)
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
@@ -4502,7 +4503,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                 .andExpect(jsonPath("$._embedded.facets", Matchers.containsInAnyOrder(
                         FacetEntryMatcher.resourceTypeFacet(false),
                         FacetEntryMatcher.typeFacet(false),
-                        FacetEntryMatcher.dateIssuedFacet(false)
+                        FacetEntryMatcher.dateIssuedFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
@@ -4687,7 +4689,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.resourceTypeFacet(false),
                         FacetEntryMatcher.typeFacet(false),
                         FacetEntryMatcher.dateIssuedFacet(false),
-                        FacetEntryMatcher.submitterFacet(false)
+                        FacetEntryMatcher.submitterFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
@@ -4737,7 +4740,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.resourceTypeFacet(false),
                         FacetEntryMatcher.typeFacet(false),
                         FacetEntryMatcher.dateIssuedFacet(false),
-                        FacetEntryMatcher.submitterFacet(false)
+                        FacetEntryMatcher.submitterFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
@@ -4770,7 +4774,8 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
                         FacetEntryMatcher.resourceTypeFacet(false),
                         FacetEntryMatcher.typeFacet(false),
                         FacetEntryMatcher.dateIssuedFacet(false),
-                        FacetEntryMatcher.submitterFacet(false)
+                        FacetEntryMatcher.submitterFacet(false),
+                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false)
                 )))
                 //There always needs to be a self link
                 .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")))
@@ -6803,6 +6808,128 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
             )))
             //There always needs to be a self link
             .andExpect(jsonPath("$._links.self.href", containsString("/api/discover/search/objects")));
+    }
+
+    @Test
+    public void discoverHasContentInOriginalBundleFacetWorkspaceItemsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community com = CommunityBuilder.createCommunity(context).build();
+        Collection col = CollectionBuilder.createCollection(context, com).build();
+
+        context.setCurrentUser(eperson);
+        try (InputStream is = IOUtils.toInputStream("dummy", CharEncoding.UTF_8)) {
+            WorkspaceItemBuilder.createWorkspaceItem(context, col)
+                    .withFulltext("test.txt", "/local/path/test.txt", is)
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+        getClient(token).perform(get("/api/discover/search/objects")
+                                         .param("configuration", "workspace"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.facets", Matchers.hasItem(
+                                allOf(
+                                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
+                                        hasJsonPath("$._embedded.values", Matchers.hasItem(
+                                                allOf(
+                                                        hasJsonPath("$.label", is("true")),
+                                                        hasJsonPath("$.count", is(1))
+                                                )
+                                        ))
+                                )
+                        )));
+    }
+
+    @Test
+    public void discoverHasContentInOriginalBundleFacetUnclaimableWorkflowItemsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community com = CommunityBuilder.createCommunity(context).build();
+        Collection col = CollectionBuilder.createCollection(context, com).withWorkflowGroup(1, admin).build();
+
+        context.setCurrentUser(eperson);
+        try (InputStream is = IOUtils.toInputStream("dummy", CharEncoding.UTF_8)) {
+            WorkflowItemBuilder.createWorkflowItem(context, col)
+                    .withFulltext("test.txt", "/local/path/test.txt", is)
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+        getClient(token).perform(get("/api/discover/search/objects")
+                                         .param("configuration", "workspace"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.facets", Matchers.hasItem(
+                                allOf(
+                                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
+                                        hasJsonPath("$._embedded.values", Matchers.hasItem(
+                                                allOf(
+                                                        hasJsonPath("$.label", is("true")),
+                                                        hasJsonPath("$.count", is(1))
+                                                )
+                                        ))
+                                )
+                        )));
+    }
+
+    @Test
+    public void discoverHasContentInOriginalBundleFacetUnclaimedWorkflowItemsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community com = CommunityBuilder.createCommunity(context).build();
+        Collection col = CollectionBuilder.createCollection(context, com).withWorkflowGroup(1, eperson).build();
+
+        try (InputStream is = IOUtils.toInputStream("dummy", CharEncoding.UTF_8)) {
+            PoolTaskBuilder.createPoolTask(context, col, eperson)
+                    .withFulltext("test.txt", "/local/path/test.txt", is)
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+        getClient(token).perform(get("/api/discover/search/objects")
+                                         .param("configuration", "workflow"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.facets", Matchers.hasItem(
+                                allOf(
+                                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
+                                        hasJsonPath("$._embedded.values", Matchers.hasItem(
+                                                allOf(
+                                                        hasJsonPath("$.label", is("true")),
+                                                        hasJsonPath("$.count", is(1))
+                                                )
+                                        ))
+                                )
+                        )));
+    }
+
+    @Test
+    public void discoverHasContentInOriginalBundleFacetClaimedWorkflowItemsTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        Community com = CommunityBuilder.createCommunity(context).build();
+        Collection col = CollectionBuilder.createCollection(context, com).withWorkflowGroup(1, eperson).build();
+
+        try (InputStream is = IOUtils.toInputStream("dummy", CharEncoding.UTF_8)) {
+            ClaimedTaskBuilder.createClaimedTask(context, col, eperson)
+                    .withFulltext("test.txt", "/local/path/test.txt", is)
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String token = getAuthToken(eperson.getEmail(), password);
+        getClient(token).perform(get("/api/discover/search/objects")
+                                         .param("configuration", "workflow"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.facets", Matchers.hasItem(
+                                allOf(
+                                        FacetEntryMatcher.hasContentInOriginalBundleFacet(false),
+                                        hasJsonPath("$._embedded.values", Matchers.hasItem(
+                                                allOf(
+                                                        hasJsonPath("$.label", is("true")),
+                                                        hasJsonPath("$.count", is(1))
+                                                )
+                                        ))
+                                )
+                        )));
     }
 
 }

--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -734,6 +734,7 @@
                 <ref bean="searchFilterObjectNamedType" />
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
             </list>
         </property>
         <!--The search filters which can be used on the discovery search page -->
@@ -742,6 +743,7 @@
                 <ref bean="searchFilterObjectNamedType" />
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -886,6 +888,7 @@
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterSubmitter" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
             </list>
         </property>
         <!--The search filters which can be used on the discovery search page -->
@@ -895,6 +898,7 @@
                 <ref bean="searchFilterType" />
                 <ref bean="searchFilterIssued" />
                 <ref bean="searchFilterSubmitter" />
+                <ref bean="searchFilterContentInOriginalBundle"/>
             </list>
         </property>
         <!--The sort filters for the discovery search-->


### PR DESCRIPTION
## References
* Fixes #12965 

## Description
The facet `searchFilterContentInOriginalBundle` does not appear on the `/mydspace` page, even when configured.

## Instructions for Reviewers
On main:
- Configure `searchFilterContentInOriginalBundle` in `discovery.xml` in `workspaceConfiguration`
- Create a WorkspaceItem
- Go to `/mydspace` and verify there is no "Has files" facet

Follow the same steps on this branch and verify there now is a "Has files" facet.
 
List of changes in this PR:
- Indexed workspace and workflow items in addition to regular items on this facet.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
