### PR TITLE
feat(#3169): Add optional HTTP Basic authentication support for Solr connections

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/solr/SolrCoreExportImport.java
@@ -39,6 +39,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.scripts.DSpaceRunnable;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.util.SolrAuthUtils;
 import org.dspace.utils.DSpace;
 
 /**
@@ -69,6 +70,7 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
     private ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
     private ObjectMapper jsonMapper = new ObjectMapper();
     private HttpClient httpClient;
+    private String authorizationHeader;
 
     // Cache for fields list to avoid multiple calls to SOLR
     private List<String> cachedFields = null;
@@ -97,6 +99,7 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(30))
                 .build();
+        this.authorizationHeader = SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService);
 
         mode = commandLine.getOptionValue('m');
         if (StringUtils.isBlank(mode) || (!mode.equals("export") && !mode.equals("import"))) {
@@ -290,10 +293,10 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
             String statsUrl = String.format("%s/select?q=*:*&rows=0&wt=json&stats=true&stats.field=%s",
                     baseUrl, dateField);
 
-            HttpRequest request = HttpRequest.newBuilder()
+            HttpRequest request = withAuth(HttpRequest.newBuilder()
                     .uri(URI.create(statsUrl))
                     .timeout(Duration.ofMinutes(2))
-                    .GET()
+                    .GET())
                     .build();
 
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -409,10 +412,10 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
 
         log.debug("Thread '{}' calling SOLR URL: {}", currentThread.getName(), url);
 
-        HttpRequest request = HttpRequest.newBuilder()
+        HttpRequest request = withAuth(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(Duration.ofMinutes(5))
-                .GET()
+                .GET())
                 .build();
 
         long queryStart = System.currentTimeMillis();
@@ -537,11 +540,11 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
         String url = baseUrl + "/update";
         String contentType = format.equals("csv") ? "application/csv" : "application/json";
 
-        HttpRequest request = HttpRequest.newBuilder()
+        HttpRequest request = withAuth(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(Duration.ofMinutes(10))
                 .header("Content-Type", contentType)
-                .POST(HttpRequest.BodyPublishers.ofFile(file.toPath()))
+                .POST(HttpRequest.BodyPublishers.ofFile(file.toPath())))
                 .build();
 
         long uploadStart = System.currentTimeMillis();
@@ -564,11 +567,11 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
     private void commitToSolr(String baseUrl) throws Exception {
         String url = baseUrl + "/update?commit=true";
 
-        HttpRequest request = HttpRequest.newBuilder()
+        HttpRequest request = withAuth(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(Duration.ofMinutes(5))
                 .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                .POST(HttpRequest.BodyPublishers.ofString("{}")))
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -602,10 +605,10 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
 
         String url = baseUrl + "/schema/fields?wt=json";
 
-        HttpRequest request = HttpRequest.newBuilder()
+        HttpRequest request = withAuth(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(Duration.ofMinutes(1))
-                .GET()
+                .GET())
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -642,10 +645,10 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
     private List<String> getFieldsFromSampleQuery(String baseUrl) throws Exception {
         String url = baseUrl + "/select?q=*:*&rows=1&wt=json";
 
-        HttpRequest request = HttpRequest.newBuilder()
+        HttpRequest request = withAuth(HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(Duration.ofMinutes(1))
-                .GET()
+                .GET())
                 .build();
 
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
@@ -715,5 +718,16 @@ public class SolrCoreExportImport extends DSpaceRunnable<SolrCoreExportImportScr
         handler.logInfo("- If start/end dates are not specified, they will be retrieved from SOLR");
         handler.logInfo("- Date increment determines how data is split across threads");
         handler.logInfo("- Import can process both old batch files and new range files");
+    }
+
+    /**
+     * Adds the Authorization header to a request builder, if HTTP Basic
+     * authentication is configured for Solr.
+     */
+    private HttpRequest.Builder withAuth(HttpRequest.Builder requestBuilder) {
+        if (authorizationHeader != null) {
+            requestBuilder.header("Authorization", authorizationHeader);
+        }
+        return requestBuilder;
     }
 }

--- a/dspace-api/src/main/java/org/dspace/app/suggestion/SolrSuggestionStorageServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/suggestion/SolrSuggestionStorageServiceImpl.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrClient;
@@ -40,12 +41,15 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.FacetParams;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.content.Item;
 import org.dspace.content.dto.MetadataValueDTO;
 import org.dspace.content.service.ItemService;
 import org.dspace.core.Context;
 import org.dspace.core.exception.SQLRuntimeException;
+import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.util.SolrAuthUtils;
 import org.dspace.util.UUIDUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -73,9 +77,16 @@ public class SolrSuggestionStorageServiceImpl implements SolrSuggestionStorageSe
      */
     public SolrClient getSolr() {
         if (solrSuggestionClient == null) {
-            String solrService = DSpaceServicesFactory.getInstance().getConfigurationService()
+            ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
+                    .getConfigurationService();
+            String solrService = configurationService
                     .getProperty("suggestion.solr.server", "http://localhost:8983/solr/suggestion");
-            solrSuggestionClient = new HttpSolrClient.Builder(solrService).build();
+            CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                    SolrAuthUtils.addAuthenticationIfConfigured(builder, "suggestion.solr", "solr",
+                            configurationService));
+            solrSuggestionClient = new HttpSolrClient.Builder(solrService)
+                    .withHttpClient(httpClient)
+                    .build();
         }
         return solrSuggestionClient;
     }

--- a/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/qaevent/service/impl/QAEventServiceImpl.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrClient;
@@ -44,6 +45,7 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.FacetParams;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.content.Item;
 import org.dspace.content.QAEvent;
 import org.dspace.content.service.ItemService;
@@ -63,6 +65,7 @@ import org.dspace.qaevent.service.QAEventSecurityService;
 import org.dspace.qaevent.service.QAEventService;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.util.SolrAuthUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
@@ -129,9 +132,16 @@ public class QAEventServiceImpl implements QAEventService {
 
     protected SolrClient getSolr() {
         if (solr == null) {
-            String solrService = DSpaceServicesFactory.getInstance().getConfigurationService()
+            ConfigurationService configurationService = DSpaceServicesFactory.getInstance()
+                    .getConfigurationService();
+            String solrService = configurationService
                     .getProperty("qaevents.solr.server", "http://localhost:8983/solr/qaevent");
-            solr = new HttpSolrClient.Builder(solrService).build();
+            CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                    SolrAuthUtils.addAuthenticationIfConfigured(builder, "qaevents.solr", "solr",
+                            configurationService));
+            solr = new HttpSolrClient.Builder(solrService)
+                    .withHttpClient(httpClient)
+                    .build();
         }
         return solr;
     }

--- a/dspace-api/src/main/java/org/dspace/service/impl/HttpConnectionPoolService.java
+++ b/dspace-api/src/main/java/org/dspace/service/impl/HttpConnectionPoolService.java
@@ -25,6 +25,7 @@ import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.services.ConfigurationService;
+import org.dspace.util.SolrAuthUtils;
 
 /**
  * Factory for HTTP clients sharing a pool of connections.
@@ -112,11 +113,11 @@ public class HttpConnectionPoolService {
      * @return the client.
      */
     public CloseableHttpClient getClient() {
-        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().builder(true).create()
-                .setKeepAliveStrategy(keepAliveStrategy)
-                .setConnectionManager(connManager)
-                .build();
-        return httpClient;
+        return DSpaceHttpClientFactory.getInstance().build(builder -> {
+            builder.setKeepAliveStrategy(keepAliveStrategy)
+                    .setConnectionManager(connManager);
+            SolrAuthUtils.addAuthenticationIfConfigured(builder, configPrefix, configurationService);
+        });
     }
 
     /**

--- a/dspace-api/src/main/java/org/dspace/statistics/HttpSolrClientFactory.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/HttpSolrClientFactory.java
@@ -7,8 +7,13 @@
  */
 package org.dspace.statistics;
 
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.dspace.app.client.DSpaceHttpClientFactory;
+import org.dspace.services.ConfigurationService;
+import org.dspace.util.SolrAuthUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Factory of HtmlSolrClient instances.
@@ -18,10 +23,16 @@ import org.apache.solr.client.solrj.impl.HttpSolrClient;
 public class HttpSolrClientFactory
         implements SolrClientFactory {
 
+    @Autowired
+    private ConfigurationService configurationService;
+
     @Override
     public SolrClient getClient(String coreUrl) {
+        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
         SolrClient client = new HttpSolrClient.Builder()
                 .withBaseSolrUrl(coreUrl)
+                .withHttpClient(httpClient)
                 .build();
         return client;
     }

--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLoggerServiceImpl.java
@@ -106,6 +106,7 @@ import org.dspace.statistics.service.SolrLoggerService;
 import org.dspace.statistics.util.LocationUtils;
 import org.dspace.statistics.util.SpiderDetector;
 import org.dspace.usage.UsageWorkflowEvent;
+import org.dspace.util.SolrAuthUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -1270,7 +1271,11 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         //DS-3458: Test to see if a solr core already exists.  If it exists,
         // return a connection to that core.  Otherwise create a new core and
         // return a connection to it.
-        HttpSolrClient returnServer = new HttpSolrClient.Builder(baseSolrUrl + coreName).build();
+        CloseableHttpClient returnServerHttpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        HttpSolrClient returnServer = new HttpSolrClient.Builder(baseSolrUrl + coreName)
+                .withHttpClient(returnServerHttpClient)
+                .build();
         try {
             SolrPingResponse ping = returnServer.ping();
             log.debug("Ping of Solr Core {} returned with Status {}",
@@ -1290,7 +1295,11 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         create.setConfigSet(configSetName);
         create.setInstanceDir(coreName);
 
-        HttpSolrClient solrServer = new HttpSolrClient.Builder(baseSolrUrl).build();
+        CloseableHttpClient solrServerHttpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        HttpSolrClient solrServer = new HttpSolrClient.Builder(baseSolrUrl)
+                .withHttpClient(solrServerHttpClient)
+                .build();
         create.process(solrServer);
         log.info("Created core with name: {} from configset {}", coreName, configSetName);
         return returnServer;
@@ -1576,7 +1585,11 @@ public class SolrLoggerServiceImpl implements SolrLoggerService, InitializingBea
         //Base url should like : http://localhost:{port.number}/solr
         String baseSolrUrl = ((HttpSolrClient) solr).getBaseURL().replace(statisticsCoreBase, "");
 
-        try (HttpSolrClient enumClient = new HttpSolrClient.Builder(baseSolrUrl).build();) {
+        CloseableHttpClient enumHttpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        try (HttpSolrClient enumClient = new HttpSolrClient.Builder(baseSolrUrl)
+                .withHttpClient(enumHttpClient)
+                .build();) {
             //Attempt to retrieve all the statistic year cores
             CoreAdminRequest coresRequest = new CoreAdminRequest();
             coresRequest.setAction(CoreAdminAction.STATUS);

--- a/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/util/StatisticsImporter.java
@@ -35,11 +35,13 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.common.SolrInputDocument;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Collection;
 import org.dspace.content.Community;
@@ -58,6 +60,7 @@ import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 import org.dspace.statistics.factory.StatisticsServiceFactory;
 import org.dspace.statistics.service.SolrLoggerService;
+import org.dspace.util.SolrAuthUtils;
 
 /**
  * Class to load intermediate statistics files (produced from log files by {@link ClassicDSpaceLogConverter}) into Solr.
@@ -463,7 +466,11 @@ public class StatisticsImporter {
         if (verbose) {
             System.out.println("Writing to solr server at: " + sserver);
         }
-        solr = new HttpSolrClient.Builder(sserver).build();
+        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        solr = new HttpSolrClient.Builder(sserver)
+                .withHttpClient(httpClient)
+                .build();
 
         String dbPath = configurationService.getProperty("usage-statistics.dbfile");
         try {

--- a/dspace-api/src/main/java/org/dspace/util/SolrAuthUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrAuthUtils.java
@@ -102,7 +102,7 @@ public final class SolrAuthUtils {
             return null;
         }
 
-        String token = user + ":" + password;
+        String token = user + ":" + StringUtils.defaultString(password);
         return "Basic " + Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/dspace-api/src/main/java/org/dspace/util/SolrAuthUtils.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrAuthUtils.java
@@ -1,0 +1,123 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.services.ConfigurationService;
+
+/**
+ * Shared helper to optionally attach preemptive HTTP Basic authentication
+ * to an HttpClientBuilder used for talking to a Solr instance, based on
+ * configuration.
+ * <p>
+ * IMPORTANT: callers must add the returned interceptor directly to their
+ * own local {@link HttpClientBuilder} instance -- NEVER register it as a
+ * Spring {@code HttpRequestInterceptor} bean. {@link org.dspace.app.client.DSpaceHttpClientFactory}
+ * auto-applies every such bean to every client it builds, which would leak
+ * these credentials to unrelated destinations (ORCID, Crossref, Google
+ * Analytics, etc.).
+ */
+public final class SolrAuthUtils {
+    private static final Logger log = LogManager.getLogger();
+
+    private SolrAuthUtils() { }
+
+    /**
+     * If PREFIX.authentication.type=basic, add a preemptive Basic
+     * "Authorization" header to every request built from this builder.
+     * No-op if the property is unset/blank/"none".
+     */
+    public static void addAuthenticationIfConfigured(HttpClientBuilder builder, String configPrefix,
+                                                       ConfigurationService configurationService) {
+        addAuthenticationIfConfigured(builder, configPrefix, null, configurationService);
+    }
+
+    /**
+     * Same as above, but if PREFIX.authentication.type is not set, falls
+     * back to checking FALLBACK_PREFIX.authentication.type instead. Useful
+     * for Solr cores/services that, by default configuration, share the
+     * same Solr instance (and therefore credentials) as the main
+     * ${solr.server} pool, but may optionally be pointed at a separate
+     * instance with its own credentials.
+     *
+     * @param fallbackPrefix e.g. "solr". May be null to disable the fallback.
+     */
+    public static void addAuthenticationIfConfigured(HttpClientBuilder builder, String configPrefix,
+                                                       String fallbackPrefix,
+                                                       ConfigurationService configurationService) {
+        String headerValue = getAuthorizationHeaderValue(configPrefix, fallbackPrefix, configurationService);
+        if (headerValue != null) {
+            builder.addInterceptorFirst(new PreemptiveBasicAuthInterceptor(headerValue));
+        }
+    }
+
+    /**
+     * Resolve the "Authorization" header value to use for Solr requests, if
+     * PREFIX.authentication.type (or FALLBACK_PREFIX.authentication.type) is
+     * set to "basic". Useful for callers that can't use an
+     * HttpRequestInterceptor -- e.g. java.net.http.HttpClient -- and need to
+     * add the header to each outgoing request themselves.
+     *
+     * @return the header value (e.g. "Basic abc123..."), or null if
+     *         authentication is not configured.
+     */
+    public static String getAuthorizationHeaderValue(String configPrefix, String fallbackPrefix,
+                                                       ConfigurationService configurationService) {
+        String prefix = configPrefix;
+        String authType = configurationService.getProperty(prefix + ".authentication.type");
+        if (StringUtils.isBlank(authType) && StringUtils.isNotBlank(fallbackPrefix)) {
+            prefix = fallbackPrefix;
+            authType = configurationService.getProperty(prefix + ".authentication.type");
+        }
+
+        if (StringUtils.isBlank(authType) || StringUtils.equalsIgnoreCase(authType, "none")) {
+            return null;
+        }
+        if (!StringUtils.equalsIgnoreCase(authType, "basic")) {
+            log.warn("Unrecognized value '{}' for {}.authentication.type (only 'basic' is currently "
+                    + "supported); no authentication will be added.", authType, prefix);
+            return null;
+        }
+
+        String user = configurationService.getProperty(prefix + ".authentication.user");
+        String password = configurationService.getProperty(prefix + ".authentication.password");
+        if (StringUtils.isBlank(user)) {
+            log.warn("{}.authentication.type=basic but {}.authentication.user is not set; "
+                    + "no authentication will be added.", prefix, prefix);
+            return null;
+        }
+
+        String token = user + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(token.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final class PreemptiveBasicAuthInterceptor implements HttpRequestInterceptor {
+        private final String headerValue;
+
+        private PreemptiveBasicAuthInterceptor(String headerValue) {
+            this.headerValue = headerValue;
+        }
+
+        @Override
+        public void process(HttpRequest request, HttpContext context) throws HttpException {
+            if (!request.containsHeader("Authorization")) {
+                request.addHeader("Authorization", headerValue);
+            }
+        }
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -28,6 +28,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -44,6 +45,7 @@ import org.apache.solr.client.solrj.response.RangeFacet;
 import org.apache.solr.common.luke.FieldFlag;
 import org.apache.solr.common.params.CoreAdminParams;
 import org.apache.solr.common.params.FacetParams;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
 
@@ -250,7 +252,11 @@ public class SolrImportExport {
         }
 
         try {
-            HttpSolrClient adminSolr = new HttpSolrClient.Builder(baseSolrUrl).build();
+            CloseableHttpClient adminHttpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                    SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+            HttpSolrClient adminSolr = new HttpSolrClient.Builder(baseSolrUrl)
+                    .withHttpClient(adminHttpClient)
+                    .build();
 
             // try to find out size of core and compare with free space in export directory
             CoreAdminResponse status = CoreAdminRequest.getStatus(indexName, adminSolr);
@@ -317,7 +323,11 @@ public class SolrImportExport {
             }
 
             // commit changes
-            HttpSolrClient origSolr = new HttpSolrClient.Builder(origSolrUrl).build();
+            CloseableHttpClient origHttpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                    SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+            HttpSolrClient origSolr = new HttpSolrClient.Builder(origSolrUrl)
+                    .withHttpClient(origHttpClient)
+                    .build();
             origSolr.commit();
 
             // swap back (statistics now going to actual core name in actual data dir)
@@ -398,7 +408,11 @@ public class SolrImportExport {
                                                     + indexName);
         }
 
-        HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl).build();
+        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl)
+                .withHttpClient(httpClient)
+                .build();
 
         // must get multivalue fields before clearing
         List<String> multivaluedFields = getMultiValuedFields(solr);
@@ -471,7 +485,11 @@ public class SolrImportExport {
      * @throws SolrServerException if there is a problem in communicating with Solr.
      */
     public static void clearIndex(String solrUrl) throws IOException, SolrServerException {
-        HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl).build();
+        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl)
+                .withHttpClient(httpClient)
+                .build();
         solr.deleteByQuery("*:*");
         solr.commit();
         solr.optimize();
@@ -510,7 +528,11 @@ public class SolrImportExport {
                                                     + indexName);
         }
 
-        HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl).build();
+        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
+        HttpSolrClient solr = new HttpSolrClient.Builder(solrUrl)
+                .withHttpClient(httpClient)
+                .build();
 
         SolrQuery query = new SolrQuery("*:*");
         if (StringUtils.isNotBlank(fromWhen)) {

--- a/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrUpgradePre6xStatistics.java
@@ -21,6 +21,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -32,6 +33,7 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.content.Bitstream;
 import org.dspace.content.Community;
 import org.dspace.content.Item;
@@ -147,7 +149,10 @@ public class SolrUpgradePre6xStatistics {
         String serverPath = configurationService.getProperty("solr-statistics.server");
         serverPath = serverPath.replaceAll("statistics$", indexName);
         System.out.println("Connecting to " + serverPath);
+        CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService));
         server = new HttpSolrClient.Builder(serverPath)
+                .withHttpClient(httpClient)
                 .build();
         this.numRec = numRec;
         this.batchSize = batchSize;

--- a/dspace-api/src/test/java/org/dspace/service/impl/HttpConnectionPoolServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/service/impl/HttpConnectionPoolServiceTest.java
@@ -15,6 +15,8 @@ import static org.mockserver.model.HttpResponse.response;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -90,6 +92,57 @@ public class HttpConnectionPoolServiceTest
             try (CloseableHttpResponse response = httpClient.execute(request)) {
                 assertEquals("Response status should be OK", HttpStatus.OK_200,
                         response.getStatusLine().getStatusCode());
+            }
+        }
+    }
+
+    @org.junit.After
+    public void tearDown() {
+        configurationService.setProperty("solr.authentication.type", null);
+        configurationService.setProperty("solr.authentication.user", null);
+        configurationService.setProperty("solr.authentication.password", null);
+    }
+
+    /**
+     * Test that getClient() attaches a preemptive HTTP Basic Authorization
+     * header when solr.authentication.* is configured.
+     */
+    @Test
+    public void testGetClientWithBasicAuthConfigured()
+            throws IOException, URISyntaxException {
+        configurationService.setProperty("solr.authentication.type", "basic");
+        configurationService.setProperty("solr.authentication.user", "solr");
+        configurationService.setProperty("solr.authentication.password", "SolrRocks");
+
+        HttpConnectionPoolService instance = new HttpConnectionPoolService("solr");
+        instance.configurationService = configurationService;
+        instance.init();
+
+        String expectedAuthHeader = "Basic " + Base64.getEncoder()
+                .encodeToString("solr:SolrRocks".getBytes(StandardCharsets.UTF_8));
+
+        final String testPath = "/test-auth";
+        mockServerClient.when(
+                request()
+                        .withPath(testPath)
+                        .withHeader("Authorization", expectedAuthHeader)
+        ).respond(
+                response()
+                        .withStatusCode(HttpStatus.OK_200)
+        );
+
+        try (CloseableHttpClient httpClient = instance.getClient()) {
+            URI uri = new URIBuilder()
+                    .setScheme("http")
+                    .setHost("localhost")
+                    .setPort(mockServerClient.getPort())
+                    .setPath(testPath)
+                    .build();
+            HttpUriRequest request = RequestBuilder.get(uri)
+                    .build();
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                assertEquals("Response status should be OK when the expected Authorization header is sent",
+                        HttpStatus.OK_200, response.getStatusLine().getStatusCode());
             }
         }
     }

--- a/dspace-api/src/test/java/org/dspace/util/SolrAuthUtilsTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/SolrAuthUtilsTest.java
@@ -1,0 +1,140 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.dspace.services.ConfigurationService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for {@link SolrAuthUtils}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SolrAuthUtilsTest {
+
+    @Mock
+    private ConfigurationService configurationService;
+
+    @Test
+    public void testGetAuthorizationHeaderValueWhenTypeNotSet() {
+        assertNull(SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueWhenTypeBlank() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("");
+        assertNull(SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueWhenTypeIsNone() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("none");
+        assertNull(SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueWhenTypeUnrecognized() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("digest");
+        assertNull(SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueWhenBasicButUserBlank() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("basic");
+        when(configurationService.getProperty("solr.authentication.user")).thenReturn(null);
+        assertNull(SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueWhenBasicConfigured() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("basic");
+        when(configurationService.getProperty("solr.authentication.user")).thenReturn("solr");
+        when(configurationService.getProperty("solr.authentication.password")).thenReturn("SolrRocks");
+
+        String expected = "Basic " + Base64.getEncoder()
+                .encodeToString("solr:SolrRocks".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(expected, SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueTreatsNullPasswordAsEmpty() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("basic");
+        when(configurationService.getProperty("solr.authentication.user")).thenReturn("solr");
+        when(configurationService.getProperty("solr.authentication.password")).thenReturn(null);
+
+        String expected = "Basic " + Base64.getEncoder()
+                .encodeToString("solr:".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(expected, SolrAuthUtils.getAuthorizationHeaderValue("solr", null, configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueUsesFallbackWhenPrimaryNotSet() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("basic");
+        when(configurationService.getProperty("solr.authentication.user")).thenReturn("solr");
+        when(configurationService.getProperty("solr.authentication.password")).thenReturn("SolrRocks");
+
+        String expected = "Basic " + Base64.getEncoder()
+                .encodeToString("solr:SolrRocks".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(expected,
+                SolrAuthUtils.getAuthorizationHeaderValue("iiif.search", "solr", configurationService));
+    }
+
+    @Test
+    public void testGetAuthorizationHeaderValueIgnoresFallbackWhenPrimarySet() {
+        when(configurationService.getProperty("iiif.search.authentication.type")).thenReturn("basic");
+        when(configurationService.getProperty("iiif.search.authentication.user")).thenReturn("iiif-solr");
+        when(configurationService.getProperty("iiif.search.authentication.password")).thenReturn("iiif-pass");
+
+        String expected = "Basic " + Base64.getEncoder()
+                .encodeToString("iiif-solr:iiif-pass".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(expected,
+                SolrAuthUtils.getAuthorizationHeaderValue("iiif.search", "solr", configurationService));
+        // The fallback prefix must never be consulted once the primary prefix is fully configured.
+        verify(configurationService, never()).getProperty("solr.authentication.type");
+    }
+
+    @Test
+    public void testAddAuthenticationIfConfiguredAddsInterceptorWhenConfigured() {
+        when(configurationService.getProperty("solr.authentication.type")).thenReturn("basic");
+        when(configurationService.getProperty("solr.authentication.user")).thenReturn("solr");
+        when(configurationService.getProperty("solr.authentication.password")).thenReturn("SolrRocks");
+
+        HttpClientBuilder builder = mock(HttpClientBuilder.class);
+        SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService);
+
+        verify(builder).addInterceptorFirst(any(HttpRequestInterceptor.class));
+    }
+
+    @Test
+    public void testAddAuthenticationIfConfiguredNoOpWhenNotConfigured() {
+        HttpClientBuilder builder = mock(HttpClientBuilder.class);
+        SolrAuthUtils.addAuthenticationIfConfigured(builder, "solr", configurationService);
+
+        verifyNoInteractions(builder);
+    }
+}

--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/WordHighlightSolrSearch.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/WordHighlightSolrSearch.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.validator.routines.UrlValidator;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -26,6 +27,7 @@ import org.apache.solr.client.solrj.impl.NoOpResponseParser;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.NamedList;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.app.iiif.model.generator.AnnotationGenerator;
 import org.dspace.app.iiif.model.generator.CanvasGenerator;
 import org.dspace.app.iiif.model.generator.ContentAsTextGenerator;
@@ -34,6 +36,7 @@ import org.dspace.app.iiif.model.generator.SearchResultGenerator;
 import org.dspace.app.iiif.service.utils.IIIFUtils;
 import org.dspace.services.ConfigurationService;
 import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.util.SolrAuthUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -86,7 +89,12 @@ public class WordHighlightSolrSearch implements SearchAnnotationService {
                 .getBooleanProperty("discovery.solr.url.validation.enabled");
         UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
         if (urlValidator.isValid(solrService) || validationEnabled) {
-            HttpSolrClient solrServer = new HttpSolrClient.Builder(solrService).build();
+            CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance().build(builder ->
+                    SolrAuthUtils.addAuthenticationIfConfigured(builder, "iiif.search", "solr",
+                            configurationService));
+            HttpSolrClient solrServer = new HttpSolrClient.Builder(solrService)
+                    .withHttpClient(httpClient)
+                    .build();
             solrServer.setUseMultiPartPost(true);
             SolrQuery solrQuery = getSolrQuery(adjustQuery(query), manifestId);
             QueryRequest req = new QueryRequest(solrQuery);

--- a/dspace/config/modules/iiif.cfg
+++ b/dspace/config/modules/iiif.cfg
@@ -1,4 +1,12 @@
 #### IIIF CONFIGURATION ####
+# (Optional) Override HTTP Basic auth for the IIIF word-highlight (OCR) Solr
+# search specifically. By default this already reuses solr.authentication.*
+# (see dspace.cfg), since iiif.search.url normally points at ${solr.server}.
+# Only set these if this search points at a genuinely separate Solr instance.
+# iiif.search.authentication.type = basic
+# iiif.search.authentication.user = solr
+# iiif.search.authentication.password =
+
 # To enable the IIIF service, set to true. Note that to use IIIF you must also provide
 # an image server.
 iiif.enabled = false

--- a/dspace/config/modules/qaevents.cfg
+++ b/dspace/config/modules/qaevents.cfg
@@ -3,6 +3,12 @@
 #---------------------------------------------------------------#
 # Configuration properties used by data correction service      #
 #---------------------------------------------------------------#
+# (Optional) Override HTTP Basic auth for the qaevent Solr core specifically.
+# By default this already reuses solr.authentication.* (see dspace.cfg).
+# qaevents.solr.authentication.type = basic
+# qaevents.solr.authentication.user = solr
+# qaevents.solr.authentication.password =
+
 # Quality Assurance enable property, false by default
 qaevents.enabled = false
 qaevents.solr.server = ${solr.server}/${solr.multicorePrefix}qaevent

--- a/dspace/config/modules/suggestion.cfg
+++ b/dspace/config/modules/suggestion.cfg
@@ -4,6 +4,12 @@
 # Configuration properties used by publication claim            #
 #  (suggestion) service                                         #
 #---------------------------------------------------------------#
+# (Optional) Override HTTP Basic auth for the suggestion Solr core specifically.
+# By default this already reuses solr.authentication.* (see dspace.cfg).
+# suggestion.solr.authentication.type = basic
+# suggestion.solr.authentication.user = solr
+# suggestion.solr.authentication.password =
+
 suggestion.solr.server = ${solr.server}/${solr.multicorePrefix}suggestion
 
 # The maximum number of researcher profiles to be processed by the publication loader.


### PR DESCRIPTION
## References
* Fixes #3169

## Description
Adds optional HTTP Basic authentication support for DSpace's connections to Solr. Previously, Solr Basic Auth (via `security.json`) could not be used with DSpace, since none of the places DSpace builds a Solr client route credentials through.

## Instructions for Reviewers

Solr's `BasicAuthPlugin` (https://solr.apache.org/guide/solr/9_10/deployment-guide/basic-authentication-plugin.html) protects the whole Solr instance, not individual cores, so this PR centers on one shared, optional configuration block (`solr.authentication.type` / `.user` / `.password` in `dspace.cfg`) that applies by default to every DSpace-managed Solr core.

Regarding `PreemptiveBasicAuthClientBuilderFactory` (raised earlier in this issue by @tehaef): this does not seem to apply in this case, because DSpace never lets SolrJ build its own `HttpClient` — every Solr client is built with an explicit, DSpace-managed `HttpClient` passed in via `.withHttpClient(...)`. So authentication has to be added at that layer instead.

List of changes in this PR:
* New shared utility, `org.dspace.util.SolrAuthUtils`, with `addAuthenticationIfConfigured(...)` (adds a preemptive HTTP Basic `Authorization` header to an `HttpClientBuilder` if configured) and `getAuthorizationHeaderValue(...)` (for callers using `java.net.http.HttpClient`, which has no interceptor concept).
* New optional config: `solr.authentication.type` / `.user` / `.password` in `dspace.cfg`. Unset by default -- zero behavior change for existing installs.
* Applied to every Solr client construction site found in the codebase:
  * `HttpConnectionPoolService` -- covers the `search`, `statistics`, `authority`, and `oai` cores, which all share this pool.
  * `HttpSolrClientFactory` -- covers the `audit` core (via `AuditSolrServiceImpl`).
  * `SolrSuggestionStorageServiceImpl` (`suggestion` core) and `QAEventServiceImpl` (`qaevent` core) -- support an independent config override (`suggestion.solr.authentication.*` / `qaevents.solr.authentication.*`) that falls back to `solr.authentication.*` if unset.
  * `WordHighlightSolrSearch` (IIIF OCR word-highlight search, `dspace-iiif`) -- same override/fallback pattern (`iiif.search.authentication.*`), since this search can optionally point at a separate Solr instance running the third-party `solr-ocrhighlighting` plugin.
  * CLI/admin tools that talk to Solr directly: `SolrImportExport`, `SolrUpgradePre6xStatistics`, `StatisticsImporter`, and the year-sharding logic inside `SolrLoggerServiceImpl`.
  * `SolrCoreExportImport` -- uses Java's native `java.net.http.HttpClient` rather than SolrJ, so it adds the `Authorization` header directly via `SolrAuthUtils.getAuthorizationHeaderValue(...)`.
* All new client construction routes through `DSpaceHttpClientFactory` (rather than a bare `HttpClientBuilder.create()`), so existing proxy configuration and any globally-registered interceptors keep working -- this is also enforced by the project's existing Checkstyle rule.

## How to test:
**Automated tests:**
* `SolrAuthUtilsTest` (unit test) covers `type`/`user`/`password` validation (missing, blank, `none`, unrecognized values), the fallback-prefix logic, and that the interceptor is only added when authentication is actually configured.
* `HttpConnectionPoolServiceTest testGetClientWithBasicAuthConfigured` (integration, via MockServer) asserts the `Authorization` header is actually present on an outgoing request when `solr.authentication.*` is set.

`cd dspace-api && mvn -DskipUnitTests=false -Dtest=SolrAuthUtilsTest,HttpConnectionPoolServiceTest test`

**Manual verification:**
1. Enable Solr's Basic Auth plugin (`security.json` with `blockUnknown: true`), per https://solr.apache.org/guide/solr/9_10/deployment-guide/basic-authentication-plugin.html, and restart Solr.
2. Confirm directly against Solr (e.g. via `curl`) that requests without credentials now get `401`, and requests with the configured credentials get `200`. This isolates Solr-side config from DSpace-side.
3. Without setting `solr.authentication.*` in DSpace's `local.cfg`, confirm Solr-backed features (search, submission indexing, statistics) now fail.
4. Set `solr.authentication.type = basic`, `.user`, `.password` in `local.cfg` to match Solr's credentials, rebuild/redeploy, and confirm those features work again.
5. Regression check: point DSpace at a Solr instance *without* Basic Auth enabled, while still leaving `solr.authentication.*` set in `local.cfg`. Confirm nothing breaks, sending an `Authorization` header to a Solr instance that doesn't require one should be a no-op.


- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
