### PR TITLE
fix: Keep the requested scope and configuration in the /discover/search self link

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/DiscoverConfigurationConverter.java
@@ -26,24 +26,24 @@ import org.springframework.stereotype.Component;
  * to the convert method.
  */
 @Component
-public class DiscoverConfigurationConverter
-        implements DSpaceConverter<DiscoveryConfiguration, SearchConfigurationRest> {
+public class DiscoverConfigurationConverter {
 
-    @Override
-    public SearchConfigurationRest convert(DiscoveryConfiguration configuration, Projection projection) {
+    /**
+     * The requested configuration name and scope are kept on the REST object so that the self link can be built
+     * from them, the same way {@link DiscoverFacetConfigurationConverter} does it.
+     */
+    public SearchConfigurationRest convert(final String configurationName, final String scope,
+                                           DiscoveryConfiguration configuration, Projection projection) {
         SearchConfigurationRest searchConfigurationRest = new SearchConfigurationRest();
         searchConfigurationRest.setProjection(projection);
+        searchConfigurationRest.setConfiguration(configurationName);
+        searchConfigurationRest.setScope(scope);
         if (configuration != null) {
             addSearchFilters(searchConfigurationRest,
                              configuration.getSearchFilters(), configuration.getSidebarFacets());
             addSortOptions(searchConfigurationRest, configuration.getSearchSortConfiguration());
         }
         return searchConfigurationRest;
-    }
-
-    @Override
-    public Class<DiscoveryConfiguration> getModelClass() {
-        return DiscoveryConfiguration.class;
     }
 
     public void addSearchFilters(SearchConfigurationRest searchConfigurationRest,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/DiscoveryRestRepository.java
@@ -87,7 +87,8 @@ public class DiscoveryRestRepository extends AbstractDSpaceRestRepository {
         DiscoveryConfiguration discoveryConfiguration = searchConfigurationService
             .getDiscoveryConfigurationByNameOrIndexableObject(context, configuration, scopeObject);
 
-        return discoverConfigurationConverter.convert(discoveryConfiguration, utils.obtainProjection());
+        return discoverConfigurationConverter.convert(configuration, dsoScope, discoveryConfiguration,
+                                                      utils.obtainProjection());
     }
 
     public SearchResultsRest getSearchObjects(final String query, final List<String> dsoTypes, final String dsoScope,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/DiscoveryRestControllerIT.java
@@ -1260,6 +1260,33 @@ public class DiscoveryRestControllerIT extends AbstractControllerIntegrationTest
     }
 
     @Test
+    public void discoverSearchSelfLinkKeepsScopeAndConfigurationTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+
+        context.restoreAuthSystemState();
+
+        //The self link has to describe the request it answers
+        getClient().perform(get("/api/discover/search")
+                   .param("scope", parentCommunity.getID().toString())
+                   .param("configuration", "personOrOrgunit"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._links.self.href",
+                                       containsString("scope=" + parentCommunity.getID())))
+                   .andExpect(jsonPath("$._links.self.href",
+                                       containsString("configuration=personOrOrgunit")));
+
+        //And it may not add parameters the request did not have
+        getClient().perform(get("/api/discover/search"))
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$._links.self.href", not(containsString("scope="))))
+                   .andExpect(jsonPath("$._links.self.href", not(containsString("configuration="))));
+    }
+
+    @Test
     public void checkSortOrderInPersonOrOrgunitConfigurationTest() throws Exception {
         getClient().perform(get("/api/discover/search")
                    .param("configuration", "personOrOrgunit"))

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/DiscoverConfigurationConverterTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/converter/DiscoverConfigurationConverterTest.java
@@ -57,20 +57,30 @@ public class DiscoverConfigurationConverterTest {
     @Test
     public void testReturnType() throws Exception {
         populateDiscoveryConfigurationWithEmptyList();
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
         assertTrue(searchConfigurationRest.getFilters().isEmpty());
         assertEquals(SearchConfigurationRest.class, searchConfigurationRest.getClass());
     }
 
     @Test
     public void testConvertWithNullParamter() throws Exception {
-        assertNotNull(discoverConfigurationConverter.convert(null, Projection.DEFAULT));
+        assertNotNull(discoverConfigurationConverter.convert(null, null, null, Projection.DEFAULT));
+    }
+
+    @Test
+    public void testRequestedConfigurationAndScopeAreKept() throws Exception {
+        searchConfigurationRest = discoverConfigurationConverter.convert("personOrOrgunit", "a-scope-uuid",
+                                                                        discoveryConfiguration, Projection.DEFAULT);
+        assertEquals("personOrOrgunit", searchConfigurationRest.getConfiguration());
+        assertEquals("a-scope-uuid", searchConfigurationRest.getScope());
     }
 
     @Test
     public void testNoSearchSortConfigurationReturnObjectNotNull() throws Exception {
         discoveryConfiguration.setSearchFilters(new LinkedList<>());
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
         assertTrue(discoveryConfiguration.getSearchFilters().isEmpty());
         assertTrue(searchConfigurationRest.getFilters().isEmpty());
         assertNotNull(searchConfigurationRest);
@@ -79,7 +89,8 @@ public class DiscoverConfigurationConverterTest {
     @Test
     public void testNoSearchFilterReturnObjectNotNull() throws Exception {
         discoveryConfiguration.setSearchSortConfiguration(new DiscoverySortConfiguration());
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
         assertTrue(searchConfigurationRest.getFilters().isEmpty());
         assertNotNull(searchConfigurationRest);
     }
@@ -88,7 +99,8 @@ public class DiscoverConfigurationConverterTest {
     // are null
     @Test
     public void testNoSearchSortConfigurationAndNoSearchFilterReturnObjectNotNull() throws Exception {
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
         assertNotNull(searchConfigurationRest);
     }
 
@@ -111,7 +123,8 @@ public class DiscoverConfigurationConverterTest {
         when(discoveryConfiguration.getSearchSortConfiguration()).thenReturn(discoverySortConfiguration);
         when(discoverySortConfiguration.getSortFields()).thenReturn(mockedList);
 
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
 
         int counter = 0;
         for (SearchConfigurationRest.SortOption sortOption : searchConfigurationRest.getSortOptions()) {
@@ -126,7 +139,8 @@ public class DiscoverConfigurationConverterTest {
     @Test
     public void testEmptySortOptionsAfterConvertWithConfigurationWithEmptySortFields() throws Exception {
         populateDiscoveryConfigurationWithEmptyList();
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
         assertEquals(0, searchConfigurationRest.getSortOptions().size());
 
     }
@@ -135,7 +149,8 @@ public class DiscoverConfigurationConverterTest {
     public void testEmptySortOptionsAfterConvertWithConfigurationWithNullSortFields() throws Exception {
         populateDiscoveryConfigurationWithEmptyList();
         when(discoveryConfiguration.getSearchSortConfiguration()).thenReturn(null);
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
 
         assertEquals(0, searchConfigurationRest.getSortOptions().size());
     }
@@ -154,7 +169,8 @@ public class DiscoverConfigurationConverterTest {
         mockedList.add(discoverySearchFilter1);
         when(discoveryConfiguration.getSearchFilters()).thenReturn(mockedList);
 
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
 
         int counter = 0;
         for (SearchConfigurationRest.Filter filter : searchConfigurationRest.getFilters()) {
@@ -172,7 +188,8 @@ public class DiscoverConfigurationConverterTest {
     @Test
     public void testEmptySearchFilterAfterConvertWithConfigurationWithEmptySearchFilters() throws Exception {
         populateDiscoveryConfigurationWithEmptyList();
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
         assertEquals(0, searchConfigurationRest.getFilters().size());
     }
 
@@ -181,7 +198,8 @@ public class DiscoverConfigurationConverterTest {
         populateDiscoveryConfigurationWithEmptyList();
 
         when(discoveryConfiguration.getSearchFilters()).thenReturn(null);
-        searchConfigurationRest = discoverConfigurationConverter.convert(discoveryConfiguration, Projection.DEFAULT);
+        searchConfigurationRest = discoverConfigurationConverter.convert(null, null, discoveryConfiguration,
+                                                                        Projection.DEFAULT);
 
         assertEquals(0, searchConfigurationRest.getFilters().size());
     }


### PR DESCRIPTION
## References
* Fixes https://github.com/DSpace/DSpace/issues/8576
* Related to https://github.com/DSpace/dspace-angular/pull/6083

## Description
`/api/discover/search` left the `scope` and `configuration` it was called with out of its own self link, so the link described a different request than the one it answered.

## Instructions for Reviewers

Changes:
* `DiscoverConfigurationConverter` now takes the requested configuration name and scope and sets them on the `SearchConfigurationRest`. It was the only converter in this family implementing `DSpaceConverter`, which passes just a model object and a projection, so there was nowhere for the request parameters to travel and the link factory ended up building the self link out of two nulls. `DiscoverFacetConfigurationConverter` already does it this way for `/api/discover/facets`.
* `DiscoveryRestRepository.getSearchConfiguration` passes both values through.
* One integration test for the self link, one unit test for the converter.

Both fields are `@JsonIgnore`, so only `_links.self` changes and the response body stays as it was. The self link of this endpoint is not described in the REST Contract, so there is nothing to update there.

How to test:

```
curl -s "http://localhost:8080/server/api/discover/search?scope=<community-uuid>&configuration=community" | jq ._links.self.href
```

Before, that returns `.../api/discover/search`. After, it returns the URL that was requested. A request without parameters still gets a bare self link.

In the UI the same bug shows up as an `ensureSelfLink` console warning on any page that runs a scoped search, for example an Entity item page with a search section, or a community or collection home page. The plain `/search` page sends no parameters at all, which is why #8576 could not be reproduced from the steps in the ticket.

## Checklist
- [x] My PR is **created against the `main` branch** of code.
- [x] My PR is **small in size** (4 files, +67/-21).
- [x] My PR **follows all coding best practices** based on the Code Conventions Guide.
- [x] My PR **passes Checkstyle** validation based on the Code Style Guide.
- [x] My PR **includes Javadoc** for all new (or modified) public methods and classes.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** (`DiscoveryRestControllerIT` 85/85, `DiscoverConfigurationConverterTest` 12/12).
- [x] My PR **includes details on how to test it**.
- [x] If my PR includes new libraries/dependencies, licenses align (none added).
- [x] If my PR modifies REST API endpoints, a REST Contract PR is opened (N/A, the response body and the documented links are unchanged).
- [x] If my PR includes new configurations, technical documentation is provided (none added).
- [x] If my PR fixes an issue ticket, I've linked them together.

<sub>Written with some help from [Claude Code](https://claude.com/claude-code).</sub>