### PR TITLE
[Port dspace-8_x] Remove findbugs dependencies

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -684,16 +684,6 @@
             <version>${flyway.version}</version>
         </dependency>
 
-        <!-- FindBugs -->
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1747,20 +1747,6 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- Findbugs annotations -->
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-                <version>3.0.1u2</version>
-                <scope>provided</scope>
-            </dependency>
-
             <!-- Converge miscellaneous transitive dependencies. -->
             <dependency>
                 <groupId>com.fasterxml</groupId>


### PR DESCRIPTION
Manual port of #12988 to `dspace-8_x`. This one only removes the dependency from poms because we don't have a dependabot configuration on 8x.