### PR TITLE
Fix missing edit permissions on researcher profiles after automatic claim

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/login/impl/ResearcherProfileAutomaticClaim.java
@@ -10,6 +10,7 @@ package org.dspace.app.rest.login.impl;
 import static org.apache.commons.collections4.IteratorUtils.toList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.dspace.content.authority.Choices.CF_ACCEPTED;
+import static org.dspace.core.Constants.WRITE;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.login.PostLoggedInAction;
 import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Item;
 import org.dspace.content.MetadataFieldName;
 import org.dspace.content.service.ItemService;
@@ -53,6 +55,9 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
 
     @Autowired
     private EPersonService ePersonService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
 
     /**
      * The field of the eperson to search for.
@@ -104,6 +109,7 @@ public class ResearcherProfileAutomaticClaim implements PostLoggedInAction {
         if (item != null) {
             itemService.addMetadata(context, item, "dspace", "object", "owner",
                                     null, fullName, id.toString(), CF_ACCEPTED);
+            authorizeService.addPolicy(context, item, WRITE, currentUser);
         }
 
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/ResearcherProfileRestRepositoryIT.java
@@ -1037,6 +1037,22 @@ public class ResearcherProfileRestRepositoryIT extends AbstractControllerIntegra
         String secondItemId = getItemIdByProfileId(newUserToken, id);
         assertEquals("The item should be the same", firstItemId, secondItemId);
 
+        getClient(getAuthToken(admin.getEmail(), password))
+                .perform(get("/api/authz/resourcepolicies/search/resource")
+                        .param("uuid", firstItemId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.resourcepolicies",
+                        hasItem(matchResourcePolicyProperties(null, user, itemToBeClaimed, null,
+                                Constants.WRITE, null))));
+
+        getClient(newUserToken)
+                .perform(get("/api/authz/authorizations/search/object")
+                        .param("uri", "http://localhost/api/core/items/" + firstItemId)
+                        .param("feature", "canEditMetadata")
+                        .param("embed", "feature"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.authorizations[0]._embedded.feature.id")
+                        .value("canEditMetadata"));
     }
 
     @Test


### PR DESCRIPTION
## References
Fixes #12106 

## Description
This PR fixes missing edit permissions on preexisting researcher profiles that are automatically claimed by a user.

When a user automatically claims a preexisting researcher profile, the profile is correctly linked to the user but no WRITE resource policy is created for that user. As a result, the user cannot edit the metadata of their claimed profile.

This PR adds the missing WRITE policy when a researcher profile is automatically claimed.

## Instructions for Reviewers
### To test manually
1. With an admin, create an item on a Person collection.
2. Create or use an existing user account whose email address matches the person.email metadata of the previously created and unclaimed Person entity, then log in with that account.
3. Open the automatically claimed researcher profile. You need the line `researcher-profile.entity-type = Person` in your `local.cfg` to be able to see the researcher profile pages.
4. Verify that the user can edit the profile metadata.

The integration test can also be run with:
`mvn clean verify -pl dspace-server-webapp,dspace -am -DskipUnitTests=true -DskipIntegrationTests=false '-Dit.test=ResearcherProfileRestRepositoryIT#testAutomaticProfileClaimByEmailWithRegularEntity'`

List of changes in this PR:
* Grant the claiming user WRITE permission on the researcher profile item.
* Add integration tests verifying the WRITE policy and the `canEditMetadata` authorization after an automatic profile claim.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
