### PR TITLE
DS-12815: Fix validation of required relation-fields

### DIFF
--- a/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
+++ b/dspace-api/src/main/java/org/dspace/validation/MetadataValidator.java
@@ -190,7 +190,9 @@ public class MetadataValidator implements SubmissionStepValidator {
                                                 SubmissionStepConfig config) {
         if (input.isRelationshipField() && input.isRequired()) {
             String relationshipType = input.getRelationshipType();
-            if (itemService.getMetadataByMetadataString(item, "relation." + relationshipType).isEmpty()) {
+            if (itemService.getMetadataByMetadataString(item, "relation." + relationshipType).isEmpty() &&
+                    (input.getFieldName() == null ||
+                            itemService.getMetadataByMetadataString(item, input.getFieldName()).isEmpty())) {
                 try {
                     List<RelationshipType> relationTypes =
                         relationshipTypeService.findByLeftwardOrRightwardTypeName(context, relationshipType);


### PR DESCRIPTION
## References
_Add references/links to any related issues or PRs:_
* Fixes #12815

## Description
As described in the related issue, it is currently not possible to add plain-text values to relation-fields which have the _required_ attribute set. You must always connect a related entity. This PR modifies the check in the `MetadataValidator.java` in order to allow plain-text values, too.

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* Modified the `relationshipRequiredFieldCheck()` method of the `MetadataValidator` class in order to check for values in the linked-metadata-field, too.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 
1. Modify the _relation-field_ of a submission workflow step (for example the _publicationStep_) in order to make a relation-field required:
```xml
              <relation-field>
                    <relationship-type>isAuthorOfPublication</relationship-type>
                    <search-configuration>person</search-configuration>
                    <repeatable>true</repeatable>
                    <label>Author</label>
                    <hint>Enter the author's name (Family name, Given names).</hint>
                    <linked-metadata-field>
                        <dc-schema>dc</dc-schema>
                        <dc-element>contributor</dc-element>
                        <dc-qualifier>author</dc-qualifier>
                        <input-type>onebox</input-type>
                    </linked-metadata-field>
                    <externalsources>orcid</externalsources>
                    <required>Please add an author.</required>
                </relation-field>
  ```
2. Start a new submission using the modified workflow and add a text value to the required field.
3. Make sure the value is accepted and the current step is marked as ready
4. Remove the text value and verify, if the _required_-message is displayed.

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] ~If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.~
- [ ] ~If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.~
- [ ] ~If my PR includes new configurations, I've provided basic technical documentation in the PR itself.~
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
