### PR TITLE
fix(iiif): treat repeated TOC labels as distinct ranges when not contiguous

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/RangeService.java
@@ -7,6 +7,7 @@
  */
 package org.dspace.app.iiif.service;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,8 @@ public class RangeService extends AbstractResourceService {
     private Map<String, RangeGenerator> tocRanges = new LinkedHashMap<String, RangeGenerator>();
     private RangeGenerator currentRange;
     private RangeGenerator root;
+    private List<String> currentLabels = new ArrayList<>();
+    private List<RangeGenerator> currentRanges = new ArrayList<>();
 
 
     public RangeService(ConfigurationService configurationService) {
@@ -103,36 +106,46 @@ public class RangeService extends AbstractResourceService {
     private void addTocRange(List<String> tocs , CanvasGenerator canvasGenerator) {
 
         for (String toc : tocs) {
-            // Make tempRange a reference to root.
             RangeGenerator tempRange = root;
             String[] parts = toc.split(IIIFUtils.TOC_SEPARATOR_REGEX);
+            List<String> newLabels = new ArrayList<>();
+            List<RangeGenerator> newRanges = new ArrayList<>();
             String key = "";
-            // Process sub-ranges.
+            boolean onCurrentPath = true;
             for (int pIdx = 0; pIdx < parts.length; pIdx++) {
                 if (pIdx > 0) {
                     key += IIIFUtils.TOC_SEPARATOR;
                 }
                 key += parts[pIdx];
-                if (tocRanges.get(key) != null) {
-                    // Handles the case of a bitstream that crosses two ranges.
-                    tempRange = tocRanges.get(key);
+                // Reuse an existing range only while this segment still lies on the path
+                // from the root to the most recently updated range. This preserves the
+                // "bitstream that crosses two ranges" case and shared parent segments,
+                // while a repeated label that was interrupted by another section becomes
+                // a distinct logical section.
+                if (onCurrentPath && pIdx < currentLabels.size()
+                        && currentLabels.get(pIdx).equals(parts[pIdx])) {
+                    tempRange = currentRanges.get(pIdx);
                 } else {
+                    onCurrentPath = false;
                     RangeGenerator range = new RangeGenerator(this);
                     range.setLabel(parts[pIdx]);
-                    // Add sub-range to the root Range
                     tempRange.addSubRange(range);
-                    // Add new sub-range to the map.
-                    tocRanges.put(key, range);
-                    // Make tempRange a reference to the new sub-range.
+                    String uniqueKey = key;
+                    int suffix = 2;
+                    while (tocRanges.containsKey(uniqueKey)) {
+                        uniqueKey = key + " #" + suffix++;
+                    }
+                    tocRanges.put(uniqueKey, range);
                     tempRange = range;
                 }
+                newLabels.add(parts[pIdx]);
+                newRanges.add(tempRange);
             }
-            // Add a simple canvas reference to the Range.
             tempRange
                 .addCanvas(canvasService.getRangeCanvasReference(canvasGenerator.getIdentifier()));
-
-            // Update the current Range.
             currentRange = tempRange;
+            currentLabels = newLabels;
+            currentRanges = newRanges;
         }
     }
 

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/iiif/IIIFControllerIT.java
@@ -531,6 +531,145 @@ public class IIIFControllerIT extends AbstractControllerIntegrationTest {
     }
 
     @Test
+    public void findOneWithRepeatedTocLabels() throws Exception {
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                .withName("Parent Community")
+                .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                .build();
+        Item publicItem1 = ItemBuilder.createItem(context, col1)
+                .withTitle("Public item 1")
+                .withIssueDate("2017-10-17")
+                .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                .withIIIFCanvasHeight(3000)
+                .withIIIFCanvasWidth(2000)
+                .withIIIFCanvasNaming("Global")
+                .enableIIIF()
+                .enableIIIFSearch()
+                .build();
+
+        String bitstreamContent = "ThisIsSomeText";
+        // The same label is used twice, separated by other sections: Cover, Appendix,
+        // Chapter 1, chapter 2, Appendix, Cover.
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                    .createBitstream(context, publicItem1, is, IIIFBundle)
+                    .withName("Bitstream1.jpg")
+                    .withMimeType("image/jpeg")
+                    .withIIIFToC("Cover")
+                    .build();
+        }
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                    .createBitstream(context, publicItem1, is, IIIFBundle)
+                    .withName("Bitstream2.jpg")
+                    .withMimeType("image/jpeg")
+                    .withIIIFToC("Appendix")
+                    .build();
+        }
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                    .createBitstream(context, publicItem1, is, IIIFBundle)
+                    .withName("Bitstream3.jpg")
+                    .withMimeType("image/jpeg")
+                    .withIIIFToC("Chapter 1")
+                    .build();
+        }
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                    .createBitstream(context, publicItem1, is, IIIFBundle)
+                    .withName("Bitstream4.jpg")
+                    .withMimeType("image/jpeg")
+                    .withIIIFToC("chapter 2")
+                    .build();
+        }
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                    .createBitstream(context, publicItem1, is, IIIFBundle)
+                    .withName("Bitstream5.jpg")
+                    .withMimeType("image/jpeg")
+                    .withIIIFToC("Appendix")
+                    .build();
+        }
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder
+                    .createBitstream(context, publicItem1, is, IIIFBundle)
+                    .withName("Bitstream6.jpg")
+                    .withMimeType("image/jpeg")
+                    .withIIIFToC("Cover")
+                    .build();
+        }
+
+        context.restoreAuthSystemState();
+        // Expect six distinct ranges, not four: the repeated Appendix and Cover labels are
+        // not contiguous with the section of the same name, so each is its own section.
+        getClient().perform(get("/iiif/" + publicItem1.getID() + "/manifest"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "application/json;charset=UTF-8"))
+                .andExpect(jsonPath("$.@context", is("http://iiif.io/api/presentation/2/context.json")))
+                .andExpect(jsonPath("$.sequences[0].canvases", Matchers.hasSize(6)))
+                .andExpect(jsonPath("$.structures[0].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0")))
+                .andExpect(jsonPath("$.structures[0].label", is("Table of Contents")))
+                .andExpect(jsonPath("$.structures[0].viewingHint", is("top")))
+                .andExpect(jsonPath("$.structures[0].ranges", Matchers.hasSize(6)))
+                // The six sub-range references are distinct.
+                .andExpect(jsonPath("$.structures[0].ranges[0]",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-0")))
+                .andExpect(jsonPath("$.structures[0].ranges[1]",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-1")))
+                .andExpect(jsonPath("$.structures[0].ranges[2]",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-2")))
+                .andExpect(jsonPath("$.structures[0].ranges[3]",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-3")))
+                .andExpect(jsonPath("$.structures[0].ranges[4]",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-4")))
+                .andExpect(jsonPath("$.structures[0].ranges[5]",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-5")))
+                .andExpect(jsonPath("$.structures[0].canvases").doesNotExist())
+                // Each of the six sections holds exactly its own canvas.
+                .andExpect(jsonPath("$.structures[1].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-0")))
+                .andExpect(jsonPath("$.structures[1].label", is("Cover")))
+                .andExpect(jsonPath("$.structures[1].canvases", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$.structures[1].canvases[0]",
+                        Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c0")))
+                .andExpect(jsonPath("$.structures[2].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-1")))
+                .andExpect(jsonPath("$.structures[2].label", is("Appendix")))
+                .andExpect(jsonPath("$.structures[2].canvases", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$.structures[2].canvases[0]",
+                        Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c1")))
+                .andExpect(jsonPath("$.structures[3].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-2")))
+                .andExpect(jsonPath("$.structures[3].label", is("Chapter 1")))
+                .andExpect(jsonPath("$.structures[3].canvases", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$.structures[3].canvases[0]",
+                        Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c2")))
+                .andExpect(jsonPath("$.structures[4].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-3")))
+                .andExpect(jsonPath("$.structures[4].label", is("chapter 2")))
+                .andExpect(jsonPath("$.structures[4].canvases", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$.structures[4].canvases[0]",
+                        Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c3")))
+                .andExpect(jsonPath("$.structures[5].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-4")))
+                .andExpect(jsonPath("$.structures[5].label", is("Appendix")))
+                .andExpect(jsonPath("$.structures[5].canvases", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$.structures[5].canvases[0]",
+                        Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c4")))
+                .andExpect(jsonPath("$.structures[6].@id",
+                        Matchers.endsWith("/iiif/" + publicItem1.getID() + "/manifest/range/r0-5")))
+                .andExpect(jsonPath("$.structures[6].label", is("Cover")))
+                .andExpect(jsonPath("$.structures[6].canvases", Matchers.hasSize(1)))
+                .andExpect(jsonPath("$.structures[6].canvases[0]",
+                        Matchers.containsString("/iiif/" + publicItem1.getID() + "/canvas/c5")))
+                .andExpect(jsonPath("$.structures[7]").doesNotExist());
+    }
+
+    @Test
     public void findOneWithBundleStructures() throws Exception {
 
         context.turnOffAuthorisationSystem();


### PR DESCRIPTION
## References

* Fixes #12527

## Description

Repeated TOC labels are collapsed into a single range because `tocRanges` is keyed on the composite TOC path alone. This PR reuses an existing range only while the path segment still lies on the path from the root to the most recently updated range, so a label that reappears after an intervening section becomes its own range.

## Instructions for Reviewers

[The design question on the issue](https://github.com/DSpace/DSpace/issues/12527#issuecomment-4663121356): continuation onto the next bitstream, or a repeated path name? Continuation is already modelled in `updateRanges` (RangeService.java:86-92) as absence of `iiif.toc` metadata, so a repeated path cannot express it. Contiguity is the discriminator:

> Reuse a segment only while it lies on the path from the root to the most recently updated range. At the first divergence, create new nodes for the remainder of the path. A repeated label interrupted by another section is a new section.

List of changes in this PR:

Line numbers throughout are against `main`, not this PR's head.

* `RangeService` now tracks the active path (`currentLabels` / `currentRanges`) alongside `currentRange`, and `addTocRange` matches against that path instead of doing a global lookup in `tocRanges`.
* When a key collides, the map entry is stored under a disambiguated key. Nothing reads these keys — `ManifestService` (lines 175-181) iterates `tocRanges.values()` — so the suffix only preserves map integrity.
* `getTocRanges()`, `updateRanges()` and `ManifestService` are untouched.
* New integration test `findOneWithRepeatedTocLabels()` in `IIIFControllerIT`, built from the issue's own example: `Cover, Appendix, Chapter 1, chapter 2, Appendix, Cover` now yields six distinct ranges (`r0-0` … `r0-5`), each holding its own canvas, instead of four.

**How to test.** Run `mvn install -DskipUnitTests=true -DskipIntegrationTests=false -Dit.test=IIIFControllerIT` (full reactor — the `dspace` module supplies the test environment config, so `-pl` will not work here). To reproduce by hand: enable IIIF on an item and give six bitstreams the `iiif.toc` values above; before this change the manifest shows four ranges, after it six.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
