### PR TITLE
dspace/config/dspace.cfg: increase default thumbnail width

### DIFF
--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1420,10 +1420,11 @@ cc.license.locale = en
 ##### Settings for Thumbnail creation #####
 
 # Maximum width and height (in pixels) of generated thumbnails
-# NOTE: In the UI's base theme, `--ds-thumbnail-max-width` defaults to 175px.
-# So, if you set 'thumbnail.maxwidth' >175, you may wish to modify that UI style variable as well.
-thumbnail.maxwidth  = 175
-thumbnail.maxheight = 175
+# NOTE: In the UI's base theme, `--ds-thumbnail-max-width` defaults to 175px. We
+# use a larger value here so that portrait thumbnails are roughly twice the width
+# and therefore look more crisp when scaled down in CSS on the frontend.
+thumbnail.maxwidth  = 500
+thumbnail.maxheight = 500
 
 # Blur before scaling.  A little blur before scaling does wonders for keeping
 # more in check. (Only used by JPEGFilter)


### PR DESCRIPTION
# References
_Add references/links to any related issues or PRs. These may include:_
* Fixes https://github.com/DSpace/DSpace/issues/12004
* Requires https://github.com/DSpace/dspace-angular/pull/6213

# Description
Increase default thumbnail width to 500px so it is roughly 2x the frontend display width for most portrait layout images. This will make them slightly more crisp.

# Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, increase default thumbnail width from 175px to 500px

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes.

Force regeneration of PDF thumbnails using `./bin/dspace filter-media -i <handle> -p "PDFBox JPEG Thumbnail" -f` and check the item page to see that they are higher quality.

# Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome).
However, reviewers may request that you complete any actions in this list if you have not done so. If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
