### PR TITLE
Fix slowness for deep OAI page response

### DIFF
--- a/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/controller/DSpaceOAIDataProvider.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 import org.dspace.app.util.XMLUtils;
 import org.dspace.core.Context;
 import org.dspace.services.ConfigurationService;
+import org.dspace.xoai.data.ResumptionCursor;
 import org.dspace.xoai.services.api.cache.XOAICacheService;
 import org.dspace.xoai.services.api.config.XOAIManagerResolver;
 import org.dspace.xoai.services.api.config.XOAIManagerResolverException;
@@ -91,7 +92,6 @@ public class DSpaceOAIDataProvider {
     @Autowired
     ConfigurationService configurationService;
 
-    private DSpaceResumptionTokenFormatter resumptionTokenFormat = new DSpaceResumptionTokenFormatter();
 
     @PostConstruct
     public void setUpHTMLTransformerFactory() {
@@ -143,11 +143,12 @@ public class DSpaceOAIDataProvider {
 
             XOAIManager manager = xoaiManagerResolver.getManager();
 
+            ResumptionCursor cursor = new ResumptionCursor();
             OAIDataProvider dataProvider = new OAIDataProvider(manager, xoaiContext,
                                                                identifyResolver.getIdentify(),
                                                                setRepositoryResolver.getSetRepository(),
-                                                               itemRepositoryResolver.getItemRepository(),
-                                                               resumptionTokenFormat);
+                                                               itemRepositoryResolver.getItemRepository(cursor),
+                                                               new DSpaceResumptionTokenFormatter(cursor));
 
             OutputStream out = response.getOutputStream();
             OAIRequestParameters parameters = new OAIRequestParameters(buildParametersMap(request));
@@ -204,7 +205,7 @@ public class DSpaceOAIDataProvider {
         } catch (InvalidContextException e) {
             log.debug(e.getMessage(), e);
             return indexAction(response, model);
-        } catch (ContextServiceException e) {
+        } catch (ContextServiceException | WritingXmlException | XMLStreamException e) {
             log.error(e.getMessage(), e);
             closeContext(context);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
@@ -217,16 +218,6 @@ public class DSpaceOAIDataProvider {
             closeContext(context);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                                "Unexpected error. For more information visit the log files.");
-        } catch (WritingXmlException e) {
-            log.error(e.getMessage(), e);
-            closeContext(context);
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                               "Unexpected error while writing the output. For more information visit the log files.");
-        } catch (XMLStreamException e) {
-            log.error(e.getMessage(), e);
-            closeContext(context);
-            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                               "Unexpected error while writing the output. For more information visit the log files.");
         } finally {
             closeContext(context);
         }

--- a/dspace-oai/src/main/java/org/dspace/xoai/data/ResumptionCursor.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/data/ResumptionCursor.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.data;
+
+/**
+ * Ordered key of the last record served by an OAI-PMH page, carried across a single request.
+ *
+ * <p>The xoai library models a resumptionToken as a plain record offset
+ * ({@link com.lyncode.xoai.dataprovider.core.ResumptionToken#getOffset()}), which forces Solr to skip that
+ * many documents before it can serve a page: the deeper a harvest goes, the slower the response gets.
+ * The {@code item.id} of the last record already served lets Solr seek straight to the next page instead, at a
+ * cost that no longer grows with the offset -- and whether more pages remain is read off the bounded query's
+ * numFound, so the key is the only position the token has to carry. It's possible because the Solr query is
+ * already sorted on {@code item.id}.</p>
+ *
+ * <p>It has nowhere to live in the xoai library's token, so it travels through this object between the two places
+ * DSpace owns:
+ *   * {@code DSpaceResumptionTokenFormatter}, which reads it from and writes it back to the token string
+ *   * {@code DSpaceItemSolrRepository}, which turns it into a Solr range query.
+ * </p>
+ *
+ * <p>One instance is created per request by {@code DSpaceOAIDataProvider} and handed to both collaborators,
+ * so concurrent harvests never share a position. A request serves one page, which is why a single key is
+ * enough: the value read from the incoming token is replaced by the one the served page ends on.</p>
+ */
+public class ResumptionCursor {
+
+    private String itemUUID;
+
+    public String valueOf() {
+        return itemUUID;
+    }
+
+    public boolean isEmpty() {
+        return itemUUID == null;
+    }
+
+    public void moveTo(String itemUUID) {
+        this.itemUUID = itemUUID;
+    }
+}

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/api/xoai/ItemRepositoryResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/api/xoai/ItemRepositoryResolver.java
@@ -8,8 +8,14 @@
 package org.dspace.xoai.services.api.xoai;
 
 import com.lyncode.xoai.dataprovider.services.api.ItemRepository;
+import org.dspace.xoai.data.ResumptionCursor;
 import org.dspace.xoai.services.api.context.ContextServiceException;
 
 public interface ItemRepositoryResolver {
-    ItemRepository getItemRepository() throws ContextServiceException;
+    /**
+     * @param cursor position holder for the request being served, shared with the resumptionToken formatter
+     * @return a repository bound to that request
+     * @throws ContextServiceException if the repository cannot be built
+     */
+    ItemRepository getItemRepository(ResumptionCursor cursor) throws ContextServiceException;
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemRepositoryResolver.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemRepositoryResolver.java
@@ -9,10 +9,9 @@ package org.dspace.xoai.services.impl.xoai;
 
 import com.lyncode.xoai.dataprovider.services.api.ItemRepository;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.dspace.xoai.data.ResumptionCursor;
 import org.dspace.xoai.services.api.CollectionsService;
 import org.dspace.xoai.services.api.HandleResolver;
-import org.dspace.xoai.services.api.config.ConfigurationService;
-import org.dspace.xoai.services.api.context.ContextService;
 import org.dspace.xoai.services.api.context.ContextServiceException;
 import org.dspace.xoai.services.api.solr.SolrQueryResolver;
 import org.dspace.xoai.services.api.solr.SolrServerResolver;
@@ -20,10 +19,6 @@ import org.dspace.xoai.services.api.xoai.ItemRepositoryResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DSpaceItemRepositoryResolver implements ItemRepositoryResolver {
-    @Autowired
-    ContextService contextService;
-    @Autowired
-    ConfigurationService configurationService;
     @Autowired
     SolrServerResolver solrServerResolver;
     @Autowired
@@ -33,23 +28,21 @@ public class DSpaceItemRepositoryResolver implements ItemRepositoryResolver {
     @Autowired
     private HandleResolver handleResolver;
 
-    private ItemRepository itemRepository;
-
-
     @Override
-    public ItemRepository getItemRepository() throws ContextServiceException {
-        if (itemRepository == null) {
-            try {
-                itemRepository = new DSpaceItemSolrRepository(
-                    solrServerResolver.getServer(),
-                    collectionsService,
-                    handleResolver,
-                    solrQueryResolver);
-            } catch (SolrServerException e) {
-                throw new ContextServiceException(e.getMessage(), e);
-            }
+    public ItemRepository getItemRepository(ResumptionCursor cursor) throws ContextServiceException {
+        try {
+            // Built per request rather than cached, because the cursor it reads and moves belongs to a single
+            // request. The cost is one wrapper object: the Solr client behind it stays shared, memorised by
+            // {@link DSpaceSolrServerResolver}.
+            return new DSpaceItemSolrRepository(
+                solrServerResolver.getServer(),
+                collectionsService,
+                handleResolver,
+                solrQueryResolver,
+                cursor
+            );
+        } catch (SolrServerException e) {
+            throw new ContextServiceException(e.getMessage(), e);
         }
-
-        return itemRepository;
     }
 }

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemSolrRepository.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceItemSolrRepository.java
@@ -24,11 +24,13 @@ import com.lyncode.xoai.dataprovider.exceptions.IdDoesNotExistException;
 import com.lyncode.xoai.dataprovider.filter.ScopedFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.TermRangeQuery;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.dspace.xoai.data.DSpaceSolrItem;
+import org.dspace.xoai.data.ResumptionCursor;
 import org.dspace.xoai.services.api.CollectionsService;
 import org.dspace.xoai.services.api.HandleResolver;
 import org.dspace.xoai.services.api.solr.SolrQueryResolver;
@@ -43,12 +45,15 @@ public class DSpaceItemSolrRepository extends DSpaceItemRepository {
     private static final Logger log = LogManager.getLogger(DSpaceItemSolrRepository.class);
     private final SolrClient server;
     private final SolrQueryResolver solrQueryResolver;
+    private final ResumptionCursor cursor;
 
     public DSpaceItemSolrRepository(SolrClient server, CollectionsService collectionsService,
-                                    HandleResolver handleResolver, SolrQueryResolver solrQueryResolver) {
+                                    HandleResolver handleResolver, SolrQueryResolver solrQueryResolver,
+                                    ResumptionCursor cursor) {
         super(collectionsService, handleResolver);
         this.server = server;
         this.solrQueryResolver = solrQueryResolver;
+        this.cursor = cursor;
     }
 
     @Override
@@ -69,8 +74,7 @@ public class DSpaceItemSolrRepository extends DSpaceItemRepository {
     }
 
     @Override
-    public ListItemIdentifiersResult getItemIdentifiers(
-        List<ScopedFilter> filters, int offset, int length) {
+    public ListItemIdentifiersResult getItemIdentifiers(List<ScopedFilter> filters, int offset, int length) {
         try {
             QueryResult queryResult = retrieveItems(filters, offset, length);
             // transform results list from a list of Items to a list of ItemIdentifiers
@@ -89,8 +93,7 @@ public class DSpaceItemSolrRepository extends DSpaceItemRepository {
     }
 
     @Override
-    public ListItemsResults getItems(List<ScopedFilter> filters, int offset,
-                                     int length) {
+    public ListItemsResults getItems(List<ScopedFilter> filters, int offset, int length) {
         try {
             QueryResult queryResult = retrieveItems(filters, offset, length);
             return new ListItemsResults(queryResult.hasMore(), queryResult.getResults(), queryResult.getTotal());
@@ -103,15 +106,37 @@ public class DSpaceItemSolrRepository extends DSpaceItemRepository {
     private QueryResult retrieveItems(List<ScopedFilter> filters, int offset, int length)
             throws DSpaceSolrException, IOException {
         List<Item> list = new ArrayList<>();
-        SolrQuery params = new SolrQuery(solrQueryResolver.buildQuery(filters))
+        String query = solrQueryResolver.buildQuery(filters);
+        // Excluding the records already served from the query itself lets Solr seek to this page, instead of
+        // walking a priority queue of offset + length entries to throw away all but the last of them.
+        // The bound is only meaningful because DSpaceSolrSearch sorts on that very field, ascending.
+        // Without a cursor -- first page, or a token issued before they existed -- the offset is skipped as it was.
+        boolean seekable = !cursor.isEmpty();
+        if (seekable) {
+            // Generates: item.id:{cursorValue TO *]
+            TermRangeQuery rangeQuery = TermRangeQuery.newStringRange("item.id", cursor.valueOf(), null, false, true);
+            query += " AND " + rangeQuery.toString();
+        }
+        SolrQuery params = new SolrQuery(query)
             .setRows(length)
-            .setStart(offset);
+            .setStart(seekable ? 0 : offset);
         SolrDocumentList solrDocuments = DSpaceSolrSearch.query(server, params);
         for (SolrDocument doc : solrDocuments) {
             list.add(new DSpaceSolrItem(doc));
         }
-        return new QueryResult(list, (solrDocuments.getNumFound() > offset + length),
-                               (int) solrDocuments.getNumFound());
+        if (!solrDocuments.isEmpty()) {
+            // move the cursor to the last item from the Solr response
+            SolrDocument last = solrDocuments.get(solrDocuments.size() - 1);
+            cursor.moveTo((String) last.getFieldValue("item.id"));
+        }
+        // With the cursor bound in place, numFound is exactly what was left to serve, this page included:
+        //   * strictly more than a page means another page
+        //   * exactly a page means this one was the last.
+        //   * -1 makes the xoai library omit that optional attribute.
+        long numFound = solrDocuments.getNumFound();
+        return (seekable)
+            ? new QueryResult(list, numFound > length, -1)
+            : new QueryResult(list, numFound > offset + length, (int) numFound);
     }
 
     private class QueryResult {

--- a/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceResumptionTokenFormatter.java
+++ b/dspace-oai/src/main/java/org/dspace/xoai/services/impl/xoai/DSpaceResumptionTokenFormatter.java
@@ -7,20 +7,43 @@
  */
 package org.dspace.xoai.services.impl.xoai;
 
+import java.util.Date;
+import java.util.StringJoiner;
+import java.util.UUID;
+
 import com.lyncode.xoai.dataprovider.core.ResumptionToken;
 import com.lyncode.xoai.dataprovider.exceptions.BadResumptionToken;
 import com.lyncode.xoai.dataprovider.services.api.ResumptionTokenFormatter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.dspace.xoai.data.ResumptionCursor;
 import org.dspace.xoai.util.DateUtils;
 
 
+/**
+ * Decode and encode the resumptionToken values DSpace hands out.
+ *
+ * <p>One shape is accepted, {@code metadataPrefix/from/until/set/cursor}: the four fields the xoai library
+ * drives, plus the position the harvest resumes from. What that position is depends on the verb:</p>
+ * <ul>
+ *   <li>the {@code item.id} of the last record served, for the verbs that page through the item repository
+ *       (ListRecords, ListIdentifiers). It lets the next page be reached with a Solr range query instead of
+ *       a deep offset skip; see {@link ResumptionCursor}.</li>
+ *   <li>a plain record offset, for ListSets: sets have no item.id and the xoai library pages them by
+ *       counting records up. An item-verb token carrying an offset instead of an item.id -- the historical
+ *       token shape -- is served the same way: slow on deep pages, but correct.</li>
+ * </ul>
+ *
+ * <p>Any other shape is refused as {@link BadResumptionToken}.</p>
+ */
 public class DSpaceResumptionTokenFormatter implements ResumptionTokenFormatter {
-    private static Logger log = LogManager
-        .getLogger(DSpaceResumptionTokenFormatter.class);
+    private final static Logger log = LogManager.getLogger(DSpaceResumptionTokenFormatter.class);
+    private final static String TOKEN_SEPARATOR = "/";
 
-    public DSpaceResumptionTokenFormatter() {
-        // TODO Auto-generated constructor stub
+    private final ResumptionCursor cursor;
+
+    public DSpaceResumptionTokenFormatter(ResumptionCursor cursor) {
+        this.cursor = cursor;
     }
 
     @Override
@@ -28,46 +51,46 @@ public class DSpaceResumptionTokenFormatter implements ResumptionTokenFormatter 
         if (resumptionToken == null) {
             return new ResumptionToken();
         }
-        String[] res = resumptionToken.split("/", -1);
+        String[] res = resumptionToken.split(TOKEN_SEPARATOR, -1);
         if (res.length != 5) {
             throw new BadResumptionToken();
-        } else {
+        }
+        try {
+            String prefix = res[0].isEmpty() ? null : res[0];
+            Date from = res[1].isEmpty() ? null : Date.from(DateUtils.parse(res[1]));
+            Date until = res[2].isEmpty() ? null : Date.from(DateUtils.parse(res[2]));
+            String set = res[3].isEmpty() ? null : res[3];
+            // The last field is the position the harvest resumes from:
+            //   * the item.id of the last record served,
+            //   * a plain offset for the verbs that have none (ListSets).
+            // Forcing the value through UUID.fromString is also what keeps a client supplied string out of the Solr
+            // query the cursor is interpolated into.
+            int offset = 0;
             try {
-                int offset = Integer.parseInt(res[4]);
-                String prefix = (res[0].equals("")) ? null : res[0];
-                String set = (res[3].equals("")) ? null : res[3];
-                java.util.Date from = (res[1].equals("")) ? null : java.util.Date.from(DateUtils.parse(res[1]));
-                java.util.Date until = res[2].equals("") ? null : java.util.Date.from(DateUtils.parse(res[2]));
-                return new ResumptionToken(offset, prefix, set, from, until);
-            } catch (Exception e) {
-                log.error(e.getMessage(), e);
-                throw new BadResumptionToken();
+                cursor.moveTo(UUID.fromString(res[4]).toString());
+            } catch (IllegalArgumentException notAnItemId) {
+                offset = Integer.parseInt(res[4]);
             }
+            return new ResumptionToken(offset, prefix, set, from, until);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            throw new BadResumptionToken();
         }
     }
 
 
     @Override
     public String format(ResumptionToken resumptionToken) {
-        String result = "";
-        if (resumptionToken.hasMetadataPrefix()) {
-            result += resumptionToken.getMetadataPrefix();
-        }
-        result += "/";
-        if (resumptionToken.hasFrom()) {
-            result += DateUtils.format(resumptionToken.getFrom().toInstant());
-        }
-        result += "/";
-        if (resumptionToken.hasUntil()) {
-            result += DateUtils.format(resumptionToken.getUntil().toInstant());
-        }
-        result += "/";
-        if (resumptionToken.hasSet()) {
-            result += resumptionToken.getSet();
-        }
-        result += "/";
-        result += resumptionToken.getOffset();
-        return result;
+        // The repository moves the cursor to the end of the page it just served, which is exactly where this
+        // token resumes from. It stays empty for the verbs that never reach the item repository -- ListSets --
+        // whose pages are reached through the offset the xoai library counts up.
+        return new StringJoiner(TOKEN_SEPARATOR)
+            .add(resumptionToken.hasMetadataPrefix() ? resumptionToken.getMetadataPrefix() : "")
+            .add(resumptionToken.hasFrom() ? DateUtils.format(resumptionToken.getFrom().toInstant()) : "")
+            .add(resumptionToken.hasUntil() ? DateUtils.format(resumptionToken.getUntil().toInstant()) : "")
+            .add(resumptionToken.hasSet() ? resumptionToken.getSet() : "")
+            .add(cursor.isEmpty() ? String.valueOf(resumptionToken.getOffset()) : cursor.valueOf())
+            .toString();
     }
 
 }

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/xoai/DSpaceItemSolrRepositoryTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/xoai/DSpaceItemSolrRepositoryTest.java
@@ -1,0 +1,163 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.tests.unit.services.impl.xoai;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import com.lyncode.xoai.dataprovider.core.ListItemsResults;
+import com.lyncode.xoai.dataprovider.filter.ScopedFilter;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.dspace.xoai.data.ResumptionCursor;
+import org.dspace.xoai.services.api.solr.SolrQueryResolver;
+import org.dspace.xoai.services.impl.xoai.DSpaceItemSolrRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class DSpaceItemSolrRepositoryTest {
+
+    private static final String QUERY = "(item.collections:col_123456789_2)";
+    private static final int TOTAL = 1000;
+    private static final int LENGTH = 10;
+    private static final int SERVED = 400;
+
+    private final List<ScopedFilter> filters = new ArrayList<>();
+    private final ResumptionCursor cursor = new ResumptionCursor();
+    private final String cursorId = UUID.randomUUID().toString();
+    private final List<String> respondedIds = new ArrayList<>();
+    private SolrClient server;
+    private DSpaceItemSolrRepository underTest;
+
+    @Before
+    public void wire() throws Exception {
+        server = mock(SolrClient.class);
+        SolrQueryResolver queryResolver = mock(SolrQueryResolver.class);
+        when(queryResolver.buildQuery(any())).thenReturn(QUERY);
+        underTest = new DSpaceItemSolrRepository(server, null, null, queryResolver, cursor);
+    }
+
+    @Test
+    public void theFirstPageSkipsNothingAndReportsWhereItStopped() throws Exception {
+        respondWith(TOTAL, LENGTH);
+
+        ListItemsResults results = underTest.getItems(filters, 0, LENGTH);
+
+        assertThat(capturedQuery().getQuery(), is(QUERY));
+        assertThat(capturedQuery().getStart(), is(0));
+        assertThat(results.getTotal(), is(TOTAL));
+        assertThat(results.hasMore(), is(true));
+        assertThat("the page just served is where the next one resumes from",
+                   cursor.valueOf(), is(lastRespondedId()));
+    }
+
+    /**
+     * The upper bound of the range has to stay open. Built from the term "*" instead of a null term,
+     * TermRangeQuery escapes it to "\*", Solr reads the literal string and answers 400 "Invalid UUID String:
+     * '*'" -- which getItems() turns into an empty page and a harvester reads as the end of the set. Hence an
+     * assertion on the exact syntax handed over, not merely on the presence of a range.
+     */
+    @Test
+    public void aPageReachedWithACursorIsBoundedByAnOpenEndedRange() throws Exception {
+        cursor.moveTo(cursorId);
+        respondWith(TOTAL - SERVED, LENGTH);
+
+        underTest.getItems(filters, 0, LENGTH);
+
+        assertThat(capturedQuery().getQuery(), is(QUERY + " AND item.id:{" + cursorId + " TO *]"));
+        assertThat("nothing left to skip once the query starts where the cursor stands",
+                   capturedQuery().getStart(), is(0));
+    }
+
+    /**
+     * With the cursor bound in place, numFound is what was left to serve, this page included: one record
+     * beyond a full page is enough to announce another one. How many records stand before the cursor is not
+     * carried anymore, so no complete list size can be reported -- the attribute is optional and omitted.
+     */
+    @Test
+    public void onePastAFullPageAnnouncesAnotherOneAndNoCompleteListSize() throws Exception {
+        cursor.moveTo(cursorId);
+        respondWith(LENGTH + 1, LENGTH);
+
+        ListItemsResults results = underTest.getItems(filters, 0, LENGTH);
+
+        assertThat("the record past this page still has to be announced",
+                   results.hasMore(), is(true));
+        assertThat(results.hasTotalResults(), is(false));
+    }
+
+    /**
+     * Also the case of a set whose size is an exact multiple of the page size: the last full page already
+     * reports no more, so no empty final page -- which the xoai library would turn into a noRecordsMatch
+     * error mid-harvest -- is ever announced.
+     */
+    @Test
+    public void aPageServingExactlyWhatWasLeftReportsNoMore() throws Exception {
+        cursor.moveTo(cursorId);
+        respondWith(LENGTH, LENGTH);
+
+        ListItemsResults results = underTest.getItems(filters, 0, LENGTH);
+
+        assertThat(results.hasMore(), is(false));
+    }
+
+    @Test
+    public void aPageWithoutACursorFallsBackToSkippingTheOffset() throws Exception {
+        // What a token whose cursor field is empty resolves to.
+        respondWith(TOTAL, LENGTH);
+
+        ListItemsResults results = underTest.getItems(filters, SERVED, LENGTH);
+
+        assertThat(capturedQuery().getQuery(), is(not(containsString("item.id:"))));
+        assertThat("the offset has to be skipped the old way", capturedQuery().getStart(), is(SERVED));
+        assertThat("an unbounded count is already the total", results.getTotal(), is(TOTAL));
+    }
+
+    private void respondWith(long numFound, int returned) throws Exception {
+        SolrDocumentList documents = new SolrDocumentList();
+        documents.setNumFound(numFound);
+        for (int i = 0; i < returned; i++) {
+            String itemId = UUID.randomUUID().toString();
+            respondedIds.add(itemId);
+            SolrDocument document = new SolrDocument();
+            document.addField("item.id", itemId);
+            document.addField("item.handle", "123456789/" + i);
+            document.addField("item.lastmodified", new Date());
+            document.addField("item.deleted", Boolean.FALSE);
+            documents.add(document);
+        }
+        QueryResponse response = mock(QueryResponse.class);
+        when(response.getResults()).thenReturn(documents);
+        when(server.query(any(SolrQuery.class))).thenReturn(response);
+    }
+
+    private String lastRespondedId() {
+        return respondedIds.get(respondedIds.size() - 1);
+    }
+
+    private SolrQuery capturedQuery() throws Exception {
+        ArgumentCaptor<SolrQuery> captor = ArgumentCaptor.forClass(SolrQuery.class);
+        verify(server).query(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/xoai/DSpaceResumptionTokenFormatterTest.java
+++ b/dspace-oai/src/test/java/org/dspace/xoai/tests/unit/services/impl/xoai/DSpaceResumptionTokenFormatterTest.java
@@ -1,0 +1,112 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.tests.unit.services.impl.xoai;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.UUID;
+
+import com.lyncode.xoai.dataprovider.core.ResumptionToken;
+import com.lyncode.xoai.dataprovider.exceptions.BadResumptionToken;
+import org.dspace.xoai.data.ResumptionCursor;
+import org.dspace.xoai.services.impl.xoai.DSpaceResumptionTokenFormatter;
+import org.junit.Test;
+
+public class DSpaceResumptionTokenFormatterTest {
+
+    private static final String SET = "col_123456789_2";
+
+    private final String itemId = UUID.randomUUID().toString();
+    private final ResumptionCursor cursor = new ResumptionCursor();
+    private final DSpaceResumptionTokenFormatter underTest = new DSpaceResumptionTokenFormatter(cursor);
+
+    @Test
+    public void theCursorReachedWhileServingAPageIsThePositionFieldOfTheToken() {
+        cursor.moveTo(itemId);
+
+        // The offset the xoai library counts up is not carried: the cursor alone names the position.
+        assertThat(underTest.format(new ResumptionToken(200, "oai_dc", SET, null, null)),
+                   is("oai_dc///" + SET + "/" + itemId));
+    }
+
+    @Test
+    public void aVerbThatNeverReachedTheItemRepositoryPagesThroughItsOffset() {
+        // ListSets paginates through its own repository, which leaves the cursor untouched: its tokens
+        // carry the offset in the position field, because sets have no item.id to stand on.
+        assertThat(underTest.format(new ResumptionToken(200, null, null, null, null)),
+                   is("////200"));
+    }
+
+    @Test
+    public void aTokenCarryingACursorIsParsedIntoThePositionItNames() throws Exception {
+        ResumptionToken token = underTest.parse("oai_dc///" + SET + "/" + itemId);
+
+        assertThat(token.getMetadataPrefix(), is("oai_dc"));
+        assertThat(token.getSet(), is(SET));
+        assertThat(cursor.valueOf(), is(itemId));
+        assertThat("the cursor is the position, nothing is left to skip", token.getOffset(), is(0));
+    }
+
+    @Test
+    public void aTokenCarryingAnOffsetIsParsedIntoIt() throws Exception {
+        // The ListSets shape -- also what a token from before cursors existed looks like: the repository
+        // then pages through the offset, slow on deep pages but correct.
+        ResumptionToken token = underTest.parse("oai_dc///" + SET + "/200");
+
+        assertThat(token.getOffset(), is(200));
+        assertThat(token.getMetadataPrefix(), is("oai_dc"));
+        assertThat(token.getSet(), is(SET));
+        assertTrue(cursor.isEmpty());
+    }
+
+    @Test
+    public void aTokenWithFewerFieldsThanExpectedIsRefused() {
+        assertRefused("oai_dc///" + SET);
+    }
+
+    @Test
+    public void theRetiredSixFieldShapeCarryingBothOffsetAndCursorIsRefused() {
+        assertRefused("oai_dc///" + SET + "/200/" + itemId);
+    }
+
+    @Test
+    public void aPositionThatIsNeitherAnItemIdNorAnOffsetIsRefused() {
+        assertRefused("////");
+    }
+
+    @Test
+    public void aCursorThatIsNotAnItemIdIsRejectedInsteadOfReachingSolr() {
+        // The token is client supplied and the cursor is interpolated into a Solr query.
+        assertRefused("oai_dc///" + SET + "/* TO *] OR item.public:false");
+    }
+
+    @Test
+    public void whatIsFormattedCanBeParsedBack() throws Exception {
+        cursor.moveTo(itemId);
+        String formatted = underTest.format(new ResumptionToken(300, "mets", SET, null, null));
+
+        ResumptionCursor parsedCursor = new ResumptionCursor();
+        ResumptionToken parsed = new DSpaceResumptionTokenFormatter(parsedCursor).parse(formatted);
+
+        assertThat(parsed.getMetadataPrefix(), is("mets"));
+        assertThat(parsed.getSet(), is(SET));
+        assertThat(parsedCursor.valueOf(), is(itemId));
+    }
+
+    private void assertRefused(String token) {
+        try {
+            underTest.parse(token);
+            fail("expected a bad resumption token for " + token);
+        } catch (BadResumptionToken expected) {
+            assertTrue("nothing must be handed to the repository", cursor.isEmpty());
+        }
+    }
+}


### PR DESCRIPTION
## References
* Fixes #12980

## Description
Usage of "start" parameter on Solr request cause slowness for deep page result. This is mainly due because solr need to skip XXX records before to serve requested records; Coupling with `item.id` sorting, this cause O(n2) complexity for Solr, impacting query response time.

This commit use another way to build the resumption token for ListRecords : we replaced "offset" resumption token part, with "cursor" mark. This cursor is the last item uuid served by previous page. As the result is already sort by `item.id`, we can enrich the Solr query to use TermRange interval on this field. No more need to skip XXX records, the result of the page_1500 is as fast as page_1.

## Instructions for Reviewers
Main of the changes are covered by new tests.

To experiment, you need a DSpace instance with a lot of record into the same set.
1) First: Try to harvest without any changes and experiment that the deeper page, the slower the result
2) Apply this commit and clean oai-cache (just to be sure, it should not cause trouble : `dspace oai clean-cache`)
3) Now try to harvest the same set: the response time for each page should be more or less constant.

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).


