### PR TITLE
Harden `/versions/{id}/item` endpoint with `@PreAuthorize` annotation

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VersionItemLinkRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/VersionItemLinkRepository.java
@@ -21,6 +21,7 @@ import org.dspace.versioning.service.VersioningService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
 
 /**
@@ -44,6 +45,7 @@ public class VersionItemLinkRepository extends AbstractDSpaceRestRepository
      * @return                  The ItemRest object that is relevant for the Version
      * @throws SQLException     If something goes wrong
      */
+    @PreAuthorize("@versioningSecurity.isEnableVersioning() && hasPermission(#versionId, 'VERSION', 'READ')")
     public ItemRest getVersionItem(@Nullable HttpServletRequest request,
                                    Integer versionId,
                                    @Nullable Pageable optionalPageable,

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/VersionRestRepositoryIT.java
@@ -84,7 +84,11 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
 
     private Item item;
 
+    private Item adminOnlyItem;
+
     private Version version;
+
+    private Version adminOnlyVersion;
 
     @Autowired
     private VersioningService versioningService;
@@ -114,7 +118,7 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
         context.turnOffAuthorisationSystem();
 
         //** GIVEN **
-        //1. A community-collection structure with one parent community with sub-community and two collections.
+        //1. A community-collection structure with one parent community with sub-community and one collection.
         parentCommunity = CommunityBuilder.createCommunity(context)
                                           .withName("Parent Community")
                                           .build();
@@ -123,7 +127,7 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
                                            .build();
         Collection col1 = CollectionBuilder.createCollection(context, child1).withName("Collection 1").build();
 
-        //2. Three public items that are readable by Anonymous with different subjects
+        //2. One public item that is readable by Anonymous
         item = ItemBuilder.createItem(context, col1)
                           .withTitle("Public item 1")
                           .withIssueDate("2017-10-17")
@@ -132,6 +136,21 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
                           .build();
 
         version = VersionBuilder.createVersion(context, item, "Fixing some typos").build();
+
+        //3. One Admin-Only Item, created by the Admin user
+        context.setCurrentUser(admin);
+        adminOnlyItem =  ItemBuilder.createItem(context, col1)
+                                    .withTitle("Admin-Only item")
+                                    .withIssueDate("2017-10-17")
+                                    .withAuthor("Smith, Donald").withAuthor("Doe, John")
+                                    .withSubject("Private")
+                                    .withReaderGroup(context.getAdminGroup())
+                                    .build();
+        adminOnlyVersion = VersionBuilder.createVersion(context, item, "Fixing some typos").build();
+
+        // Revert current user to EPerson for all tests
+        context.setCurrentUser(eperson);
+
         context.restoreAuthSystemState();
     }
 
@@ -272,6 +291,31 @@ public class VersionRestRepositoryIT extends AbstractControllerIntegrationTest {
         getClient(adminToken).perform(get("/api/versioning/versions/" + version.getID() + "/item"))
                              .andExpect(status().isOk())
                              .andExpect(jsonPath("$", Matchers.is(ItemMatcher.matchItemProperties(version.getItem()))));
+    }
+
+    @Test
+    public void versionRestrictedItemAdminTest() throws Exception {
+        String adminToken = getAuthToken(admin.getEmail(), password);
+
+        // The Admin-only item is visible to Admin
+        getClient(adminToken).perform(get("/api/versioning/versions/" + adminOnlyVersion.getID() + "/item"))
+                               .andExpect(status().isOk());
+    }
+
+    @Test
+    public void versionRestrictedItemForbiddenUserTest() throws Exception {
+        String epersonToken = getAuthToken(eperson.getEmail(), password);
+
+        // The Admin-only item is not visible to another user
+        getClient(epersonToken).perform(get("/api/versioning/versions/" + adminOnlyVersion.getID() + "/item"))
+                   .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void versionRestrictedItemAnonymousTest() throws Exception {
+        // Anonymous user cannot access info about an Admin-only item
+        getClient().perform(get("/api/versioning/versions/" + adminOnlyVersion.getID() + "/item"))
+                               .andExpect(status().isUnauthorized());
     }
 
     @Test


### PR DESCRIPTION
## Description

The `/api/versioning/versions/[id]/item` endpoint is missing a `@PreAuthorize` annotation.  The internal code already does protect access (so no security threat exists).  But, we should have a `@PreAuthorize` to harden this endpoint.

This PR adds the `@PreAuthorize` to ensure the user has `READ` access to the version in question.  It also adds ITs to verify the expected behavior.

## Instructions for Reviewers
* Review code and verify that ITs are accurate and pass tests.
* Optionally verify that Item versioning still functions the same.