### PR TITLE
ItemImport process I/O improvements and better validation

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImport.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -40,6 +41,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.factory.HandleServiceFactory;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.DSpaceRunnable;
+import org.dspace.storage.secure.SecureFileAccess;
 import org.dspace.utils.DSpace;
 
 /**
@@ -352,8 +354,16 @@ public class ItemImport extends DSpaceRunnable<ItemImportScriptConfiguration> {
                     validateZip(validationFileStream.get());
                 }
 
-                workFile = new File(itemImportService.getTempWorkDir() + File.separator
-                        + zipfilename + "-" + context.getCurrentUser().getID());
+                String workDir = itemImportService.getTempWorkDir();
+
+                // zipfilename is user controlled (via -z or -u param). So, we must validate the expected
+                // file path using SecureFileAccess to protect against path traversal attacks.
+                String fileName = zipfilename + "-" + context.getCurrentUser().getID();
+                String fileAbsolutePath = SecureFileAccess.calculateAbsolutePathUsingBaseDir(fileName, workDir);
+                Path validatedFilePath = SecureFileAccess.validatePathForWrite(fileAbsolutePath, List.of(workDir),
+                                                                               "ItemImport zip validation");
+
+                workFile = validatedFilePath.toFile();
                 FileUtils.copyInputStreamToFile(optionalFileStream.get(), workFile);
             } else {
                 throw new IllegalArgumentException(

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportCLI.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +24,7 @@ import org.dspace.app.itemimport.service.ItemImportService;
 import org.dspace.content.Collection;
 import org.dspace.core.Context;
 import org.dspace.eperson.EPerson;
+import org.dspace.storage.secure.SecureFileAccess;
 
 /**
  * CLI variant for the {@link ItemImport} class.
@@ -103,8 +105,14 @@ public class ItemImportCLI extends ItemImport {
         // If this is a zip archive, unzip it first
         if (zip) {
             if (!remoteUrl) {
+                // zipfilename is user controlled (via -z or -u param). So, we must validate the expected
+                // file path using SecureFileAccess to protect against path traversal attacks.
+                String fileAbsolutePath = SecureFileAccess.calculateAbsolutePathUsingBaseDir(zipfilename, sourcedir);
+                Path validatedZipPath = SecureFileAccess.validatePathForRead(fileAbsolutePath, List.of(sourcedir),
+                                                                             "ItemImportCLI zip validation");
+                File myZipFile = validatedZipPath.toFile();
+
                 // confirm zip file exists
-                File myZipFile = new File(sourcedir + File.separator + zipfilename);
                 if ((!myZipFile.exists()) || (!myZipFile.isFile())) {
                     throw new IllegalArgumentException(
                         "Error reading file, the file couldn't be found for filename: " + zipfilename);
@@ -120,8 +128,7 @@ public class ItemImportCLI extends ItemImport {
 
                 workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR
                         + File.separator + context.getCurrentUser().getID());
-                sourcedir = itemImportService.unzip(
-                        new File(sourcedir + File.separator + zipfilename), workDir.getAbsolutePath());
+                sourcedir = itemImportService.unzip(myZipFile, workDir.getAbsolutePath());
             } else {
                 // manage zip via remote url
                 Optional<InputStream> optionalFileStream = Optional.ofNullable(new URL(zipfilename).openStream());
@@ -134,10 +141,19 @@ public class ItemImportCLI extends ItemImport {
                             validateZip(validationFileStream.get());
                         }
 
-                        workFile = new File(itemImportService.getTempWorkDir() + File.separator
-                                + zipfilename + "-" + context.getCurrentUser().getID());
+                        // zipfilename is user controlled (via -z or -u param). So, we must validate the expected
+                        // file path using SecureFileAccess to protect against path traversal attacks.
+                        String tempWorkDir = itemImportService.getTempWorkDir();
+                        String zipName = zipfilename + "-" + context.getCurrentUser().getID();
+                        String fileAbsolutePath = SecureFileAccess.calculateAbsolutePathUsingBaseDir(zipName,
+                                                                                                     tempWorkDir);
+                        Path validatedZipPath = SecureFileAccess
+                            .validatePathForWrite(fileAbsolutePath, List.of(tempWorkDir),
+                                                  "ItemImportCLI remote zip validation");
+
+                        workFile = validatedZipPath.toFile();
                         FileUtils.copyInputStreamToFile(optionalFileStream.get(), workFile);
-                        workDir = new File(itemImportService.getTempWorkDir() + File.separator + TEMP_DIR
+                        workDir = new File(tempWorkDir + File.separator + TEMP_DIR
                                 + File.separator + context.getCurrentUser().getID());
                         sourcedir = itemImportService.unzip(workFile, workDir.getAbsolutePath());
                     } else {

--- a/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemimport/ItemImportServiceImpl.java
@@ -111,6 +111,7 @@ import org.dspace.eperson.service.GroupService;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.services.ConfigurationService;
+import org.dspace.storage.secure.SecureFileAccess;
 import org.dspace.workflow.WorkflowItem;
 import org.dspace.workflow.WorkflowService;
 import org.springframework.beans.factory.InitializingBean;
@@ -202,7 +203,7 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
         //Ensure tempWorkDir exists
         File tempWorkDirFile = new File(tempWorkDir);
         if (!tempWorkDirFile.exists()) {
-            boolean success = tempWorkDirFile.mkdir();
+            boolean success = tempWorkDirFile.mkdirs();
             if (success) {
                 logInfo("Created org.dspace.app.batchitemimport.work.dir of: " + tempWorkDir);
             } else {
@@ -1984,9 +1985,14 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             logError("Unable to create temporary directory: " + tempdir.getAbsolutePath());
         }
         String sourcedir = destinationDir + System.getProperty("file.separator") + zipfile.getName();
-        String zipDir = destinationDir + System.getProperty("file.separator") + zipfile.getName() + System
-            .getProperty("file.separator");
+        String zipDir = sourcedir + System.getProperty("file.separator");
+        File sourcedirFile = new File(sourcedir);
 
+        // Create the source directory we will be unzipping into. We must pre-create this directory to validate
+        // the final path of each zip entry using SecureFileAccess (see below)
+        if (!sourcedirFile.exists() && !sourcedirFile.mkdirs()) {
+            logError("Unable to create directory for unzipping: " + sourcedir);
+        }
 
         // 3
         String sourceDirForZip = sourcedir;
@@ -1997,13 +2003,22 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
             while (entries.hasMoreElements()) {
                 entry = entries.nextElement();
                 String entryName = entry.getName();
-                File outFile = new File(zipDir + entryName);
+
                 // Verify that this file/directory will be extracted into our zipDir (and not somewhere else!)
-                if (!outFile.toPath().normalize().startsWith(zipDir)) {
+                Path validatedOutPath;
+                try {
+                    String fileAbsolutePath =
+                        SecureFileAccess.calculateAbsolutePathUsingBaseDir(entryName, zipDir);
+                    validatedOutPath = SecureFileAccess.validatePathForWrite(fileAbsolutePath, List.of(zipDir),
+                                                                             "ItemImport zip entry extraction");
+                } catch (IOException e) {
                     throw new IOException("Bad zip entry: '" + entryName
                                               + "' in file '" + zipfile.getAbsolutePath() + "'!"
-                                              + " Cannot process this file or directory.");
+                                              + " Cannot process this file or directory.", e);
                 }
+
+                File outFile = validatedOutPath.toFile();
+
                 if (entry.isDirectory()) {
                     if (!outFile.mkdirs()) {
                         logError("Unable to create contents directory: " + zipDir + entry.getName());
@@ -2049,6 +2064,13 @@ public class ItemImportServiceImpl implements ItemImportService, InitializingBea
                     out.close();
                 }
             }
+        } catch (Exception e) {
+            // If an error occurs in unzipping, cleanup the directory we were unzipping this file into
+            if (sourcedirFile.exists()) {
+                FileUtils.deleteDirectory(sourcedirFile);
+            }
+            // Then throw error upwards
+            throw e;
         } finally {
             //Close zip file
             zf.close();

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -193,6 +193,11 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
             String fileName = file.getOriginalFilename();
             if (fileNames.contains(fileName)) {
                 throw new UnprocessableEntityException("There are two files with the same name: " + fileName);
+            } else if (StringUtils.containsAny(fileName, "..", "/", "\\")) {
+                // NOTE: This is just a "fail-fast", basic protection against a potential path traversal attack.
+                // Individual scripts MUST also contain their own path traversal protections.
+                throw new UnprocessableEntityException(
+                    "Filenames cannot contain path characters such as '..', '/', or '\\' : " + fileName);
             } else {
                 fileNames.add(fileName);
             }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/itemimport/ItemImportIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/itemimport/ItemImportIT.java
@@ -59,6 +59,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.ResultMatcher;
 
 /**
  * Basic integration testing for the SAF Import feature via UI {@link ItemImport}.
@@ -135,6 +136,39 @@ public class ItemImportIT extends AbstractEntityIntegrationTest {
         // confirm that TEMP_DIR still exists
         File workTempDir = new File(workDir + File.separator + TEMP_DIR);
         assertTrue(workTempDir.exists());
+    }
+
+    @Test
+    public void importItemUsingInvalidZipName() throws Exception {
+        String zipfileName = "saf-bitstreams.zip";
+        // This zip name is invalid as it must only contain a file name.
+        // This is an example path traversal attack.
+        String badZipFileName = "../../../" + zipfileName;
+
+        // First attack attempt. Provide a path traversal via both "-z" param and "filename" of multipart request.
+        LinkedList<DSpaceCommandLineParameter> parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-a", ""));
+        parameters.add(new DSpaceCommandLineParameter("-c", collection.getID().toString()));
+        parameters.add(new DSpaceCommandLineParameter("-z", badZipFileName));
+        MockMultipartFile bitstreamFile = new MockMultipartFile("file", badZipFileName,
+                                                                MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                                                                getClass().getResourceAsStream("saf-bitstreams.zip"));
+
+        // Verify this import will fail and throw a 422 error
+        performImportScriptExpectError(parameters, bitstreamFile, status().isUnprocessableEntity());
+
+        // Second attack attempt. Provide a path traversal via "-z" param but a VALID file in "filename"
+        // of multipart request.
+        parameters = new LinkedList<>();
+        parameters.add(new DSpaceCommandLineParameter("-a", ""));
+        parameters.add(new DSpaceCommandLineParameter("-c", collection.getID().toString()));
+        parameters.add(new DSpaceCommandLineParameter("-z", badZipFileName));
+        bitstreamFile = new MockMultipartFile("file", zipfileName,
+                                              MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                                              getClass().getResourceAsStream("saf-bitstreams.zip"));
+
+        // Verify this import will also fail and throw a 422 error
+        performImportScriptExpectError(parameters, bitstreamFile, status().isUnprocessableEntity());
     }
 
     @Test
@@ -266,5 +300,24 @@ public class ItemImportIT extends AbstractEntityIntegrationTest {
                 process.getBitstreams().stream()
                 .filter(b -> Strings.CS.contains(b.getName(), ".zip"))
                 .count());
+    }
+
+    private void performImportScriptExpectError(LinkedList<DSpaceCommandLineParameter> parameters,
+                                               MockMultipartFile bitstreamFile,
+                                               ResultMatcher expectedErrorMatcher)
+        throws Exception {
+        List<ParameterValueRest> list = parameters.stream()
+                                                  .map(dSpaceCommandLineParameter -> dSpaceRunnableParameterConverter
+                                                      .convert(dSpaceCommandLineParameter, Projection.DEFAULT))
+                                                  .collect(Collectors.toList());
+
+        AtomicReference<Integer> idRef = new AtomicReference<>();
+
+        // Verify process fails
+        getClient(getAuthToken(admin.getEmail(), password))
+            .perform(multipart("/api/system/scripts/import/processes")
+                         .file(bitstreamFile)
+                         .param("properties", mapper.writeValueAsString(list)))
+            .andExpect(expectedErrorMatcher);
     }
 }


### PR DESCRIPTION
## References

* Enhancements to `import` script based on #12537

## Description
The `import` script accepts a zipfile name parameter (`-z`). This PR improves the validation of that parameter when it is sent via the REST API directly.  It uses the existing `SecureFileAccess` utility script (implemented in #12537) to perform validation.

Refactored the commandline version of the `import` script to also use the `SecureFileAccess` utility, even though it already had similar logic.

Finally, adds some ITs to verify expected behavior.

## Instructions for Reviewers
* Verify code & tests pass
* Verify behavior of Item Import (i.e. `import` script) is unchanged (especially when importing via the Admin UI)