### PR TITLE
Retire obsolete configuration files during "ant update"

### DIFF
--- a/dspace/src/main/config/build.xml
+++ b/dspace/src/main/config/build.xml
@@ -126,6 +126,7 @@ Common usage:
         <echo message="fresh_install   --> Perform a fresh installation of the software. " />
         <echo message="" />
         <echo message="clean_backups   --> Remove .bak directories under install directory" />
+        <echo message="clean_obsolete  --> Remove configuration files retired by update_configs (*.obsolete-*)" />
         <echo message="test_database   --> Attempt to connect to the DSpace database in order to verify that configuration is correct" />
         <echo message="" />
         <echo message="" />
@@ -164,6 +165,16 @@ Common usage:
     </target>
 
     <!-- ============================================================= -->
+    <!-- clean out configuration files retired by update_configs       -->
+    <!-- ============================================================= -->
+    <target name="clean_obsolete"
+            description="Remove configuration files which were retired by a previous 'ant update'">
+        <delete>
+            <fileset dir="${dspace.dir}" includes="config/**/*.obsolete-**" />
+        </delete>
+    </target>
+
+    <!-- ============================================================= -->
     <!-- Update an installation                                        -->
     <!-- ============================================================= -->
 
@@ -178,9 +189,81 @@ Common usage:
     <!-- and should be hand updated afterward.                         -->
     <!-- ============================================================= -->
     <target name="update_configs"
-            depends="overwrite_configs,overwrite_solr_configs"
+            depends="retire_obsolete_configs,overwrite_configs,overwrite_solr_configs"
             description="Updates the Configuration Directory">
         <antcall target="init_spiders" />
+    </target>
+
+    <!-- ============================================================= -->
+    <!-- Retire configuration files which DSpace no longer ships.      -->
+    <!-- They are renamed rather than deleted, so that they can no     -->
+    <!-- longer be picked up by the wildcard configuration loaders     -->
+    <!-- while any local customizations remain available for review.   -->
+    <!-- ============================================================= -->
+    <target name="retire_obsolete_configs"
+            depends="move_obsolete_configs,report_obsolete_configs"
+            description="Rename configuration files DSpace no longer ships, so they are no longer loaded">
+    </target>
+
+    <target name="move_obsolete_configs">
+
+        <!--
+        ****************************************************************
+        Configuration files which DSpace shipped in an earlier version
+        and no longer ships. Paths are relative to ${dspace.dir}/config.
+
+        WHEN A PULL REQUEST REMOVES OR RENAMES A FILE UNDER dspace/config,
+        ADD ITS OLD PATH HERE IN THE SAME PULL REQUEST.
+
+        A <filelist> is used rather than a <fileset> on purpose: it names
+        files instead of matching patterns, so entries which are not
+        installed are simply skipped by <exists>, and an empty list stays
+        empty. (A <fileset> with no include patterns matches everything,
+        which would rename the entire configuration directory.)
+        ****************************************************************
+        -->
+        <restrict id="obsolete.configs">
+            <filelist dir="${dspace.dir}/config">
+                <!-- Sherpa Romeo became Open Policy Finder in PR #12005, and this file
+                     was replaced by spring/api/openpolicyfinder.xml -->
+                <file name="spring/api/sherpa.xml" />
+            </filelist>
+            <exists />
+        </restrict>
+
+        <!--
+        The property is left unset when nothing matched (setonempty="false"), which is
+        what suppresses the report below.
+        -->
+        <pathconvert pathsep="${line.separator}    " property="obsolete.configs.found"
+                     refid="obsolete.configs" setonempty="false" />
+
+        <!--
+        Rename (never delete), so that the file no longer matches the "*.xml" pattern
+        which the Spring configuration loaders use to scan config/spring/**.
+        -->
+        <move todir="${dspace.dir}/config" failonerror="false">
+            <resources refid="obsolete.configs" />
+            <globmapper from="*" to="*.obsolete-${build.date}" />
+        </move>
+
+    </target>
+
+    <target name="report_obsolete_configs" if="obsolete.configs.found">
+
+        <echo>
+====================================================================
+ The following configuration files are no longer part of DSpace.
+ Each one has been renamed to "&lt;filename&gt;.obsolete-${build.date}"
+ so that it can no longer be loaded by DSpace:
+
+    ${obsolete.configs.found}
+
+ Nothing was deleted. Review these files for any local customizations
+ you still need, then run "ant clean_obsolete" to remove them.
+====================================================================
+        </echo>
+
     </target>
 
     <target name="overwrite_configs" description="Overwrites a configuration directory." if="${overwrite}" depends="copy_configs_keep">


### PR DESCRIPTION
## References

* Fixes #13017

## Description

`ant update` has only ever added or overwritten configuration files, never withdrawn one. This adds a list of configuration files DSpace used to ship but no longer ships, and a new `update_configs` step which renames each one it still finds to `<filename>.obsolete-<timestamp>`, so it can no longer be loaded.

## Instructions for Reviewers

### The problem

`ant update` never removes a configuration file which DSpace has stopped shipping. That is harmless for configs loaded by name, but not for the ones loaded by a wildcard: `APISpringLoader`, `RESTSpringLoader` and `OAISpringLoader` each hand Spring a `config/spring/<area>/` + [`SpringLoader.XML_SUFFIX`](https://github.com/DSpace/DSpace/blob/main/dspace-services/src/main/java/org/dspace/kernel/config/SpringLoader.java#L19) (`"*.xml"`) glob, so **any** leftover file in those directories is still loaded into the Spring context.

Upgrading from 9.3 leaves `config/spring/api/sherpa.xml` behind. PR #12005 replaced it with `openpolicyfinder.xml` and deleted the classes it refers to, so the kernel dies at `ant update`'s `test_database` step with a `ClassNotFoundException` for `org.dspace.app.sherpa.submit.SHERPASubmitConfigurationService`, until the admin finds and deletes `sherpa.xml` by hand.

I checked how much of a backlog this represents. Diffing the `dspace/config/` file lists of `dspace-8.4`, `dspace-9.3` and `dspace-10.0-rc1` against `main` yields exactly **one** orphaned file, `spring/api/sherpa.xml`, and all four active branches already ship `openpolicyfinder.xml`. So the list starts with a single entry and the patch is identical on `main`, `dspace-10_x`, `dspace-9_x` and `dspace-8_x`.

(For completeness: `config/modules/*.cfg` files are **not** at risk. They are pulled in by explicit `include = ${module_dir}/x.cfg` lines in `dspace.cfg`, which `ant update` overwrites, so a withdrawn `.cfg` stops being read automatically.)

### List of changes in this PR

All in `dspace/src/main/config/build.xml`:

* **`move_obsolete_configs`** holds the list of withdrawn config files and renames each one it still finds to `<filename>.obsolete-<timestamp>`.
* **`report_obsolete_configs`** prints what was retired, and points at `clean_obsolete`.
* **`retire_obsolete_configs`** ties those two together and is prepended to `update_configs`'s `depends`, so it runs before the new configs are installed and long before `test_database`.
* **`clean_obsolete`** is a new user-facing target which removes `config/**/*.obsolete-*`.
* One extra line in the `help` target.

### Why rename instead of delete

Because the loaders are globs, a file only has to stop matching `*.xml` to become inert. Renaming means the "did the admin customize this file?" question never has to be answered: nothing is deleted, no bytes are rewritten, and an admin who wants the file back just runs `mv`. There is already in-tree precedent for the trick, `config/spring/api/virtual-metadata.xml.openaire4` is a complete, valid Spring file deliberately shipped with a non-`.xml` suffix so the loader ignores it.

This is also the approach Debian settled on for the same problem: `dpkg-maintscript-helper rm_conffile` takes a hand-maintained list of conffiles a package has stopped shipping and, if the admin edited one, renames it aside rather than removing it. Ant's `<sync>` task (make the target match the source, delete the extras) is the obvious built-in alternative and is the wrong tool here, since admins legitimately add their own bean files to `config/spring/api/` and `<sync>` would delete them.

### Naming, and why this is not folded into `clean_backups`

Per the [discussion on the ticket](https://github.com/DSpace/DSpace/issues/13017#issuecomment-3325383104): @tdonohue suggested `sherpa.xml.bak-<timestamp>` for consistency with the `bin`/`lib`/`webapps` `.bak-` directories, and folding the cleanup into `clean_backups`. This PR keeps the positional convention (identifier before the timestamp) but uses `.obsolete-` and a separate `clean_obsolete` target, because a `.bak-` directory is a *second* copy of something the admin still has, whereas a retired config is the *only* remaining copy of a file DSpace has withdrawn. An admin clearing disk space with `clean_backups` should not silently discard it. Keeping it distinct also separates it from the third category already in play, the `*-<timestamp>.old` merge files that `overwrite_configs` produces.

### One implementation detail worth a close look

The list is a `<restrict>` / `<filelist>` / `<exists>` rather than a `<fileset>` with `<include>` patterns. That is deliberate and is the one thing I would ask a reviewer not to "simplify". Measured with Ant 1.10.17, for the day someone removes the last entry from the list:

| Construct | What an **empty** list matches |
| --- | --- |
| `<fileset>` with an empty `<patternset>` | **everything** |
| `<restrict><filelist/><exists/></restrict>` | nothing |

A `<fileset>` with no include patterns matches every file, so the obvious spelling would rename the entire `${dspace.dir}/config` tree the first time the list was emptied. `<filelist>` names files instead of matching patterns, so an empty list stays empty, and entries which are not installed are simply skipped by `<exists>`. The reason is written into the build.xml comment. It also means no existence guard is needed, since `<filelist>` never scans the directory, a missing `${dspace.dir}/config` is already a no-op.

The trade-off is that entries must be literal paths, no globs. For "files DSpace used to ship" the exact path is always known, so I think that constraint is worth having.

### How to test

Reproduce the bug first, then confirm the fix, using a real 9.3 configuration directory:

```bash
# 1. Build the installer from this branch
mvn package -DskipTests

# 2. Create a fixture installation holding an authentic 9.3 config tree
FIX=/tmp/dspace-13017
mkdir -p $FIX
git archive dspace-9.3 dspace/config | tar -x -C $FIX --strip-components=1
printf 'dspace.dir = %s\n' "$FIX" > $FIX/config/local.cfg
cd dspace/target/dspace-installer
ant -Ddspace.dir=$FIX init_installation

# 3. BEFORE: the kernel cannot start
ant -Ddspace.dir=$FIX test_database
#    -> Cannot find class [org.dspace.app.sherpa.submit.SHERPASubmitConfigurationService]
#       ... defined in file [.../config/spring/api/sherpa.xml]

# 4. Retire it
ant -Ddspace.dir=$FIX update_configs
#    -> sherpa.xml becomes sherpa.xml.obsolete-<timestamp>, and the run reports it

# 5. AFTER: the kernel starts (this now reaches the database connection step)
ant -Ddspace.dir=$FIX test_database

# 6. The retired file survives clean_backups, and is removed by clean_obsolete
ant -Ddspace.dir=$FIX clean_backups
ant -Ddspace.dir=$FIX clean_obsolete
```

Worth checking while you are in there: your own bean files in `config/spring/api/`, the current `openpolicyfinder.xml`, and the `*-<timestamp>.old` merge files are all untouched throughout.

### What I verified locally

Against a from-scratch `mvn package` of this branch, with an authentic `dspace-9.3` config tree as `${dspace.dir}/config` plus an admin-authored `spring/api/my-local-custom-beans.xml`. Kernel start was checked with the database-free `dsprop` script as well as `test_database`.

* **Before:** kernel init fails with the exact trace from the ticket (`pubmedImportService` -> `Cannot find class [...SHERPASubmitConfigurationService] ... sherpa.xml`), exit 1.
* **After `ant update_configs`:** renamed to `sherpa.xml.obsolete-<timestamp>` with content byte-identical, kernel starts, exit 0.
* `ant update` target order confirmed: retire runs first, before `prepare_configs` and long before `test_database`.
* `-Doverwrite=false` path works too (53 `.new` files created, still retired).
* The 53 `*-<timestamp>.old` merge files, the admin's own bean file and `openpolicyfinder.xml` are untouched by both clean targets.
* `clean_backups` does not touch `.obsolete-` files; `clean_obsolete` removes only those; both are idempotent and leave empty directories alone.
* Fail-safe behaviour proven against the real build.xml: with the last `<file>` entry removed, **0 of 272** config files are renamed; an entry naming a file which was never installed is silently skipped rather than reported.
* No-ops where expected: second `update_configs`, missing `${dspace.dir}/config`, and the `fresh_install` path (`init_installation` + `init_configs`).

### Follow-ups I deliberately left out

The list is hand-maintained, which is the same bargain Debian makes. Two things would make that safer, but both are larger than this fix and I would rather they were discussed separately:

1. A CI check that fails a commit which deletes a file under `dspace/config/` without adding a matching entry, plus a line in the PR checklist.
2. Having `ant update` write a manifest of what it installed into `${dspace.dir}/config`, so the next update can derive the "used to ship, no longer shipped" set automatically. Note this can never fully replace the explicit list, since 9.3 and earlier wrote no manifest, so existing installations still need it.

### Backports

The diff applies unchanged to `dspace-10_x`, `dspace-9_x` and `dspace-8_x`. Happy to open those as soon as this is reviewed, `dspace-9_x` in particular given the 9.4 timing.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md). (No Java is changed by this PR.)
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods. (Not applicable, no Java. The new Ant targets are commented in place.)
- [ ] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide). — existing tests pass, but there is no harness in DSpace for exercising `build.xml`, so this is covered by the manual verification listed above instead. Happy to take suggestions if reviewers would like it automated.
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (No new dependencies.)
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change. (No REST changes.)
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. (The new `clean_obsolete` target and the `.obsolete-<timestamp>` convention are documented above; both are also in `ant help`. The 9.4 "Breaking Changes" note about deleting `sherpa.xml` by hand can be retired once this is released.)

https://claude.ai/code/session_017odRv9QLrNAJJUYCW1qa94
