### PR TITLE
Harden OAI ingestion crosswalk resource handling

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
+++ b/dspace-api/src/main/java/org/dspace/content/crosswalk/OREIngestionCrosswalk.java
@@ -10,21 +10,29 @@ package org.dspace.content.crosswalk;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.sql.SQLException;
 import java.text.NumberFormat;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.Logger;
+import org.dspace.app.client.DSpaceHttpClientFactory;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
@@ -56,7 +64,7 @@ import org.jdom2.xpath.XPathFactory;
  * @author Alexey Maslov
  */
 public class OREIngestionCrosswalk
-    implements IngestionCrosswalk {
+        implements IngestionCrosswalk {
     /**
      * log4j category
      */
@@ -64,37 +72,37 @@ public class OREIngestionCrosswalk
 
     /* Namespaces */
     public static final Namespace ATOM_NS =
-        Namespace.getNamespace("atom", "http://www.w3.org/2005/Atom");
+            Namespace.getNamespace("atom", "http://www.w3.org/2005/Atom");
     private static final Namespace ORE_ATOM =
-        Namespace.getNamespace("oreatom", "http://www.openarchives.org/ore/atom/");
+            Namespace.getNamespace("oreatom", "http://www.openarchives.org/ore/atom/");
     private static final Namespace ORE_NS =
-        Namespace.getNamespace("ore", "http://www.openarchives.org/ore/terms/");
+            Namespace.getNamespace("ore", "http://www.openarchives.org/ore/terms/");
     private static final Namespace RDF_NS =
-        Namespace.getNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+            Namespace.getNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
     private static final Namespace DCTERMS_NS =
-        Namespace.getNamespace("dcterms", "http://purl.org/dc/terms/");
+            Namespace.getNamespace("dcterms", "http://purl.org/dc/terms/");
     private static final Namespace DS_NS =
-        Namespace.getNamespace("ds", "http://www.dspace.org/objectModel/");
+            Namespace.getNamespace("ds", "http://www.dspace.org/objectModel/");
 
+    private String[] forbiddenHostUrls = null;
 
     protected BitstreamService bitstreamService = ContentServiceFactory.getInstance().getBitstreamService();
     protected BitstreamFormatService bitstreamFormatService = ContentServiceFactory.getInstance()
-                                                                                   .getBitstreamFormatService();
+            .getBitstreamFormatService();
     protected BundleService bundleService = ContentServiceFactory.getInstance().getBundleService();
     protected ItemService itemService = ContentServiceFactory.getInstance().getItemService();
     protected ConfigurationService configurationService = DSpaceServicesFactory.getInstance().getConfigurationService();
 
-
     @Override
     public void ingest(Context context, DSpaceObject dso, List<Element> metadata, boolean createMissingMetadataFields)
-        throws CrosswalkException, IOException, SQLException, AuthorizeException {
+            throws CrosswalkException, IOException, SQLException, AuthorizeException {
 
         // If this list contains only the root already, just pass it on
         if (metadata.size() == 1) {
-            ingest(context, dso, metadata.get(0), createMissingMetadataFields);
+            ingest(context, dso, metadata.getFirst(), createMissingMetadataFields);
         } else {
             // Otherwise, wrap them up
-            Element wrapper = new Element("wrap", metadata.get(0).getNamespace());
+            Element wrapper = new Element("wrap", metadata.getFirst().getNamespace());
             wrapper.addContent(metadata);
 
             ingest(context, dso, wrapper, createMissingMetadataFields);
@@ -104,7 +112,7 @@ public class OREIngestionCrosswalk
 
     @Override
     public void ingest(Context context, DSpaceObject dso, Element root, boolean createMissingMetadataFields)
-        throws CrosswalkException, IOException, SQLException, AuthorizeException {
+            throws CrosswalkException, IOException, SQLException, AuthorizeException {
 
         Instant timeStart = Instant.now();
 
@@ -118,21 +126,26 @@ public class OREIngestionCrosswalk
             return;
         }
 
+        var followRedirects = configurationService
+                .getBooleanProperty("oai.harvester.ore.follow-redirects", false);
+        var requestConfig = RequestConfig.custom()
+                .setRedirectsEnabled(followRedirects).build();
+
         Document doc = new Document();
         doc.addContent(root.detach());
 
         List<Element> aggregatedResources;
         String entryId;
         XPathExpression<Element> xpathLinks =
-            XPathFactory.instance()
+                XPathFactory.instance()
                         .compile("/atom:entry/atom:link[@rel=\"" + ORE_NS.getURI() + "aggregates" + "\"]",
-                                 Filters.element(), null, ATOM_NS);
+                                Filters.element(), null, ATOM_NS);
         aggregatedResources = xpathLinks.evaluate(doc);
 
         XPathExpression<Attribute> xpathAltHref =
-            XPathFactory.instance()
+                XPathFactory.instance()
                         .compile("/atom:entry/atom:link[@rel='alternate']/@href",
-                                 Filters.attribute(), null, ATOM_NS);
+                                Filters.attribute(), null, ATOM_NS);
         entryId = xpathAltHref.evaluateFirst(doc).getValue();
 
         // Next for each resource, create a bitstream
@@ -143,18 +156,24 @@ public class OREIngestionCrosswalk
         for (Element resource : aggregatedResources) {
             String href = resource.getAttributeValue("href");
             log.debug("ORE processing: " + href);
+            String processedURL;
+            try {
+                processedURL = new URIBuilder(href).build().toString();
+            } catch (URISyntaxException e) {
+                throw new CrosswalkException("Could not parse URI: " + href, e);
+            }
 
             String bundleName;
             Element desc = null;
             XPathExpression<Element> xpathDesc =
-                XPathFactory.instance()
-                    .compile("/atom:entry/oreatom:triples/rdf:Description[@rdf:about=\"" +
-                                 this.encodeForURL(href) + "\"][1]",
-                             Filters.element(), null, ATOM_NS, ORE_ATOM, RDF_NS);
+                    XPathFactory.instance()
+                            .compile("/atom:entry/oreatom:triples/rdf:Description[@rdf:about=\"" +
+                                            this.encodeForURL(href) + "\"][1]",
+                                    Filters.element(), null, ATOM_NS, ORE_ATOM, RDF_NS);
             desc = xpathDesc.evaluateFirst(doc);
 
             if (desc != null && desc.getChild("type", RDF_NS).getAttributeValue("resource", RDF_NS)
-                                    .equals(DS_NS.getURI() + "DSpaceBitstream")) {
+                    .equals(DS_NS.getURI() + "DSpaceBitstream")) {
                 bundleName = desc.getChildText("description", DCTERMS_NS);
                 log.debug("Setting bundle name to: " + bundleName);
             } else {
@@ -167,63 +186,81 @@ public class OREIngestionCrosswalk
             Bundle targetBundle;
 
             // if null, create the new bundle and add it in
-            if (targetBundles.size() == 0) {
+            if (targetBundles.isEmpty()) {
                 targetBundle = bundleService.create(context, item, bundleName);
                 itemService.addBundle(context, item, targetBundle);
             } else {
-                targetBundle = targetBundles.get(0);
+                targetBundle = targetBundles.getFirst();
             }
 
-            URL ARurl = null;
-            InputStream in = null;
-            if (href != null) {
-                try {
-                    // Make sure the url string escapes all the oddball characters
-                    String processedURL = encodeForURL(href);
-                    if (validResourceUri(entryId, processedURL)) {
-                        // Generate a request for the aggregated resource
-                        ARurl = new URL(processedURL);
-                        in = ARurl.openStream();
-                    } else {
-                        throw new FileNotFoundException("Failed to validate " + processedURL);
-                    }
-                } catch (FileNotFoundException fe) {
-                    log.error("The provided URI failed to return a resource: " + href);
-                } catch (ConnectException fe) {
-                    log.error("The provided URI was invalid: " + href);
+            if (StringUtils.isBlank(href)) {
+                throw new CrosswalkException("The href attribute is required for the ORE ingestion.");
+            }
+            try (CloseableHttpClient httpClient = DSpaceHttpClientFactory.getInstance()
+                    .buildWithRequestConfig(requestConfig)) {
+                if (!validResourceUri(processedURL)) {
+                    throw new FileNotFoundException("Invalid resource URI: " + processedURL);
                 }
-            } else {
-                throw new CrosswalkException("Entry did not contain link to resource: " + entryId);
-            }
-
-            // ingest and update
-            if (in != null) {
-                Bitstream newBitstream = bitstreamService.create(context, targetBundle, in);
-
-                String bsName = resource.getAttributeValue("title");
-                newBitstream.setName(context, bsName);
-
-                // Identify the format
-                String mimeString = resource.getAttributeValue("type");
-                BitstreamFormat bsFormat = bitstreamFormatService.findByMIMEType(context, mimeString);
-                if (bsFormat == null) {
-                    bsFormat = bitstreamFormatService.guessFormat(context, newBitstream);
+                // Generate a request for the aggregated resource
+                HttpGet httpGet = new HttpGet(processedURL);
+                HttpResponse response = httpClient.execute(httpGet);
+                if (response == null || response.getEntity() == null) {
+                    throw new FileNotFoundException(processedURL + " returned a null response or body");
                 }
-                newBitstream.setFormat(context, bsFormat);
-                bitstreamService.update(context, newBitstream);
-
-                bundleService.addBitstream(context, targetBundle, newBitstream);
-                bundleService.update(context, targetBundle);
-            } else {
-                throw new CrosswalkException("Could not retrieve bitstream: " + entryId);
+                if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                    throw new FileNotFoundException(processedURL
+                            + " returned a " + response.getStatusLine() + " response");
+                }
+                if (response.getEntity() == null || response.getEntity().getContent() == null) {
+                    throw new FileNotFoundException(processedURL + " returned an empty body");
+                }
+                // ingest and update
+                try (InputStream in = response.getEntity().getContent()) {
+                    ingestStreamAsBitstream(context, in, targetBundle, resource, entryId);
+                }
             }
-
         }
         log.info(
-            "OREIngest for Item " + item.getID() + " took: " +
-                (Instant.now().toEpochMilli() - timeStart.toEpochMilli()) + "ms.");
+                "OREIngest for Item " + item.getID() + " took: " +
+                        (Instant.now().toEpochMilli() - timeStart.toEpochMilli()) + "ms.");
     }
 
+    /**
+     * Read an input stream and ingest it as a bitstream to the target bundle
+     * @param context Dspace context
+     * @param inputStream input stream containing bitstream content
+     * @param targetBundle the target bundle for the new bitstream
+     * @param resource the ORE resource Element
+     * @param entryId the entry ID of the ORE resource
+     * @throws AuthorizeException if current user does not have permission to add / create bitstream
+     * @throws IOException if the input stream is null or unreadable
+     * @throws SQLException if bitstream or bundle database operations fail
+     */
+    void ingestStreamAsBitstream(Context context, InputStream inputStream,
+                                         Bundle targetBundle, Element resource, String entryId)
+            throws AuthorizeException, IOException, SQLException {
+        // ingest and update
+        if (inputStream != null) {
+            Bitstream newBitstream = bitstreamService.create(context, targetBundle, inputStream);
+
+            String bsName = resource.getAttributeValue("title");
+            newBitstream.setName(context, bsName);
+
+            // Identify the format
+            String mimeString = resource.getAttributeValue("type");
+            BitstreamFormat bsFormat = bitstreamFormatService.findByMIMEType(context, mimeString);
+            if (bsFormat == null) {
+                bsFormat = bitstreamFormatService.guessFormat(context, newBitstream);
+            }
+            newBitstream.setFormat(context, bsFormat);
+            bitstreamService.update(context, newBitstream);
+
+            bundleService.addBitstream(context, targetBundle, newBitstream);
+            bundleService.update(context, targetBundle);
+        } else {
+            throw new IOException("Could not read input stream for: " + entryId);
+        }
+    }
 
     /**
      * Helper method to escape all characters that are not part of the canon set
@@ -265,58 +302,101 @@ public class OREIngestionCrosswalk
 
     /**
      * Validate a resource URI against the host and scheme of the remote OAI endpoint, or a configured
-     * list of allowed prefixes.
-     * This still implicitly "trusts" the remote OAI server, but will reject resource URIs with a totally
-     * different hostname to avoid downloading malicious resources from a compromised endpoint.
+     * list of allowed prefixes. Some default forbidden hosts are also included to prevent SSRF.
      * Even if the URL prefix validation is disabled, schemes will still be enforced to http(s) so file:/// and
      * other unwanted schemes cannot be used
-     * @param entryUrl the entryId of the parent ORE resource
      * @param resourceUrl the resource URL of the aggregated ORE resource
      * @return result of the validation
      */
-    private boolean validResourceUri(String entryUrl, String resourceUrl) {
+    boolean validResourceUri(String resourceUrl) {
+        URI resourceUri;
         try {
-            Set<String> allowedSchemes = Set.of("http", "https");
-            URI entryUri = new URI(entryUrl).normalize();
-            URI resourceUri = new URI(resourceUrl).normalize();
-            String scheme = resourceUri.getScheme();
-
-            if (scheme == null ||
-                    !allowedSchemes.contains(scheme.toLowerCase(Locale.ROOT))) {
-                log.warn("Illegal scheme requested for ORE resource: {}", resourceUri);
-                return false;
-            }
-
-            if (configurationService.getBooleanProperty("oai.harvester.ore.file.validateUrlPrefix", false)) {
-                for (String allowedPrefix : configurationService
-                        .getArrayProperty("oai.harvester.ore.file.allowedUrlPrefix")) {
-                    URI allowedUri = new URI(allowedPrefix).normalize();
-                    // Return true on the first allowed prefix match
-                    if (Objects.equals(resourceUri.getScheme(), allowedUri.getScheme())
-                            && Objects.equals(resourceUri.getHost().toLowerCase(Locale.ROOT),
-                            allowedUri.getHost().toLowerCase(Locale.ROOT))) {
-                        return true;
-                    }
-                }
-
-                // If no allowed prefixes were matched, we require scheme + host to match the remote OAI server
-                if (!Objects.equals(entryUri.getScheme(), resourceUri.getScheme())) {
-                    log.warn("Illegal scheme requested for ORE resource: {}", resourceUri);
-                    return false;
-                }
-                if (!Objects.equals(
-                        entryUri.getHost().toLowerCase(Locale.ROOT),
-                        resourceUri.getHost().toLowerCase(Locale.ROOT))) {
-                    log.warn("Illegal host requested for ORE resource: {}", resourceUri);
-                    return false;
-                }
-            }
-
-            return true;
-
-        } catch (URISyntaxException e) {
-            log.warn("Could not validate ORE resource URI: {}", resourceUrl);
+            resourceUri = new URI(resourceUrl).normalize();
+        } catch (URISyntaxException | NullPointerException e) {
+            log.error("Invalid resource URI: " + resourceUrl);
             return false;
+        }
+        String resourceHost = resourceUri.getHost();
+
+        Set<String> allowedSchemes = Set.of("http", "https");
+        String resourceScheme = resourceUri.getScheme();
+        if (resourceScheme == null ||
+                !allowedSchemes.contains(resourceScheme.toLowerCase(Locale.ROOT))) {
+            log.warn("Illegal scheme requested for ORE resource: {}", resourceUrl);
+            return false;
+        }
+
+        initializeForbiddenHosts();
+        if (forbiddenHostUrls != null) {
+            for (String forbiddenHostUrl : forbiddenHostUrls) {
+                String forbiddenHost = extractHostname(forbiddenHostUrl);
+                if (forbiddenHost != null && Objects.equals(forbiddenHost, resourceHost)) {
+                    log.warn("Forbidden hostname in ORE resource URL: {}", resourceUrl);
+                    return false;
+                }
+            }
+        }
+
+        // This is now very strict - it is up to administrators to configure a list of allowed URL prefixes.
+        // If validateHost is set to 'true', and an empty list will cause every resource URL to be rejected
+        // Unlike forbidden URLs, we expect these to be hostnames rather than partial or full URIs as well
+        if (configurationService.getBooleanProperty("oai.harvester.ore.file.validateHost", false)) {
+            for (String allowedHost : configurationService
+                    .getArrayProperty("oai.harvester.ore.file.allowedHosts")) {
+                if (Objects.equals(resourceUri.getHost().toLowerCase(Locale.ROOT),
+                        allowedHost.toLowerCase(Locale.ROOT))) {
+                    return true;
+                }
+            }
+        } else {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * To keep config easier to maintain with both plain hostnames like 'bad.example.com' and references
+     * to partial URLs elsewhere in configuration like ${dspace.ui.url}, we test to see which it is
+     * and return the string representing the hostname.
+     * @param urlOrHost URL, partial URL or hostname to extract and validate
+     * @return extracted hostname or null
+     */
+    String extractHostname(String urlOrHost) {
+        if (StringUtils.isBlank(urlOrHost)) {
+            return null;
+        }
+        try {
+            URI uri = new URI(urlOrHost);
+            String host = uri.getHost();
+            if (host != null) {
+                return host.toLowerCase(Locale.ROOT);
+            }
+        } catch (URISyntaxException e) {
+            // pass through
+        }
+        // Return plain lower-cased string as defaulg
+        return urlOrHost.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Initialize forbidden hosts from config, if not set already
+     */
+    void initializeForbiddenHosts() {
+        if (forbiddenHostUrls == null) {
+            String dspaceServerUrl = configurationService.getProperty("dspace.server.url");
+            String dspaceUiUrl = configurationService.getProperty("dspace.ui.url");
+            String[] localAndEC2Hosts = {"localhost", "127.0.0.1", "[::1]", "169.254.169.254", "[fd00:ec2::254]"};
+            List<String> defaultForbiddenUrlPrefixes = new ArrayList<>();
+            Collections.addAll(defaultForbiddenUrlPrefixes, localAndEC2Hosts);
+            if (StringUtils.isNotBlank(dspaceServerUrl)) {
+                defaultForbiddenUrlPrefixes.add(dspaceServerUrl);
+            }
+            if (StringUtils.isNotBlank(dspaceUiUrl)) {
+                defaultForbiddenUrlPrefixes.add(dspaceUiUrl);
+            }
+            forbiddenHostUrls = configurationService.getArrayProperty(
+                    "oai.harvester.ore.file.forbiddenHostUrls",
+                    defaultForbiddenUrlPrefixes.toArray(new String[0]));
         }
     }
 

--- a/dspace-api/src/test/java/org/dspace/content/crosswalk/OREIngestionCrosswalkTest.java
+++ b/dspace-api/src/test/java/org/dspace/content/crosswalk/OREIngestionCrosswalkTest.java
@@ -1,0 +1,239 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.content.crosswalk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.dspace.AbstractIntegrationTestWithDatabase;
+import org.dspace.app.client.DSpaceHttpClientFactory;
+import org.dspace.builder.BundleBuilder;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ItemBuilder;
+import org.dspace.content.Bundle;
+import org.dspace.content.Collection;
+import org.dspace.content.Item;
+import org.dspace.content.factory.ContentServiceFactory;
+import org.dspace.content.service.ItemService;
+import org.dspace.eperson.EPerson;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Test class for OREIngestionCrosswalk
+ *
+ * @author Kim Shepherd
+ */
+public class OREIngestionCrosswalkTest extends AbstractIntegrationTestWithDatabase {
+
+    private Bundle bundle;
+    private OREIngestionCrosswalk crosswalk;
+    private Item item;
+    private ItemService itemService;
+    private EPerson prevUser;
+
+    private static final Namespace ATOM_NS = Namespace.getNamespace("atom", "http://www.w3.org/2005/Atom");
+    private static final Namespace ORE_NS = Namespace.getNamespace("ore", "http://www.openarchives.org/ore/terms/");
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        crosswalk = new OREIngestionCrosswalk();
+        itemService = ContentServiceFactory.getInstance().getItemService();
+
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).build();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity).build();
+        item = ItemBuilder.createItem(context, collection).withTitle("Test ORE Object").build();
+        bundle = BundleBuilder.createBundle(context, item).withName("ORIGINAL").build();
+        context.restoreAuthSystemState();
+        prevUser = context.getCurrentUser();
+        context.setCurrentUser(admin);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        context.setCurrentUser(prevUser);
+    }
+
+    @Test
+    public void testIngestNullRoot() throws Exception {
+        // should just return without exception
+        crosswalk.ingest(context, item, (Element) null, false);
+    }
+
+    @Test
+    public void testIngestEmptyResources() throws Exception {
+        Element entry = createOREEntryWithoutResources();
+        crosswalk.ingest(context, item, entry, false);
+
+        List<Bundle> bundles = itemService.getBundles(item, "ORIGINAL");
+        assertTrue("Should have no bundles or empty bundle",
+                bundles.isEmpty() || bundles.getFirst().getBitstreams().isEmpty());
+    }
+
+    @Test(expected = CrosswalkException.class)
+    public void testIngestInvalidURISyntaxThrowsException() throws Exception {
+        Element entry = createOREEntryWithInvalidURI();
+        crosswalk.ingest(context, item, entry, false);
+    }
+
+    @Test
+    public void testHostValidation() {
+        // localhost = forbidden
+        boolean result = crosswalk.validResourceUri("http://localhost:8080/resource");
+        assertFalse("localhost should be forbidden", result);
+
+        // 127.0.0.1 = forbidden
+        result = crosswalk.validResourceUri("http://127.0.0.1:8080/resource");
+        assertFalse("127.0.0.1 should be forbidden", result);
+
+        // allowed.example.com = not forbidden
+        result = crosswalk.validResourceUri("http://allowed.example.com/resource");
+        assertTrue("External host should be allowed", result);
+    }
+
+    @Test
+    public void testSchemeValidation() throws Exception {
+        boolean result = crosswalk.validResourceUri("file:///etc/passwd");
+        assertFalse("file:// scheme should be forbidden", result);
+
+        result = crosswalk.validResourceUri("ftp://example.com/resource");
+        assertFalse("ftp:// scheme should be forbidden", result);
+
+        result = crosswalk.validResourceUri("https://example.com/resource");
+        assertTrue("https:// scheme should be allowed", result);
+    }
+
+    @Test
+    public void testSuccessfulBitstreamIngest() throws Exception {
+        // fully mocked response
+        try (MockedStatic<DSpaceHttpClientFactory> mockedFactory =
+                     mockHttpClient(200, "Test bitstream content")) {
+
+            Element entry = createValidOREEntry();
+            crosswalk.ingest(context, item, entry, false);
+
+            List<Bundle> bundles = itemService.getBundles(item, "ORIGINAL");
+            assertFalse("Should have created bundle", bundles.isEmpty());
+            assertFalse("Bundle should have bitstream", bundles.getFirst().getBitstreams().isEmpty());
+        }
+    }
+
+    @Test
+    public void testIngestStreamAsBitstream() throws Exception {
+        String testContent = "Test bitstream content";
+        InputStream inputStream = new ByteArrayInputStream(testContent.getBytes());
+
+        Element resource = new Element("link", ATOM_NS);
+        resource.setAttribute("href", "http://example.com/test.pdf");
+        resource.setAttribute("title", "Test Document");
+        resource.setAttribute("type", "application/pdf");
+
+        crosswalk.ingestStreamAsBitstream(context, inputStream, bundle, resource, "test-entry");
+
+        assertFalse("Bundle should have bitstream", bundle.getBitstreams().isEmpty());
+        assertEquals("Bitstream should have correct name", "Test Document",
+                bundle.getBitstreams().getFirst().getName());
+    }
+
+    @Test(expected = IOException.class)
+    public void testIngestStreamAsBitstreamNullStreamThrowsException() throws Exception {
+        Element resource = new Element("link", ATOM_NS);
+        resource.setAttribute("href", "http://example.com/test.pdf");
+
+        crosswalk.ingestStreamAsBitstream(context, null, bundle, resource, "test-entry");
+    }
+
+    private Element createValidOREEntry() {
+        Element entry = new Element("entry", ATOM_NS);
+        Element altLink = new Element("link", ATOM_NS);
+        altLink.setAttribute("rel", "alternate");
+        altLink.setAttribute("href", "http://example.com/entry/123");
+        entry.addContent(altLink);
+        Element resLink = new Element("link", ATOM_NS);
+        resLink.setAttribute("rel", ORE_NS.getURI() + "aggregates");
+        resLink.setAttribute("href", "http://example.com/resource.pdf");
+        resLink.setAttribute("title", "Test Resource");
+        resLink.setAttribute("type", "application/pdf");
+        entry.addContent(resLink);
+        return entry;
+    }
+
+    private Element createOREEntryWithoutResources() {
+        Element entry = new Element("entry", ATOM_NS);
+        Element altLink = new Element("link", ATOM_NS);
+        altLink.setAttribute("rel", "alternate");
+        altLink.setAttribute("href", "http://example.com/entry/123");
+        entry.addContent(altLink);
+        return entry;
+    }
+
+
+    private Element createOREEntryWithInvalidURI() {
+        Element entry = new Element("entry", ATOM_NS);
+        Element altLink = new Element("link", ATOM_NS);
+        altLink.setAttribute("rel", "alternate");
+        altLink.setAttribute("href", "http://example.com/entry/123");
+        entry.addContent(altLink);
+        Element resLink = new Element("link", ATOM_NS);
+        resLink.setAttribute("rel", ORE_NS.getURI() + "aggregates");
+        resLink.setAttribute("href", "hello, i am an invalid URI");
+        entry.addContent(resLink);
+        return entry;
+    }
+
+    private MockedStatic<DSpaceHttpClientFactory> mockHttpClient(int statusCode, String content) throws IOException {
+        MockedStatic<DSpaceHttpClientFactory> mockedFactory = Mockito.mockStatic(DSpaceHttpClientFactory.class);
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        DSpaceHttpClientFactory mockFactoryInstance = mock(DSpaceHttpClientFactory.class);
+        CloseableHttpResponse mockResponse = mockHttpResponse(statusCode, content);
+
+        when(mockFactoryInstance.buildWithRequestConfig(any())).thenReturn(mockClient);
+        when(mockClient.execute(any(HttpGet.class))).thenReturn(mockResponse);
+        mockedFactory.when(DSpaceHttpClientFactory::getInstance).thenReturn(mockFactoryInstance);
+
+        return mockedFactory;
+    }
+
+    private CloseableHttpResponse mockHttpResponse(int statusCode, String content) throws IOException {
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        HttpEntity mockEntity = mock(HttpEntity.class);
+        StatusLine mockStatus = mock(StatusLine.class);
+
+        when(mockStatus.getStatusCode()).thenReturn(statusCode);
+        when(mockEntity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes()));
+        when(mockResponse.getStatusLine()).thenReturn(mockStatus);
+        when(mockResponse.getEntity()).thenReturn(mockEntity);
+
+        return mockResponse;
+    }
+
+}

--- a/dspace/config/modules/oai.cfg
+++ b/dspace/config/modules/oai.cfg
@@ -146,9 +146,26 @@ oai.harvester.unknownSchema = fail
 # this config parameter, a new handle will be minted instead. Default value: 123456789.
 #oai.harvester.rejectedHandlePrefix = 123456789, myTestHandle
 
-# If ingesting files with ORE, only files with URLs that match the base URL of the remote
-# OAI endpoint's domain name are accepted, or a list of other URL prefixes defined below
-#oai.harvester.ore.file.validateUrlPrefix = true
+
+# If ingesting files with ORE, enforce some validation on resource URL hosts and schemes.
+
+# Should redirects be followed? The safe default is 'false'
+# to avoid a malicious endpoint from circumventing the below hostname / URL validation
+#oai.harvester.ore.follow-redirects = false
+
+# The following forbidden hosts are configured by default. It is highly recommended not to
+# remove entries from this list unless you are very certain you can trust ORE harvested content.
+# Both plain hosts (with or without URI scheme) and URLs can be listed here; the host will
+# be extracted from a constructed URI object.
+#oai.harvester.ore.file.forbiddenHostUrls = localhost, 127.0.0.1, [::1], 169.254.169.254, [fd00:ec2::254], \
+#                                       ${dspace.server.url}, ${dspace.ui.url}
+
+# If validateUrlPrefix is true, then *only* resource URLs matching
+# the configured URL prefixes are allowed by ORE harvesting. This is the strictest
+# setting and requires some knowledge of trusted ORE sources and their contents
+# but it is also the best mitigation against an ORE source becoming compromised
+# and linking to malicious resource URLs
+#oai.harvester.ore.file.validateHost = true
 # Prefixes that are allowed globally (for any endpoint) are below
-#oai.harvester.ore.file.allowedUrlPrefix = dspace.myinstitution.edu
-#oai.harvester.ore.file.allowedUrlPrefix = files.myinstitution.edu
+#oai.harvester.ore.file.allowedHosts = dspace.remote-institution.edu
+#oai.harvester.ore.file.allowedHosts = files.remote-institution.edu


### PR DESCRIPTION
## Description

We recently added some resource URL scheme and host validation in https://github.com/DSpace/DSpace/pull/12538

However, as reported by @vidiecan , the fix was incomplete and did not enforce the allowed list as strictly as advertised. We also identified a few other gaps in the approach, like a malicious ORE endpoint bypassing URL validation through redirects.

This fix is not completely exhaustive but aims to further harden the ORE ingestion crosswalk against SSRF or ingestion of malicious content, in the event that a trusted ORE harvest source is ever compromised.

## References
* Improves #12538 

## Instructions for Reviewers

**AI disclosure**: Kiro was used to generate some HTTP mock stubs in the new test class, which were then tidied up by hand

### Change list
1. Improved allowed hosts list replaces the previous "allowedUrlPrefix" list and, if enabled, strictly enforces that the resource URL match one of the configured hosts or it is rejected
2. New forbidden hostUrls list can be configured with hostnames or URLs (from which hostnames will be extracted), is always enabled and includes local host names and IPs, dspace backend and frontend URLs and the Amazon EC2 metadata IP to provide some first-line mitigation against SSRF
3. The old `URL.stream()` code is updated to follow current conventions in using the shared `DSpaceHttpClientFactory`, and builds a client that disables redirects by default. (this can be overridden)
4. Some basic tests are written to test validation and response handling with mock ORE documents

### To test

If you have a real ORE endpoint to test against, follow the normal [DSpace OAI harvest documentation ](https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944783/OAI#OAI-OAI-PMH/OAI-OREHarvester(Client)) and try out some practical tests, like:

* Adding a hostname to the forbidden list in `oai.cfg` that you expect to be returned, and confirm that nothing was ingested as a bitstream
* Enable `validateHost` in `oai.cfg` with the hostname now in the allowed list (and removed from forbidden) and confirm that the bitstreams you expect are now ingested normally

Other than these practical tests, I hope the ITs are sufficient so some extra attention to these will help, in case I've missed any coverage gaps.

### Configuration reference

```
# If ingesting files with ORE, enforce some validation on resource URL hosts and schemes.

# Should redirects be followed? The safe default is 'false'
# to avoid a malicious endpoint from circumventing the below hostname / URL validation
oai.harvester.ore.follow-redirects = false

# The following forbidden hosts are configured by default. It is highly recommended not to
# remove entries from this list unless you are very certain you can trust ORE harvested content.
# Both plain hosts (with or without URI scheme) and URLs can be listed here; the host will
# be extracted from a constructed URI object.
oai.harvester.ore.file.forbiddenHostUrls = localhost, 127.0.0.1, [::1], 169.254.169.254, [fd00:ec2::254], \
#                                       ${dspace.server.url}, ${dspace.ui.url}

# If validateUrlPrefix is true, then *only* resource URLs matching
# the configured URL prefixes are allowed by ORE harvesting. This is the strictest
# setting and requires some knowledge of trusted ORE sources and their contents
# but it is also the best mitigation against an ORE source becoming compromised
# and linking to malicious resource URLs
#oai.harvester.ore.file.validateHost = true
# Prefixes that are allowed globally (for any endpoint) are below
#oai.harvester.ore.file.allowedHosts = dspace.remote-institution.edu
#oai.harvester.ore.file.allowedHosts = files.remote-institution.edu
```

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [ ] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
