### PR TITLE
Harden auto-registration process via external systems like ORCID

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -256,11 +256,12 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
         return converter.toRest(registrationData, utils.obtainProjection());
     }
 
-    private void validateToken(Context context, String token) {
+    private void validateToken(Context context, Integer id, String token) {
         try {
             RegistrationData registrationData =
                 registrationDataService.findByToken(context, token);
-            if (registrationData == null || !registrationDataService.isValid(registrationData)) {
+            if (registrationData == null || !registrationDataService.isValid(registrationData) ||
+                !id.equals(registrationData.getID())) {
                 throw new AccessDeniedException("The token is invalid");
             }
         } catch (SQLException e) {
@@ -294,7 +295,7 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
         }
         Context context = obtainContext();
 
-        validateToken(context, token);
+        validateToken(context, id, token);
 
         try {
             resourcePatch.patch(context, registrationDataService.find(context, id), patch.getOperations());

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -256,13 +256,26 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
         return converter.toRest(registrationData, utils.obtainProjection());
     }
 
-    private void validateToken(Context context, Integer id, String token) {
+    /**
+     * Validate that this registration token allows PATCHing the registration data.
+     * PATCH is only allowed if the token is valid, corresponds to the registration ID, and
+     * the registration is related to an external login (e.g. ORCID).
+     * @param context DSpace Context
+     * @param id Registration ID
+     * @param token Registration token
+     */
+    private void validateTokenForPatch(Context context, Integer id, String token) {
         try {
             RegistrationData registrationData =
                 registrationDataService.findByToken(context, token);
             if (registrationData == null || !registrationDataService.isValid(registrationData) ||
                 !id.equals(registrationData.getID())) {
                 throw new AccessDeniedException("The token is invalid");
+            }
+            // PATCH can only be used for external-login and review-account type registrations.
+            if (!RegistrationTypeEnum.ORCID.equals(registrationData.getRegistrationType()) &&
+                !RegistrationTypeEnum.VALIDATION_ORCID.equals(registrationData.getRegistrationType())) {
+                throw new AccessDeniedException("The registration data cannot be updated");
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -295,7 +308,7 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
         }
         Context context = obtainContext();
 
-        validateToken(context, id, token);
+        validateTokenForPatch(context, id, token);
 
         try {
             resourcePatch.patch(context, registrationDataService.find(context, id), patch.getOperations());

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -665,26 +665,12 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationData_whenPatchInvalidValue_thenUnprocessableEntityResponse()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest = new RegistrationRest();
-        registrationRest.setEmail(eperson.getEmail());
-        registrationRest.setUser(eperson.getID());
-
         Email spy = Mockito.spy(Email.class);
         doNothing().when(spy).send();
 
-        emailMockedStatic.when(() -> Email.getEmail(any())).thenReturn(spy);
-
-        // given RegistrationData with email
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registrationRest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create first registration request of type "external-login" with an associated email address.
         RegistrationData registrationData =
-            registrationDataService.findByEmail(context, registrationRest.getEmail());
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -728,26 +714,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationData_whenPatchWithInvalidToken_thenUnprocessableEntityResponse()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest = new RegistrationRest();
-        registrationRest.setEmail(eperson.getEmail());
-        registrationRest.setUser(eperson.getID());
-
-        Email spy = Mockito.spy(Email.class);
-        doNothing().when(spy).send();
-
-        emailMockedStatic.when(() -> Email.getEmail(any())).thenReturn(spy);
-
-        // given RegistrationData with email
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registrationRest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create first registration request of type "external-login" with an associated email address.
         RegistrationData registrationData =
-            registrationDataService.findByEmail(context, registrationRest.getEmail());
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.ORCID);
 
 
         assertThat(registrationData, notNullValue());
@@ -816,41 +785,18 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationDataWithEmail_whenPatchWithDifferentToken_thenThrowError()
         throws Exception {
-
-        // Create first registration
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest = new RegistrationRest();
-        registrationRest.setEmail(eperson.getEmail());
-        registrationRest.setUser(eperson.getID());
-
-        // Post first RegistrationData to create registration entry
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registrationRest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create first registration request of type "external-login" with an associated email address.
         RegistrationData registrationData =
-            registrationDataService.findByEmail(context, registrationRest.getEmail());
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
 
         String tokenOne = registrationData.getToken();
 
-        // Create second registration with different email
-        RegistrationRest registration2Rest = new RegistrationRest();
-        registration2Rest.setEmail("person@example.org");
-
-        // Post second RegistrationData to create registration entry
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registration2Rest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create second registration request of type "external-login" with a different associated email address.
         RegistrationData registration2Data =
-            registrationDataService.findByEmail(context, registration2Rest.getEmail());
+            createNewRegistrationData(null, "different@example.org", RegistrationTypeEnum.ORCID);
 
         assertThat(registration2Data, notNullValue());
         assertThat(registration2Data.getToken(), not(emptyOrNullString()));
@@ -875,21 +821,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationDataWithEmail_whenPatchForReplaceEmail_thenSuccessfullResponse()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest = new RegistrationRest();
-        registrationRest.setEmail(eperson.getEmail());
-        registrationRest.setUser(eperson.getID());
-
-        // given RegistrationData with email
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registrationRest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create a registration request of type "external-login" with an associated email address.
         RegistrationData registrationData =
-            registrationDataService.findByEmail(context, registrationRest.getEmail());
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -912,9 +846,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationDataWithoutEmail_whenPatchForAddEmail_thenSuccessfullResponse()
         throws Exception {
-
+        // Create a registration request of type "external-login" without an associated email address.
         RegistrationData registrationData =
-            createNewRegistrationData("0000-1111-2222-3333", RegistrationTypeEnum.ORCID);
+            createNewRegistrationData("0000-1111-2222-3333", null, RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -937,21 +871,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationDataWithEmail_whenPatchForReplaceEmail_thenNewRegistrationDataCreated()
         throws Exception {
-
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest = new RegistrationRest();
-        registrationRest.setEmail(eperson.getEmail());
-        registrationRest.setUser(eperson.getID());
-
-        // given RegistrationData with email
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registrationRest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create a registration request of type "external-login" with an associated email address.
         RegistrationData registrationData =
-            registrationDataService.findByEmail(context, registrationRest.getEmail());
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -976,18 +898,51 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         assertThat(newRegistration.getToken(), not(emptyOrNullString()));
         assertThat(newRegistration.getEmail(), equalTo(newMail));
 
+        // verify token and email are both changed in updated registration
         assertThat(newRegistration.getEmail(), not(equalTo(registrationData.getEmail())));
         assertThat(newRegistration.getToken(), not(equalTo(registrationData.getToken())));
 
+        // verify prior registration data is nullified
         registrationData = context.reloadEntity(registrationData);
         assertThat(registrationData, nullValue());
+
+        // Attempt to update the registration data a SECOND TIME.
+        // It should be possible but email & token will change again.
+        String token2 = newRegistration.getToken();
+        String newMail2 = "person1@example.org";
+        String patchContent2 = getPatchContent(
+            List.of(new ReplaceOperation("/email", newMail2))
+        );
+
+        // Second patch to replace email again using the updated token
+        getClient().perform(patch("/api/eperson/registrations/" + newRegistration.getID())
+                                .param(TOKEN_QUERY_PARAM, token2)
+                                .content(patchContent2)
+                                .contentType(contentType))
+                   // then successful response returned
+                   .andExpect(status().is2xxSuccessful());
+
+        // Again find the updated registration and verify it's valid
+        RegistrationData newRegistration2 = registrationDataService.findByEmail(context, newMail2);
+        assertThat(newRegistration2, notNullValue());
+        assertThat(newRegistration2.getToken(), not(emptyOrNullString()));
+        assertThat(newRegistration2.getEmail(), equalTo(newMail2));
+
+        // verify token and email are both changed in updated registration
+        assertThat(newRegistration2.getEmail(), not(equalTo(newRegistration.getEmail())));
+        assertThat(newRegistration2.getToken(), not(equalTo(newRegistration.getToken())));
+
+        // verify prior registration data is nullified (again)
+        newRegistration = context.reloadEntity(newRegistration);
+        assertThat(newRegistration, nullValue());
     }
 
     @Test
     public void givenRegistrationDataWithoutEmail_whenPatchForReplaceEmail_thenNewRegistrationDataCreated()
         throws Exception {
+        // Create a registration request of type "external-login" without an associated email address.
         RegistrationData registrationData =
-            createNewRegistrationData("0000-1111-2222-3333", RegistrationTypeEnum.ORCID);
+            createNewRegistrationData("0000-1111-2222-3333", null, RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
 
@@ -1020,8 +975,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
     @Test
     public void givenRegistrationDataWithoutEmail_whenPatchForAddEmail_thenExternalLoginSent() throws Exception {
+        // Create a registration request of type "external-login" without an associated email address.
         RegistrationData registrationData =
-            createNewRegistrationData("0000-1111-2222-3333", RegistrationTypeEnum.ORCID);
+            createNewRegistrationData("0000-1111-2222-3333", null, RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -1057,8 +1013,10 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
     @Test
     public void givenRegistrationDataWithEmail_whenPatchForNewEmail_thenExternalLoginSent() throws Exception {
+        // Create a registration request of type "external-login" without an associated email address.
+        // NOTE: We'll add an email to this registration data via PATCH below
         RegistrationData registrationData =
-            createNewRegistrationData("0000-1111-2222-3333", RegistrationTypeEnum.ORCID);
+            createNewRegistrationData("0000-1111-2222-3333", null, RegistrationTypeEnum.ORCID);
 
         String token = registrationData.getToken();
         String newMail = "vincenzo.mecca@orcid.com";
@@ -1071,7 +1029,7 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
         emailMockedStatic.when(() -> Email.getEmail(any())).thenReturn(spy);
 
-        // when patch for replace email
+        // when patch for add email
         getClient().perform(patch("/api/eperson/registrations/" + registrationData.getID())
                                 .param(TOKEN_QUERY_PARAM, token)
                                 .content(patchContent)
@@ -1122,20 +1080,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void givenRegistrationDataWithEmail_whenPatchForExistingEPersonEmail_thenReviewAccountLinkSent()
         throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest = new RegistrationRest();
-        registrationRest.setEmail(eperson.getEmail());
-        registrationRest.setNetId("0000-0000-0000-0000");
-
-        // given RegistrationData with email
-        getClient().perform(post("/api/eperson/registrations")
-                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
-                                .content(mapper.writeValueAsBytes(registrationRest))
-                                .contentType(contentType))
-                   .andExpect(status().isCreated());
-
+        // Create a registration request of type "external-login" with an associated email address.
         RegistrationData registrationData =
-            registrationDataService.findByEmail(context, registrationRest.getEmail());
+            createNewRegistrationData("0000-0000-0000-0000", "test@example.org", RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -1179,8 +1126,9 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
 
     @Test
     public void givenRegistrationDataWithoutEmail_whenPatchForExistingAccount_thenReviewAccountSent() throws Exception {
+        // Create a registration request of type "external-login" without an associated email address.
         RegistrationData registrationData =
-            createNewRegistrationData("0000-1111-2222-3333", RegistrationTypeEnum.ORCID);
+            createNewRegistrationData("0000-1111-2222-3333", null, RegistrationTypeEnum.ORCID);
 
         assertThat(registrationData, notNullValue());
         assertThat(registrationData.getToken(), not(emptyOrNullString()));
@@ -1223,13 +1171,74 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
         verify(spy, times(1)).send();
     }
 
+    @Test
+    public void givenNonExternalRegistrationData_whenPatch_throwError() throws Exception {
+        // PATCH of registration data REQUIRES the "external-login" type. So, we'll verify that all other types fail.
+
+        // Create patch content to replace the email to something different
+        String newMail = "different@example.org";
+        String patchContent = getPatchContent(
+            List.of(new ReplaceOperation("/email", newMail))
+        );
+
+        // Create a registration request of type "forgot" with an associated email address.
+        RegistrationData registrationDataForgot =
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.FORGOT);
+
+        // Attempt to patch the "forgot" request with a new email
+        // Expect it to fail as this would be a potential vulnerability allowing attackers to change the linked account
+        getClient().perform(patch("/api/eperson/registrations/" + registrationDataForgot.getID())
+                                .param(TOKEN_QUERY_PARAM, registrationDataForgot.getToken())
+                                .content(patchContent)
+                                .contentType(contentType))
+                   // then unauthorized error is thrown
+                   .andExpect(status().isUnauthorized());
+
+        // Create a registration request of type "register" with an associated email address.
+        RegistrationData registrationDataRegister =
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.REGISTER);
+
+        // Attempt to patch the "register" request with a new email
+        getClient().perform(patch("/api/eperson/registrations/" + registrationDataRegister.getID())
+                                .param(TOKEN_QUERY_PARAM, registrationDataRegister.getToken())
+                                .content(patchContent)
+                                .contentType(contentType))
+                   // then unauthorized error is thrown
+                   .andExpect(status().isUnauthorized());
+
+        // Create a registration request of type "change-password" with an associated email address.
+        RegistrationData registrationDataChangePass =
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.CHANGE_PASSWORD);
+
+        // Attempt to patch the "change-password" request with a new email
+        // Expect it to fail as this would be a potential vulnerability allowing attackers to change the linked account
+        getClient().perform(patch("/api/eperson/registrations/" + registrationDataChangePass.getID())
+                                .param(TOKEN_QUERY_PARAM, registrationDataChangePass.getToken())
+                                .content(patchContent)
+                                .contentType(contentType))
+                   // then unauthorized error is thrown
+                   .andExpect(status().isUnauthorized());
+
+        // Create a registration request of type "invitation" with an associated email address.
+        RegistrationData registrationDataInvitation =
+            createNewRegistrationData(null, "test@example.org", RegistrationTypeEnum.INVITATION);
+
+        // Attempt to patch the "invitation" request with a new email
+        getClient().perform(patch("/api/eperson/registrations/" + registrationDataInvitation.getID())
+                                .param(TOKEN_QUERY_PARAM, registrationDataInvitation.getToken())
+                                .content(patchContent)
+                                .contentType(contentType))
+                   // then unauthorized error is thrown
+                   .andExpect(status().isUnauthorized());
+    }
 
     private RegistrationData createNewRegistrationData(
-        String netId, RegistrationTypeEnum type
+        String netId, String email, RegistrationTypeEnum type
     ) throws SQLException, AuthorizeException {
         context.turnOffAuthorisationSystem();
         RegistrationData registrationData =
             registrationDataService.create(context, netId, type);
+        registrationData.setEmail(email);
         context.commit();
         context.restoreAuthSystemState();
         return registrationData;

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -814,6 +814,65 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     }
 
     @Test
+    public void givenRegistrationDataWithEmail_whenPatchWithDifferentToken_thenThrowError()
+        throws Exception {
+
+        // Create first registration
+        ObjectMapper mapper = new ObjectMapper();
+        RegistrationRest registrationRest = new RegistrationRest();
+        registrationRest.setEmail(eperson.getEmail());
+        registrationRest.setUser(eperson.getID());
+
+        // Post first RegistrationData to create registration entry
+        getClient().perform(post("/api/eperson/registrations")
+                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
+                                .content(mapper.writeValueAsBytes(registrationRest))
+                                .contentType(contentType))
+                   .andExpect(status().isCreated());
+
+        RegistrationData registrationData =
+            registrationDataService.findByEmail(context, registrationRest.getEmail());
+
+        assertThat(registrationData, notNullValue());
+        assertThat(registrationData.getToken(), not(emptyOrNullString()));
+
+        String tokenOne = registrationData.getToken();
+
+        // Create second registration with different email
+        RegistrationRest registration2Rest = new RegistrationRest();
+        registration2Rest.setEmail("person@example.org");
+
+        // Post second RegistrationData to create registration entry
+        getClient().perform(post("/api/eperson/registrations")
+                                .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
+                                .content(mapper.writeValueAsBytes(registration2Rest))
+                                .contentType(contentType))
+                   .andExpect(status().isCreated());
+
+        RegistrationData registration2Data =
+            registrationDataService.findByEmail(context, registration2Rest.getEmail());
+
+        assertThat(registration2Data, notNullValue());
+        assertThat(registration2Data.getToken(), not(emptyOrNullString()));
+
+        String tokenTwo = registration2Data.getToken();
+
+        // Create patch content to modify the email fo the first registration
+        String newMail = "vins-01@fake.mail";
+        String patchContent = getPatchContent(
+            List.of(new ReplaceOperation("/email", newMail))
+        );
+
+        // Here we are attempting to patch the *first* registration using the token from the *second* registration
+        getClient().perform(patch("/api/eperson/registrations/" + registrationData.getID())
+                                .param(TOKEN_QUERY_PARAM, tokenTwo)
+                                .content(patchContent)
+                                .contentType(contentType))
+                   // then unauthorized error is thrown
+                   .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     public void givenRegistrationDataWithEmail_whenPatchForReplaceEmail_thenSuccessfullResponse()
         throws Exception {
 


### PR DESCRIPTION
## Description
When authenticating via ORCID for the first time, an auto-registration process is kicked off in DSpace.  That registration process requires `PATCH`ing the registration entry if an ORCID authenticated user needs to enter or update the email they wish to register with DSpace.

This PR hardens that registration process by ensuring the `PATCH` command is only triggered at the point it is necessary for ORCID or similar external systems.

## Instructions for Reviewers
* Verify code changes
* Verify tests included, which mock the improved behavior
* Optionally test the ORCID authentication process. (This was tested locally by me and I didn't find any issues, but additional testing is more than welcome)