### PR TITLE
Fix haveNA to honor additional handle prefixes #11449

### DIFF
--- a/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandlePlugin.java
@@ -307,10 +307,17 @@ public class HandlePlugin implements HandleStorage {
     }
 
     /**
-     * Return true if we have this handle in storage.
+     * Return true if this Handle server is responsible for the given naming
+     * authority handle.
+     * <p>
+     * Naming authority handles are of the form {@code 0.NA/<prefix>}. When
+     * {@code handle.plugin.checknameauthority} is true (the default), this
+     * matches {@code handle.prefix} and any {@code handle.additional.prefixes}.
+     * When that property is false, this method always returns true so the
+     * server will answer for any naming authority.
      *
      * @param theHandle byte array representation of handle
-     * @return True if we have this handle in storage
+     * @return True if this server should answer for the naming authority
      * @throws HandleException If an error occurs while calling the Handle API.
      */
     @Override
@@ -322,32 +329,31 @@ public class HandlePlugin implements HandleStorage {
         /*
          * Naming authority Handles are in the form: 0.NA/1721.1234
          *
-         * 0.NA is basically the naming authority for naming authorities. For
-         * this simple implementation, we will just check that the prefix
-         * configured in dspace.cfg is the one in the request, returning true if
-         * this is the case, false otherwise.
-         *
-         * FIXME: For more complex Handle situations, this will need enhancing.
+         * 0.NA is the naming authority for naming authorities. When
+         * handle.plugin.checknameauthority is true (default), we accept the
+         * primary handle.prefix and every handle.additional.prefixes entry.
+         * That covers merged repositories that still need to resolve more than
+         * one prefix. Set handle.plugin.checknameauthority = false only if this
+         * server must answer for prefixes that are not listed in those
+         * properties.
          */
-
-        // This parameter allows the dspace handle server to be capable of having multiple
-        // name authorities assigned to it. So long as the handle table the alternative prefixes
-        // defined the dspace will answer for those handles prefixes. This is not ideal and only
-        // works if the dspace instances assumes control over all the items in a prefix, but it
-        // does allow the admin to merge together two previously separate dspace instances each
-        // with their own prefixes and have the one instance handle both prefixes. In this case
-        // all new handle would be given a unified prefix but all old handles would still be
-        // resolvable.
         if (configurationService.getBooleanProperty("handle.plugin.checknameauthority", true)) {
-            // First, construct a string representing the naming authority Handle
-            // we'd expect.
-            String expected = "0.NA/" + handleService.getPrefix();
-
-            // Which authority does the request pertain to?
             String received = Util.decodeString(theHandle);
 
-            // Return true if they match
-            return expected.equals(received);
+            if (("0.NA/" + handleService.getPrefix()).equals(received)) {
+                return true;
+            }
+
+            String[] additionalPrefixes = handleService.getAdditionalPrefixes();
+            if (additionalPrefixes != null) {
+                for (String additionalPrefix : additionalPrefixes) {
+                    if (("0.NA/" + additionalPrefix).equals(received)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         } else {
             return true;
         }

--- a/dspace-api/src/test/java/org/dspace/handle/HandlePluginTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/HandlePluginTest.java
@@ -1,0 +1,62 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.handle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import net.handle.hdllib.Util;
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.handle.factory.HandleServiceFactory;
+import org.dspace.handle.service.HandleService;
+import org.dspace.services.ConfigurationService;
+import org.dspace.utils.DSpace;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link HandlePlugin#haveNA(byte[])}.
+ */
+public class HandlePluginTest extends AbstractDSpaceTest {
+    protected HandleService handleService = HandleServiceFactory.getInstance().getHandleService();
+    protected ConfigurationService configurationService = new DSpace().getConfigurationService();
+    private HandlePlugin plugin;
+
+    @Before
+    public void setUpPlugin() {
+        configurationService.setProperty("handle.prefix", "123456789");
+        configurationService.setProperty("handle.additional.prefixes", "987654321, 654321987");
+        configurationService.setProperty("handle.plugin.checknameauthority", true);
+
+        plugin = new HandlePlugin();
+        plugin.handleService = handleService;
+        plugin.configurationService = configurationService;
+    }
+
+    @Test
+    public void haveNAAcceptsPrimaryPrefix() throws Exception {
+        assertTrue(plugin.haveNA(Util.encodeString("0.NA/123456789")));
+    }
+
+    @Test
+    public void haveNARejectsUnknownPrefix() throws Exception {
+        assertFalse(plugin.haveNA(Util.encodeString("0.NA/999999999")));
+    }
+
+    @Test
+    public void haveNAAcceptsAdditionalPrefixes() throws Exception {
+        assertTrue(plugin.haveNA(Util.encodeString("0.NA/987654321")));
+        assertTrue(plugin.haveNA(Util.encodeString("0.NA/654321987")));
+    }
+
+    @Test
+    public void haveNAAlwaysTrueWhenCheckDisabled() throws Exception {
+        configurationService.setProperty("handle.plugin.checknameauthority", false);
+        assertTrue(plugin.haveNA(Util.encodeString("0.NA/999999999")));
+    }
+}

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -347,6 +347,16 @@ handle.dir = ${dspace.dir}/handle-server
 # that repository)
 # handle.additional.prefixes = prefix1[, prefix2]
 
+# Whether HandlePlugin.haveNA() should check that a naming authority request
+# (0.NA/<prefix>) matches this repository's handle.prefix and
+# handle.additional.prefixes. Defaults to true.
+#
+# Merged repositories that resolve more than one prefix should list the extra
+# prefixes in handle.additional.prefixes. Set this to false only in special
+# cases where the Handle server must answer for prefixes that are not listed
+# there. When false, haveNA() always returns true.
+# handle.plugin.checknameauthority = true
+
 # Whether to enable the DSpace handle resolver endpoints necessary for
 # https://github.com/DSpace/Remote-Handle-Resolver
 # Defaults to "false" which means these handle resolver endpoints are not available.


### PR DESCRIPTION
## References
* Fixes #11449

## Description
`HandlePlugin.haveNA()` now treats `handle.additional.prefixes` as naming authorities, and `handle.plugin.checknameauthority` is documented in `dspace.cfg`.

## Instructions for Reviewers
List of changes in this PR:
* `haveNA()` matches `0.NA/<prefix>` against `handle.prefix` and every `handle.additional.prefixes` entry when `handle.plugin.checknameauthority` is true (default).
* When that property is false, `haveNA()` still always returns true.
* Javadoc and the inline comment now describe that behavior instead of saying the method checks storage.
* Commented default added next to the other Handle settings in `dspace.cfg`.
* Unit tests cover the primary prefix, additional prefixes, an unknown prefix, and the disabled check.

I could not run `dspace-api` tests on this machine (no JDK 21). CI should run `HandlePluginTest`.

Merged repositories that already list extra prefixes should no longer need `handle.plugin.checknameauthority = false`.

## Checklist
- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
