### PR TITLE
[Port dspace-8_x] Add JSON payload and URL parameter validation in /api/epersons/registrations REST endpoints

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RegistrationRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RegistrationRest.java
@@ -10,10 +10,8 @@ package org.dspace.app.rest.model;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
-
 import org.dspace.app.rest.RestResourceController;
 
 /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RegistrationRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/RegistrationRest.java
@@ -10,8 +10,11 @@ package org.dspace.app.rest.model;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.dspace.app.rest.RestResourceController;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+
+import org.dspace.app.rest.RestResourceController;
 
 /**
  * This class acts as the REST representation of the RegistrationData model class.
@@ -24,7 +27,10 @@ public class RegistrationRest extends RestAddressableModel {
     public static final String PLURAL_NAME = "registrations";
     public static final String CATEGORY = EPERSON;
 
+    @Email
+    @NotEmpty
     private String email;
+
     private UUID user;
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -11,14 +11,14 @@ import static org.dspace.eperson.service.CaptchaService.REGISTER_ACTION;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.Validator;
-import java.util.Set;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -13,6 +13,9 @@ import java.io.IOException;
 import java.sql.SQLException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.Set;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -79,6 +82,12 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @Autowired
     private RegistrationDataService registrationDataService;
 
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private Validator validator;
+
     @Override
     @PreAuthorize("permitAll()")
     public RegistrationRest findOne(Context context, Integer integer) {
@@ -93,8 +102,6 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @Override
     public RegistrationRest createAndReturn(Context context) {
         HttpServletRequest request = requestService.getCurrentRequest().getHttpServletRequest();
-        ObjectMapper mapper = new ObjectMapper();
-        RegistrationRest registrationRest;
         String accountType = request.getParameter(TYPE_QUERY_PARAM);
         if (StringUtils.isBlank(accountType) ||
             (!accountType.equalsIgnoreCase(TYPE_FORGOT) && !accountType.equalsIgnoreCase(TYPE_REGISTER))) {
@@ -112,61 +119,42 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
             }
         }
 
+        RegistrationRest registrationRest;
         try {
             ServletInputStream input = request.getInputStream();
             registrationRest = mapper.readValue(input, RegistrationRest.class);
         } catch (IOException e1) {
             throw new UnprocessableEntityException("Error parsing request body.", e1);
         }
-        if (StringUtils.isBlank(registrationRest.getEmail())) {
-            throw new UnprocessableEntityException("The email cannot be omitted from the Registration endpoint");
+
+        // Validation of deserialized object
+        Set<ConstraintViolation<RegistrationRest>> violations = validator.validate(registrationRest);
+        if (violations != null && !violations.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            for (ConstraintViolation<RegistrationRest> v : violations) {
+                sb.append(v.getPropertyPath())
+                    .append(": ")
+                    .append(v.getMessage())
+                    .append("; ");
+            }
+            throw new UnprocessableEntityException("Validation error: " + sb.toString());
         }
+
         EPerson eperson = null;
         try {
             eperson = ePersonService.findByEmail(context, registrationRest.getEmail());
         } catch (SQLException e) {
             log.error("Something went wrong retrieving EPerson for email: " + registrationRest.getEmail(), e);
         }
+
         if (eperson != null && accountType.equalsIgnoreCase(TYPE_FORGOT)) {
-            try {
-                if (!AuthorizeUtil.authorizeForgotPassword()) {
-                    throw new AccessDeniedException("Password reset is not allowed!");
-                }
-                if (!AuthorizeUtil.authorizeUpdatePassword(context, eperson.getEmail())) {
-                    throw new DSpaceBadRequestException("Password cannot be updated for the given EPerson with email: "
-                                                            + eperson.getEmail());
-                }
-                accountService.sendForgotPasswordInfo(context, registrationRest.getEmail());
-            } catch (SQLException | IOException | MessagingException | AuthorizeException e) {
-                log.error("Something went wrong with sending forgot password info email: "
-                              + registrationRest.getEmail(), e);
-            }
+            resetPassword(context, registrationRest, eperson);
         } else if (accountType.equalsIgnoreCase(TYPE_REGISTER)) {
             if (eperson == null) {
-                try {
-                    String email = registrationRest.getEmail();
-                    if (!AuthorizeUtil.authorizeNewAccountRegistration(context, request)) {
-                        throw new AccessDeniedException(
-                            "Registration is disabled, you are not authorized to create a new Authorization");
-                    }
-                    if (!authenticationService.canSelfRegister(context, request, email)) {
-                        throw new UnprocessableEntityException(
-                            String.format("Registration is not allowed with email address" +
-                                          " %s", email));
-                    }
-                    accountService.sendRegistrationInfo(context, email);
-                } catch (SQLException | IOException | MessagingException | AuthorizeException e) {
-                    log.error("Something went wrong with sending registration info email: "
-                              + registrationRest.getEmail(), e);
-                }
+                registerEperson(context, request, registrationRest);
             } else {
                 // if an eperson with this email already exists then send "forgot password" email instead
-                try {
-                    accountService.sendForgotPasswordInfo(context, registrationRest.getEmail());
-                }  catch (SQLException | IOException | MessagingException | AuthorizeException e) {
-                    log.error("Something went wrong with sending forgot password info email: "
-                              + registrationRest.getEmail(), e);
-                }
+                resetPassword(context, registrationRest, eperson);
             }
         }
         return null;
@@ -175,6 +163,63 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @Override
     public Class<RegistrationRest> getDomainClass() {
         return RegistrationRest.class;
+    }
+
+    /**
+     * This method will register a new eperson with the email given in the registrationRest object, and send an
+     * registration email to that email address.
+     * @param context
+     * @param request
+     * @param registrationRest
+     * @throws UnprocessableEntityException If self registration is not allowed.
+     * @throws AccessDeniedException If the user is not authorized to register a new eperson
+     */
+    private void registerEperson(Context context, HttpServletRequest request, RegistrationRest registrationRest)
+        throws UnprocessableEntityException, AccessDeniedException {
+        try {
+            if (!AuthorizeUtil.authorizeNewAccountRegistration(context, request)) {
+                throw new AccessDeniedException(
+                        "Registration is disabled, you are not authorized to create a new Authorization");
+            }
+
+            if (!authenticationService.canSelfRegister(context, request, registrationRest.getEmail())) {
+                throw new UnprocessableEntityException(
+                        String.format("Registration is not allowed with email address" +
+                                " %s", registrationRest.getEmail()));
+            }
+
+            accountService.sendRegistrationInfo(context, registrationRest.getEmail());
+        } catch (SQLException | IOException | MessagingException | AuthorizeException e) {
+            log.error("Something went wrong with sending registration info email: "
+                    + registrationRest.getEmail(), e);
+        }
+    }
+
+    /**
+     * This method will send a forgot password email to the email address given in the registrationRest object, if the
+     * email address belongs to an existing eperson. If the email address doesn't belong to any existing eperson,
+     * nothing will happen.
+     * @param context
+     * @param registrationRest
+     * @param eperson
+     * @throws AccessDeniedException If the user is not authorized to reset the password for the given eperson
+     * @throws DSpaceBadRequestException If the password cannot be updated for the given eperson
+     */
+    private void resetPassword(Context context, RegistrationRest registrationRest, EPerson eperson)
+        throws AccessDeniedException, DSpaceBadRequestException {
+        try {
+            if (!AuthorizeUtil.authorizeForgotPassword()) {
+                throw new AccessDeniedException("Password reset is not allowed!");
+            }
+            if (!AuthorizeUtil.authorizeUpdatePassword(context, eperson.getEmail())) {
+                throw new DSpaceBadRequestException("Password cannot be updated for the given EPerson with email: "
+                                                        + eperson.getEmail());
+            }
+            accountService.sendForgotPasswordInfo(context, registrationRest.getEmail());
+        } catch (SQLException | IOException | MessagingException | AuthorizeException e) {
+            log.error("Something went wrong with sending forgot password info email: "
+                          + registrationRest.getEmail(), e);
+        }
     }
 
     /**

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -232,6 +232,9 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
     @SearchRestMethod(name = "findByToken")
     public RegistrationRest findByToken(@Parameter(value = "token", required = true) String token)
         throws SQLException, AuthorizeException, DSpaceBadRequestException {
+        if (StringUtils.isBlank(token)) {
+            throw new DSpaceBadRequestException("Missing or empty token query parameter");
+        }
         if (StringUtils.length(token) > 48) {
             throw new DSpaceBadRequestException("Token length cannot be longer than 48 characters");
         }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/RegistrationRestRepository.java
@@ -231,7 +231,11 @@ public class RegistrationRestRepository extends DSpaceRestRepository<Registratio
      */
     @SearchRestMethod(name = "findByToken")
     public RegistrationRest findByToken(@Parameter(value = "token", required = true) String token)
-        throws SQLException, AuthorizeException {
+        throws SQLException, AuthorizeException, DSpaceBadRequestException {
+        if (StringUtils.length(token) > 48) {
+            throw new DSpaceBadRequestException("Token length cannot be longer than 48 characters");
+        }
+
         Context context = obtainContext();
         RegistrationData registrationData = registrationDataService.findByToken(context, token);
         if (registrationData == null) {

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -159,6 +159,13 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     @Test
     public void findByTokenWithEmptyToken() throws Exception {
         getClient().perform(get("/api/eperson/registrations/search/findByToken")
+            .param("token", ""))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findByTokenWithBlankToken() throws Exception {
+        getClient().perform(get("/api/eperson/registrations/search/findByToken")
             .param("token", "  "))
             .andExpect(status().isBadRequest());
     }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -33,6 +33,7 @@ import org.dspace.app.rest.model.RegistrationRest;
 import org.dspace.app.rest.repository.RegistrationRestRepository;
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
 import org.dspace.builder.EPersonBuilder;
+import org.dspace.core.Email;
 import org.dspace.eperson.CaptchaServiceImpl;
 import org.dspace.eperson.InvalidReCaptchaException;
 import org.dspace.eperson.RegistrationData;
@@ -40,7 +41,12 @@ import org.dspace.eperson.dao.RegistrationDataDAO;
 import org.dspace.eperson.service.CaptchaService;
 import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationTest {
@@ -53,6 +59,29 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     private ConfigurationService configurationService;
     @Autowired
     private RegistrationRestRepository registrationRestRepository;
+    @Autowired
+    private ObjectMapper mapper;
+
+    private static MockedStatic<Email> emailMockedStatic;
+
+    @After
+    public void tearDown() throws Exception {
+        Iterator<RegistrationData> iterator = registrationDataDAO.findAll(context, RegistrationData.class).iterator();
+        while (iterator.hasNext()) {
+            RegistrationData registrationData = iterator.next();
+            registrationDataDAO.delete(context, registrationData);
+        }
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        emailMockedStatic = Mockito.mockStatic(Email.class);
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        emailMockedStatic.close();
+    }
 
     @Test
     public void findByTokenTestExistingUserTest() throws Exception {
@@ -472,4 +501,51 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
             .andExpect(status().isBadRequest());
     }
 
+    @Test
+    public void registrationWithInvalidEmailFormatTest() throws Exception {
+        Email spy = Mockito.spy(Email.class);
+        doNothing().when(spy).send();
+        emailMockedStatic.when(() -> Email.getEmail(any())).thenReturn(spy);
+
+        RegistrationRest registrationRest = new RegistrationRest();
+        registrationRest.setEmail("invalid-email!!!!");
+
+        getClient().perform(post("/api/eperson/registrations")
+            .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
+            .content(mapper.writeValueAsBytes(registrationRest))
+            .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    public void registrationWithEmptyEmailTest() throws Exception {
+        Email spy = Mockito.spy(Email.class);
+        doNothing().when(spy).send();
+        emailMockedStatic.when(() -> Email.getEmail(any())).thenReturn(spy);
+
+        RegistrationRest registrationRest = new RegistrationRest();
+        registrationRest.setEmail("");
+
+        getClient().perform(post("/api/eperson/registrations")
+            .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
+            .content(mapper.writeValueAsBytes(registrationRest))
+            .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    public void registrationWithNullEmailTest() throws Exception {
+        Email spy = Mockito.spy(Email.class);
+        doNothing().when(spy).send();
+        emailMockedStatic.when(() -> Email.getEmail(any())).thenReturn(spy);
+
+        RegistrationRest registrationRest = new RegistrationRest();
+        registrationRest.setEmail(null);
+
+        getClient().perform(post("/api/eperson/registrations")
+            .param(TYPE_QUERY_PARAM, TYPE_REGISTER)
+            .content(mapper.writeValueAsBytes(registrationRest))
+            .contentType(contentType))
+            .andExpect(status().isUnprocessableEntity());
+    }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/RegistrationRestRepositoryIT.java
@@ -151,6 +151,26 @@ public class RegistrationRestRepositoryIT extends AbstractControllerIntegrationT
     }
 
     @Test
+    public void findByTokenWithoutToken() throws Exception {
+        getClient().perform(get("/api/eperson/registrations/search/findByToken"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findByTokenWithEmptyToken() throws Exception {
+        getClient().perform(get("/api/eperson/registrations/search/findByToken")
+            .param("token", "  "))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void findByTokenWithTooLongToken() throws Exception {
+        getClient().perform(get("/api/eperson/registrations/search/findByToken")
+            .param("token", "t".repeat(49))) // token length cannot be longer than 48 characters
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     public void registrationFlowTest() throws Exception {
         List<RegistrationData> registrationDataList = registrationDataDAO.findAll(context, RegistrationData.class);
         assertEquals(0, registrationDataList.size());


### PR DESCRIPTION
Manual port of #12695 by @saschaszott to `dspace-8_x`.

NOTE: This only contains a subset of the fixes because some fixes don't apply to 8.x  For instance 8.x didn't support `netid` on the `EPerson` and also didn't support registration tokens in the same way as 9.x+