### PR TITLE
Harden the experimental IIIF Search API feature

### DIFF
--- a/dspace-iiif/src/main/java/org/dspace/app/iiif/service/WordHighlightSolrSearch.java
+++ b/dspace-iiif/src/main/java/org/dspace/app/iiif/service/WordHighlightSolrSearch.java
@@ -24,6 +24,7 @@ import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.impl.NoOpResponseParser;
 import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.NamedList;
 import org.dspace.app.iiif.model.generator.AnnotationGenerator;
@@ -126,8 +127,10 @@ public class WordHighlightSolrSearch implements SearchAnnotationService {
      * @return solr query
      */
     private SolrQuery getSolrQuery(String query, String manifestId) {
+        String safeQuery = ClientUtils.escapeQueryChars(query);
+        String safeManifestId = ClientUtils.escapeQueryChars(manifestId);
         SolrQuery solrQuery = new SolrQuery();
-        solrQuery.set("q", "ocr_text:" + query + " AND manifest_url:\"" + manifestId + "\"");
+        solrQuery.set("q", "ocr_text:" + safeQuery + " AND manifest_url:\"" + safeManifestId + "\"");
         solrQuery.set(CommonParams.WT, "json");
         solrQuery.set("hl", "true");
         solrQuery.set("hl.ocr.fl", "ocr_text");


### PR DESCRIPTION
## Description

DSpace has an experimental IIIF Search API which is documented at https://wiki.lyrasis.org/spaces/DSDOC10x/pages/408944973/IIIF+Configuration#IIIFConfiguration-IIIFSearchAPI

This IIIF Search API is noted as experimental code, especially since there is _no support in DSpace for indexing files_ using the required Solr OCR Highlighting Plugin.  Therefore this code appears to be unused.

That said, recently it was pointed out by @ik0z that the experimental code seems to fail to sanitize possible query characters.

This PR provides basic sanitization to ensure the code is secured should it ever be used within DSpace.

## Instructions for Reviewers
* Review the code changes.  Notice the changes simply use `ClientUtils.escapeQueryChars()` similar to other areas of our codebase that escape Solr query chars.
* Unfortunately, there is no easy way to test this because it requires building a custom indexing solution for the Solr OCR Highlighting Plugin