### PR TITLE
ItemExport Service I/O improvements

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -120,14 +120,12 @@ public class ItemExportServiceImpl implements ItemExportService {
 
     /**
      * Get the configured list of allowed base directories for item export.
-     * @return list of absolute allowed base paths, or null
+     * @return list of absolute allowed base paths. If this is an empty list, it will forbid all exports
      */
-    protected List<String> getAllowedExportBaseDirs() {
+    protected List<String> getAllowedExportBaseDirs() throws Exception {
+        String workDir = getExportWorkDirectory();
         String[] configured =
-            configurationService.getArrayProperty("org.dspace.app.itemexport.allowed.dir");
-        if (configured == null || configured.length == 0) {
-            return null;
-        }
+            configurationService.getArrayProperty("org.dspace.app.itemexport.allowed.dir", new String[]{workDir});
         return Arrays.stream(configured)
                      .map(String::trim)
                      .collect(Collectors.toList());
@@ -137,13 +135,8 @@ public class ItemExportServiceImpl implements ItemExportService {
     public void exportItem(Context c, Iterator<Item> i,
                            String destDirName, int seqStart, boolean migrate,
                            boolean excludeBitstreams) throws Exception {
-        // Validate dest dir argument against a base path, if configured
-        // (otherwise trust user input)
-        List<String> allowedBaseDirs = getAllowedExportBaseDirs();
-        if (allowedBaseDirs != null) {
-            destDirName = SecureFileAccess.validatePathForWrite(
-                destDirName, allowedBaseDirs, "itemexport").toString();
-        }
+        destDirName = SecureFileAccess.validatePathForWrite(
+            destDirName, getAllowedExportBaseDirs(), "itemexport").toString();
 
         int mySequenceNumber = seqStart;
         int counter = SUBDIR_LIMIT - 1;
@@ -485,11 +478,8 @@ public class ItemExportServiceImpl implements ItemExportService {
                             String destDirName, String zipFileName,
                             int seqStart, boolean migrate,
                             boolean excludeBitstreams) throws Exception {
-        List<String> allowedBaseDirs = getAllowedExportBaseDirs();
-        if (allowedBaseDirs != null) {
-            destDirName = SecureFileAccess.validatePathForWrite(
-                destDirName, allowedBaseDirs, "itemexport").toString();
-        }
+        destDirName = SecureFileAccess.validatePathForWrite(
+            destDirName, getAllowedExportBaseDirs(), "itemexport").toString();
 
         String workDir = getExportWorkDirectory() +
             System.getProperty("file.separator") +
@@ -1007,14 +997,7 @@ public class ItemExportServiceImpl implements ItemExportService {
     public void zip(String strSource, String target) throws Exception {
         ZipOutputStream cpZipOutputStream = null;
         String tempFileName = target + "_tmp";
-        // TODO: is this out of scope for the specific fix?
-        //  and adds extra docs since download, cli export etc must now share a base path
-        List<String> allowedBaseDirs = getAllowedExportBaseDirs();
-        if (allowedBaseDirs == null) {
-            File parent = new File(target).getParentFile();
-            allowedBaseDirs = List.of(parent != null ? parent.getPath() : ".");
-        }
-        SecureFileAccess.validatePathForWrite(target, allowedBaseDirs, "itemexport");
+        SecureFileAccess.validatePathForWrite(target, getAllowedExportBaseDirs(), "itemexport");
         try {
             File cpFile = new File(strSource);
             if (!cpFile.isFile() && !cpFile.isDirectory()) {
@@ -1025,7 +1008,7 @@ public class ItemExportServiceImpl implements ItemExportService {
                 logWarn("Target file already exists: " + targetFile.getName());
             }
 
-            OutputStream fos = SecureFileAccess.getOutputStream(tempFileName, allowedBaseDirs, "itemexport");
+            OutputStream fos = SecureFileAccess.getOutputStream(tempFileName, getAllowedExportBaseDirs(), "itemexport");
             cpZipOutputStream = new ZipOutputStream(fos);
             cpZipOutputStream.setLevel(9);
             zipFiles(cpFile, strSource, tempFileName, cpZipOutputStream);

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -485,9 +485,17 @@ public class ItemExportServiceImpl implements ItemExportService {
                             String destDirName, String zipFileName,
                             int seqStart, boolean migrate,
                             boolean excludeBitstreams) throws Exception {
+        List<String> allowedBaseDirs = getAllowedExportBaseDirs();
+        if (allowedBaseDirs != null) {
+            destDirName = SecureFileAccess.validatePathForWrite(
+                destDirName, allowedBaseDirs, "itemexport").toString();
+        }
+
         String workDir = getExportWorkDirectory() +
             System.getProperty("file.separator") +
             zipFileName;
+        workDir = SecureFileAccess.validatePathForWrite(
+            workDir, List.of(getExportWorkDirectory()), "itemexport").toString();
 
         File wkDir = new File(workDir);
         if (!wkDir.exists() && !wkDir.mkdirs()) {
@@ -999,6 +1007,14 @@ public class ItemExportServiceImpl implements ItemExportService {
     public void zip(String strSource, String target) throws Exception {
         ZipOutputStream cpZipOutputStream = null;
         String tempFileName = target + "_tmp";
+        // TODO: is this out of scope for the specific fix?
+        //  and adds extra docs since download, cli export etc must now share a base path
+        List<String> allowedBaseDirs = getAllowedExportBaseDirs();
+        if (allowedBaseDirs == null) {
+            File parent = new File(target).getParentFile();
+            allowedBaseDirs = List.of(parent != null ? parent.getPath() : ".");
+        }
+        SecureFileAccess.validatePathForWrite(target, allowedBaseDirs, "itemexport");
         try {
             File cpFile = new File(strSource);
             if (!cpFile.isFile() && !cpFile.isDirectory()) {
@@ -1009,7 +1025,7 @@ public class ItemExportServiceImpl implements ItemExportService {
                 logWarn("Target file already exists: " + targetFile.getName());
             }
 
-            FileOutputStream fos = new FileOutputStream(tempFileName);
+            OutputStream fos = SecureFileAccess.getOutputStream(tempFileName, allowedBaseDirs, "itemexport");
             cpZipOutputStream = new ZipOutputStream(fos);
             cpZipOutputStream.setLevel(9);
             zipFiles(cpFile, strSource, tempFileName, cpZipOutputStream);

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -11,18 +11,19 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -61,6 +63,7 @@ import org.dspace.eperson.service.EPersonService;
 import org.dspace.handle.service.HandleService;
 import org.dspace.scripts.handler.DSpaceRunnableHandler;
 import org.dspace.services.ConfigurationService;
+import org.dspace.storage.secure.SecureFileAccess;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -115,11 +118,33 @@ public class ItemExportServiceImpl implements ItemExportService {
 
     }
 
+    /**
+     * Get the configured list of allowed base directories for item export.
+     * @return list of absolute allowed base paths, or null
+     */
+    protected List<String> getAllowedExportBaseDirs() {
+        String[] configured =
+            configurationService.getArrayProperty("org.dspace.app.itemexport.allowed.dir");
+        if (configured == null || configured.length == 0) {
+            return null;
+        }
+        return Arrays.stream(configured)
+                     .map(String::trim)
+                     .collect(Collectors.toList());
+    }
 
     @Override
     public void exportItem(Context c, Iterator<Item> i,
                            String destDirName, int seqStart, boolean migrate,
                            boolean excludeBitstreams) throws Exception {
+        // Validate dest dir argument against a base path, if configured
+        // (otherwise trust user input)
+        List<String> allowedBaseDirs = getAllowedExportBaseDirs();
+        if (allowedBaseDirs != null) {
+            destDirName = SecureFileAccess.validatePathForWrite(
+                destDirName, allowedBaseDirs, "itemexport").toString();
+        }
+
         int mySequenceNumber = seqStart;
         int counter = SUBDIR_LIMIT - 1;
         int subDirSuffix = 0;
@@ -232,13 +257,11 @@ public class ItemExportServiceImpl implements ItemExportService {
             filename = "metadata_" + schema + ".xml";
         }
 
-        File outFile = new File(destDir, filename);
+        logInfo("Attempting to create metadata file " + filename + " in " + destDir);
 
-        logInfo("Attempting to create file " + outFile);
-
-        if (outFile.createNewFile()) {
-            BufferedOutputStream out = new BufferedOutputStream(
-                new FileOutputStream(outFile));
+        try (BufferedOutputStream out = new BufferedOutputStream(SecureFileAccess.getOutputStream(
+                new File(destDir, filename).getPath(),
+                List.of(destDir.getPath()), "itemexport"))) {
 
             List<MetadataValue> dcorevalues = itemService.getMetadata(i, schema, Item.ANY, Item.ANY,
                                                                       Item.ANY);
@@ -315,10 +338,8 @@ public class ItemExportServiceImpl implements ItemExportService {
 
             utf8 = "</dublin_core>\n".getBytes("UTF-8");
             out.write(utf8, 0, utf8.length);
-
-            out.close();
-        } else {
-            throw new Exception("Cannot create dublin_core.xml in " + destDir);
+        } catch (IOException e) {
+            throw new IOException("Cannot create " + filename + " in " + destDir, e);
         }
     }
 
@@ -337,18 +358,10 @@ public class ItemExportServiceImpl implements ItemExportService {
         }
         String filename = "handle";
 
-        File outFile = new File(destDir, filename);
-
-        if (outFile.createNewFile()) {
-            PrintWriter out = new PrintWriter(new FileWriter(outFile, StandardCharsets.UTF_8));
-
+        try (PrintWriter out = new PrintWriter(SecureFileAccess.getBufferedWriter(
+                new File(destDir, filename).getPath(),
+                List.of(destDir.getPath()), "itemexport", StandardCharsets.UTF_8))) {
             out.println(i.getHandle());
-
-            // close the contents file
-            out.close();
-        } else {
-            throw new Exception("Cannot create file " + filename + " in "
-                                    + destDir);
         }
     }
 
@@ -362,22 +375,19 @@ public class ItemExportServiceImpl implements ItemExportService {
      */
     protected void writeCollections(Item item, File destDir)
             throws IOException {
-        File outFile = new File(destDir, "collections");
-        if (outFile.createNewFile()) {
-            try (PrintWriter out = new PrintWriter(new FileWriter(outFile))) {
-                Collection owningCollection = item.getOwningCollection();
-                // The owning collection is null for workspace and workflow items
-                if (owningCollection != null) {
-                    out.println(owningCollection.getHandle());
-                }
-                for (Collection collection : item.getCollections()) {
-                    if (!collection.equals(owningCollection)) {
-                        out.println(collection.getHandle());
-                    }
+        try (PrintWriter out = new PrintWriter(SecureFileAccess.getBufferedWriter(
+                new File(destDir, "collections").getPath(),
+                List.of(destDir.getPath()), "itemexport", StandardCharsets.UTF_8))) {
+            Collection owningCollection = item.getOwningCollection();
+            // The owning collection is null for workspace and workflow items
+            if (owningCollection != null) {
+                out.println(owningCollection.getHandle());
+            }
+            for (Collection collection : item.getCollections()) {
+                if (!collection.equals(owningCollection)) {
+                    out.println(collection.getHandle());
                 }
             }
-        } else {
-            throw new IOException("Cannot create 'collections' in " + destDir);
         }
     }
 
@@ -396,10 +406,9 @@ public class ItemExportServiceImpl implements ItemExportService {
      */
     protected void writeBitstreams(Context c, Item i, File destDir,
                                    boolean excludeBitstreams) throws Exception {
-        File outFile = new File(destDir, "contents");
-
-        if (outFile.createNewFile()) {
-            PrintWriter out = new PrintWriter(new FileWriter(outFile, StandardCharsets.UTF_8));
+        try (PrintWriter out = new PrintWriter(SecureFileAccess.getBufferedWriter(
+                new File(destDir, "contents").getPath(),
+                List.of(destDir.getPath()), "itemexport", StandardCharsets.UTF_8))) {
 
             List<Bundle> bundles = i.getBundles();
 
@@ -431,33 +440,26 @@ public class ItemExportServiceImpl implements ItemExportService {
                     // written
 
                     while (!excludeBitstreams && !isDone) {
-                        if (myName.contains(File.separator)) {
-                            String dirs = myName.substring(0, myName
-                                .lastIndexOf(File.separator));
-                            File fdirs = new File(destDir + File.separator
-                                                      + dirs);
-                            if (!fdirs.exists() && !fdirs.mkdirs()) {
-                                logError("Unable to create destination directory");
-                            }
+                        File fout = SecureFileAccess.validatePathForWrite(
+                            new File(destDir, myName).getPath(),
+                            List.of(destDir.getPath()), "itemexport").toFile();
+                        // Allow nested dirs in file name but still validate to parent file dir
+                        File parentDir = fout.getParentFile();
+                        if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+                            logError("Unable to create destination directory");
                         }
 
-                        File fout = new File(destDir, myName);
-
-                        if (fout.createNewFile()) {
-                            InputStream is = bitstreamService.retrieve(c, bitstream);
-                            FileOutputStream fos = new FileOutputStream(fout);
-                            Utils.bufferedCopy(is, fos);
-                            // close streams
-                            is.close();
-                            fos.close();
-
+                        // Filename collision detection.
+                        if (!Files.exists(fout.toPath())) {
+                            try (InputStream is = bitstreamService.retrieve(c, bitstream);
+                                 OutputStream fos = SecureFileAccess.getOutputStream(
+                                     fout.getPath(), List.of(destDir.getPath()), "itemexport")) {
+                                Utils.bufferedCopy(is, fos);
+                            }
                             isDone = true;
                         } else {
-                            myName = myPrefix + "_" + oldName; // keep
-                            // appending
-                            // numbers to the
-                            // filename until
-                            // unique
+                            myName = myPrefix + "_" + oldName;
+                            // keep appending numbers to the filename until unique
                             myPrefix++;
                         }
                     }
@@ -475,11 +477,6 @@ public class ItemExportServiceImpl implements ItemExportService {
 
                 }
             }
-
-            // close the contents file
-            out.close();
-        } else {
-            throw new Exception("Cannot create contents in " + destDir);
         }
     }
 

--- a/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/app/itemexport/ItemExportServiceImpl.java
@@ -121,6 +121,8 @@ public class ItemExportServiceImpl implements ItemExportService {
     /**
      * Get the configured list of allowed base directories for item export.
      * @return list of absolute allowed base paths. If this is an empty list, it will forbid all exports
+     *         but in practice, it will always at least default to workDir, and
+     *         {@link getExportWorkDirectory} throws an Exception if not set
      */
     protected List<String> getAllowedExportBaseDirs() throws Exception {
         String workDir = getExportWorkDirectory();

--- a/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
+++ b/dspace-api/src/main/java/org/dspace/storage/secure/SecureFileAccess.java
@@ -8,6 +8,7 @@
 package org.dspace.storage.secure;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -98,6 +99,7 @@ public final class SecureFileAccess {
      * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
      * @param allowedBasePaths the allowed base paths for this use case as per system configuration
      * @param purpose the name of the calling component / use case for logging and inspection
+     * @param charset the charset to use, or UTF-8 if null
      * @throws IOException on validation failure
      */
     public static BufferedReader getBufferedReader(String unvalidatedFile, List<String> allowedBasePaths,
@@ -135,6 +137,25 @@ public final class SecureFileAccess {
             throws IOException {
         Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePaths, purpose);
         return Files.newOutputStream(validatedFile);
+    }
+
+    /**
+     * Get a buffered writer after validating file path. As with {@link #getOutputStream}, new files
+     * can't use toRealPath() for link calculation so there is a trade-off allowing some symlink
+     * traversal to occur.
+     * @param unvalidatedFile the unvalidated file, usually derived from user input or configuration
+     * @param allowedBasePaths the allowed base paths for this use case as per system configuration
+     * @param purpose the name of the calling component / use case for logging and inspection
+     * @param charset the charset to use, or UTF-8 if null
+     * @throws IOException on validation failure
+     */
+    public static BufferedWriter getBufferedWriter(String unvalidatedFile, List<String> allowedBasePaths,
+            String purpose, Charset charset) throws IOException {
+        if (charset == null) {
+            charset = StandardCharsets.UTF_8;
+        }
+        Path validatedFile = validatePathForWrite(unvalidatedFile, allowedBasePaths, purpose);
+        return Files.newBufferedWriter(validatedFile, charset);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
@@ -8,7 +8,9 @@
 package org.dspace.app.itemexport;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -78,11 +80,15 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
             Files.createDirectory(Path.of(file.getAbsolutePath()));
         }
         workDir = Path.of(file.getAbsolutePath());
+
+        configurationService.setProperty("org.dspace.app.itemexport.allowed.dir",
+                new String[] { tempDir.toString(), workDir.toString() });
     }
 
     @After
     @Override
     public void destroy() throws Exception {
+        configurationService.setProperty("org.dspace.app.itemexport.allowed.dir", null);
         PathUtils.deleteOnExit(tempDir);
         for (Path path : Files.list(workDir).collect(Collectors.toList())) {
             PathUtils.deleteOnExit(path);
@@ -317,6 +323,64 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
 
         checkDir();
         checkItemMigration(item);
+    }
+
+    @Test
+    public void exportItemWithPathTraversalBitstreamName() throws Exception {
+        Path notAllowed = Files.createTempDirectory("notSafExportDir");
+        String traversalName = "../../../../../../../"
+                + notAllowed.getFileName().toString() + "/test.txt";
+
+        context.turnOffAuthorisationSystem();
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle(title)
+                .withMetadata("dc", "date", "issued", dateIssued)
+                .build();
+        String bitstreamContent = "some arbitrary content";
+        try (InputStream is = IOUtils.toInputStream(bitstreamContent, CharEncoding.UTF_8)) {
+            BitstreamBuilder.createBitstream(context, item, is)
+                    .withName(traversalName)
+                    .withMimeType("text/plain")
+                    .build();
+        }
+        context.restoreAuthSystemState();
+
+        String[] args = new String[] { "export", "-t", "ITEM",
+                "-i", item.getHandle(), "-d", tempDir.toString(), "-n", "1" };
+
+        // Exception should be thrown at validation
+        Exception thrown = assertThrows(Exception.class, () -> perfomExportScript(args));
+        assertTrue(thrown.getMessage().contains("Illegal file path attempted for I/O (itemexport)"));
+
+        // File should never have been written
+        assertFalse(Files.exists(notAllowed.resolve("test.txt")));
+        PathUtils.deleteOnExit(notAllowed);
+    }
+
+    @Test
+    public void exportRejectedWhenDestDirOutsideAllowedBase() throws Exception {
+        configurationService.setProperty(
+                "org.dspace.app.itemexport.allowed.dir", workDir.toString());
+
+        Path notAllowed = Files.createTempDirectory("");
+
+        context.turnOffAuthorisationSystem();
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle(title)
+                .withMetadata("dc", "date", "issued", dateIssued)
+                .build();
+        context.restoreAuthSystemState();
+
+        String[] args = new String[] { "export", "-t", "ITEM",
+                "-i", item.getHandle(), "-d", notAllowed.toString(), "-n", "1" };
+
+        // Exception should be thrown at validation
+        Exception thrown = assertThrows(Exception.class, () -> perfomExportScript(args));
+        assertTrue(thrown.getMessage().contains("Illegal file path attempted for I/O (itemexport)"));
+
+        // File should never have been written
+        assertFalse(Files.list(notAllowed).findAny().isPresent());
+        PathUtils.deleteOnExit(notAllowed);
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
@@ -90,7 +90,7 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
     public void destroy() throws Exception {
         PathUtils.deleteOnExit(tempDir);
         for (Path path : Files.list(workDir).collect(Collectors.toList())) {
-            PathUtils.deleteOnExit(path);
+            PathUtils.delete(path);
         }
         super.destroy();
     }
@@ -407,7 +407,7 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
         Exception thrown = assertThrows(Exception.class, () -> perfomExportScript(args2));
         assertTrue(thrown.getMessage().contains("Illegal file path attempted for I/O (itemexport)"));
         // File should never have been written
-        assertFalse(Files.list(workDir).findAny().isPresent());
+        assertFalse(Files.list(tempDir).findAny().isPresent());
     }
 
     /**

--- a/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
+++ b/dspace-api/src/test/java/org/dspace/app/itemexport/ItemExportCLIIT.java
@@ -88,7 +88,6 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
     @After
     @Override
     public void destroy() throws Exception {
-        configurationService.setProperty("org.dspace.app.itemexport.allowed.dir", null);
         PathUtils.deleteOnExit(tempDir);
         for (Path path : Files.list(workDir).collect(Collectors.toList())) {
             PathUtils.deleteOnExit(path);
@@ -362,7 +361,7 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
         configurationService.setProperty(
                 "org.dspace.app.itemexport.allowed.dir", workDir.toString());
 
-        Path notAllowed = Files.createTempDirectory("");
+        Path notAllowed = Files.createTempDirectory("notSafExportDir");
 
         context.turnOffAuthorisationSystem();
         Item item = ItemBuilder.createItem(context, collection)
@@ -381,6 +380,34 @@ public class ItemExportCLIIT extends AbstractIntegrationTestWithDatabase {
         // File should never have been written
         assertFalse(Files.list(notAllowed).findAny().isPresent());
         PathUtils.deleteOnExit(notAllowed);
+    }
+
+    @Test
+    public void allowedDirDefaultsToExportWorkDir() throws Exception {
+        // default array property is workDir, used on null or empty value set
+        configurationService.setProperty(
+                "org.dspace.app.itemexport.allowed.dir", new String[]{});
+
+        context.turnOffAuthorisationSystem();
+        Item item = ItemBuilder.createItem(context, collection)
+                .withTitle(title)
+                .withMetadata("dc", "date", "issued", dateIssued)
+                .build();
+        context.restoreAuthSystemState();
+
+        // Work dir should be allowed
+        String[] args = new String[] { "export", "-t", "ITEM",
+                "-i", item.getHandle(), "-d", workDir.toString(), "-n", "1" };
+        perfomExportScript(args);
+        assertTrue(Files.list(workDir).findAny().isPresent());
+
+        String[] args2 = new String[] { "export", "-t", "ITEM",
+                "-i", item.getHandle(), "-d", tempDir.toString(), "-n", "1" };
+        // Exception should be thrown at validation
+        Exception thrown = assertThrows(Exception.class, () -> perfomExportScript(args2));
+        assertTrue(thrown.getMessage().contains("Illegal file path attempted for I/O (itemexport)"));
+        // File should never have been written
+        assertFalse(Files.list(workDir).findAny().isPresent());
     }
 
     /**

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1241,6 +1241,11 @@ checker.retention.CHECKSUM_MATCH=8w
 # The directory where the exports will be done and compressed
 org.dspace.app.itemexport.work.dir = ${dspace.dir}/exports
 
+# Allowed base directories for item export output. If configured, this directory
+# will be enforced as the parent dir of all exports, including downloads, CLI "-d"
+# destination path, and so on. To allow any base directory, comment out or leave blank
+org.dspace.app.itemexport.allowed.dir = ${dspace.dir}/exports
+
 # The directory where the compressed files will reside and be read by the downloader
 org.dspace.app.itemexport.download.dir = ${dspace.dir}/exports/download
 

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1241,10 +1241,11 @@ checker.retention.CHECKSUM_MATCH=8w
 # The directory where the exports will be done and compressed
 org.dspace.app.itemexport.work.dir = ${dspace.dir}/exports
 
-# Allowed base directories for item export output. If configured, this directory
-# will be enforced as the parent dir of all exports, including downloads, CLI "-d"
-# destination path, and so on. To allow any base directory, comment out or leave blank
-org.dspace.app.itemexport.allowed.dir = ${dspace.dir}/exports
+# Allowed base directories for item export output. This directory
+# will be enforced as the parent dir of all exports, including downloads, script "-d"
+# destination path, and so on. The default value matches org.dspace.app.itemexport.work.dir.
+# If this property is set to an empty list or value, all exports will be forbidden.
+#org.dspace.app.itemexport.allowed.dir = ${org.dspace.app.itemexport.work.dir}
 
 # The directory where the compressed files will reside and be read by the downloader
 org.dspace.app.itemexport.download.dir = ${dspace.dir}/exports/download

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1244,7 +1244,6 @@ org.dspace.app.itemexport.work.dir = ${dspace.dir}/exports
 # Allowed base directories for item export output. This directory
 # will be enforced as the parent dir of all exports, including downloads, script "-d"
 # destination path, and so on. The default value matches org.dspace.app.itemexport.work.dir.
-# If this property is set to an empty list or value, all exports will be forbidden.
 #org.dspace.app.itemexport.allowed.dir = ${org.dspace.app.itemexport.work.dir}
 
 # The directory where the compressed files will reside and be read by the downloader


### PR DESCRIPTION
## Description
Improve File I/O handling in `ItemExportServiceImpl` by making use of the `SecureFileAccess` class to obtain trusted output streams and writers, and to validate canonical paths constructed with bitstream filenames.

## Instructions for Reviewers

List of changes in this PR:
* `SecureFileAccess` expanded to include `getBufferedWriter` method
* New `org.dspace.app.itemexport.allowed.dir` array config property added (defaults to export work dir)
* `ItemExportServiceImpl` uses secure file access methods to validate base export directory and all subdirectories created when writing bitstream, collection, metadata and handle directories.
* Tests added to `ItemExportCLIIT` to prove output directories are validated using the allowed dir config, and bitstream names cannot be used to break out of the given destination directory.

It was not strictly necessary to apply the stricter I/O to handle, metadata and collection file outputs as they are constructed with static strings off the base dir, but this was done for the sake of consistency and good practice (only obtain output streams / writers from `SecureFileAccess` unless there is a really good reason not to).

To test

* Set `org.dspace.app.itemexport.allowed.dir`
* Run the script where the `-d` flag is within this allowed dir and observe successful export
* Run the script where the `-d` flag is outside the allowed dir and observe the thrown IOException
* Verify new tests in `ItemExportCLIIT` cover the changes and expected behaviour

Additionally, to test path traversal mitigation: craft a special bitstream with a name like `../../../../../../../tmp/test.txt`, perform an export of its owning item, and observe the thrown IOException.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.