### PR TITLE
Make four ReDoS-prone regular expressions linear

### DIFF
--- a/dspace-api/src/main/java/org/dspace/discovery/FacetYearRange.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/FacetYearRange.java
@@ -19,7 +19,16 @@ import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
  * Utility class that represents the year range for a date facet
  */
 public class FacetYearRange {
-    private static final Pattern PATTERN = Pattern.compile("\\[(.*? TO .*?)\\]");
+    /**
+     * Matches a Solr year range such as <code>[2000 TO 2010]</code>.
+     * <p>
+     * The bounds are restricted to (optionally negative) integers instead of the <code>.*?</code>
+     * wildcards this pattern used previously. Both bounds are parsed with
+     * {@link Integer#parseInt} immediately below, so no other bound was ever usable, and the
+     * wildcard form allowed a crafted filter query to drive matching into quadratic time
+     * (CodeQL <code>java/polynomial-redos</code>).
+     */
+    private static final Pattern PATTERN = Pattern.compile("\\[( *-?\\d+ +TO +-?\\d+ *)\\]");
 
     private final DiscoverySearchFilterFacet facet;
     private String dateFacet;

--- a/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/discovery/SolrServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import jakarta.mail.MessagingException;
 import org.apache.commons.collections4.CollectionUtils;
@@ -110,6 +111,11 @@ public class SolrServiceImpl implements SearchService, IndexingService {
     // Suffix of the solr field used to index the facet/filter so that the facet search can search all word in a
     // facet by indexing "each word to end of value' partial value
     public static final String SOLR_FIELD_SUFFIX_FACET_PREFIXES = "_prefix";
+
+    /**
+     * The characters that "." in a regular expression never matches.
+     */
+    private static final Pattern LINE_TERMINATOR = Pattern.compile("[\\n\\r\\u0085\\u2028\\u2029]");
 
     @Autowired
     protected ContentServiceFactory contentServiceFactory;
@@ -1318,7 +1324,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
             filterQuery.append(":");
             if ("equals".equals(operator) || "notequals".equals(operator)) {
                 //DO NOT ESCAPE RANGE QUERIES !
-                if (!value.matches("\\[.*TO.*\\]")) {
+                if (!isRangeQuery(value)) {
                     value = ClientUtils.escapeQueryChars(value);
                     filterQuery.append(value);
                 } else {
@@ -1331,7 +1337,7 @@ public class SolrServiceImpl implements SearchService, IndexingService {
                 }
             } else {
                 //DO NOT ESCAPE RANGE QUERIES !
-                if (!value.matches("\\[.*TO.*\\]")) {
+                if (!isRangeQuery(value)) {
                     value = ClientUtils.escapeQueryChars(value);
                     filterQuery.append("\"").append(value).append("\"");
                 } else {
@@ -1344,6 +1350,22 @@ public class SolrServiceImpl implements SearchService, IndexingService {
 
         result.setFilterQuery(filterQuery.toString());
         return result;
+    }
+
+    /**
+     * Determine whether a filter value is a Solr range query, i.e. <code>[x TO y]</code>.
+     * <p>
+     * This replaces the regular expression <code>\[.*TO.*\]</code>, whose two unbounded
+     * wildcards around the literal <code>TO</code> allowed a crafted filter value to drive
+     * matching into quadratic time (CodeQL <code>java/polynomial-redos</code>). The three
+     * conditions below accept exactly the same values in linear time.
+     *
+     * @param value the filter value to inspect
+     * @return true if the value is shaped like a range query and must not be escaped
+     */
+    protected static boolean isRangeQuery(String value) {
+        return value.startsWith("[") && value.endsWith("]") && value.contains("TO")
+            && !LINE_TERMINATOR.matcher(value).find();
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/handle/HandleServiceImpl.java
@@ -62,9 +62,18 @@ public class HandleServiceImpl implements HandleService {
     private static final Pattern[] IDENTIFIER_PATTERNS = {
         Pattern.compile("^hdl:(.*)$"),
         Pattern.compile("^info:hdl/(.*)$"),
-        Pattern.compile("^https?://hdl\\.handle\\.net/(.*)$"),
-        Pattern.compile("^https?://.+/handle/(.*)$")
+        Pattern.compile("^https?://hdl\\.handle\\.net/(.*)$")
     };
+
+    /**
+     * Path segment separating a repository base URL from the handle it resolves.
+     */
+    private static final String HANDLE_URL_SEGMENT = "/handle/";
+
+    /**
+     * The characters that "." in a regular expression never matches.
+     */
+    private static final Pattern LINE_TERMINATOR = Pattern.compile("[\\n\\r\\u0085\\u2028\\u2029]");
 
     /**
      * Public Constructor
@@ -391,6 +400,11 @@ public class HandleServiceImpl implements HandleService {
             }
         }
 
+        String handleFromUrl = parseHandleFromUrl(identifier);
+        if (handleFromUrl != null) {
+            return handleFromUrl;
+        }
+
         // Check additional prefixes supported in the config file
         String[] additionalPrefixes = getAdditionalPrefixes();
         for (String additionalPrefix : additionalPrefixes) {
@@ -401,6 +415,45 @@ public class HandleServiceImpl implements HandleService {
         }
 
         return null;
+    }
+
+    /**
+     * Extract the handle from a <code>http(s)://&lt;base&gt;/handle/&lt;handle&gt;</code> URL.
+     * <p>
+     * This replaces the pattern <code>^https?://.+/handle/(.*)$</code>. The unbounded
+     * <code>.+</code> preceding a literal that <code>.</code> can itself match allowed a crafted
+     * identifier to drive matching into quadratic time (CodeQL
+     * <code>java/polynomial-redos</code>). Because <code>.+</code> was greedy it selected the
+     * last <code>/handle/</code> segment, which is what scanning backwards does here, in linear
+     * time.
+     *
+     * @param identifier the identifier to parse
+     * @return the handle, or null if the identifier is not a handle URL
+     */
+    protected String parseHandleFromUrl(String identifier) {
+        int baseStart;
+        if (identifier.startsWith("http://")) {
+            baseStart = "http://".length();
+        } else if (identifier.startsWith("https://")) {
+            baseStart = "https://".length();
+        } else {
+            return null;
+        }
+
+        // neither ".+" nor ".*" in the replaced pattern matched a line terminator. Rejecting such
+        // identifiers up front is also what removes the backtracking: it was a trailing line
+        // terminator that forced the greedy ".+" to retry every "/handle/" segment in turn.
+        if (LINE_TERMINATOR.matcher(identifier).find()) {
+            return null;
+        }
+
+        int segmentStart = identifier.lastIndexOf(HANDLE_URL_SEGMENT);
+        // ".+" required at least one character between the scheme and "/handle/"
+        if (segmentStart < baseStart + 1) {
+            return null;
+        }
+
+        return identifier.substring(segmentStart + HANDLE_URL_SEGMENT.length());
     }
 
     @Override

--- a/dspace-api/src/main/java/org/dspace/importer/external/service/DoiCheck.java
+++ b/dspace-api/src/main/java/org/dspace/importer/external/service/DoiCheck.java
@@ -30,10 +30,21 @@ public class DoiCheck {
             "dx.doi.org/",
             "doi:");
 
+    /**
+     * Recognises the DOI forms published by CrossRef.
+     * <p>
+     * Two constructs in the third alternative were rewritten because they let a crafted query
+     * drive matching into cubic time (CodeQL <code>java/polynomial-redos</code>).
+     * <code>\d+X?(\d+)\d+</code> became the equivalent but unambiguous
+     * <code>(?:\d{3,}|\d+X\d{2,})</code>: with the optional <code>X</code> absent it is three
+     * adjacent unbounded digit runs, and with it present two. The unescaped dots in
+     * <code>\d+.\d+.\w+</code> became literal dots, which is what the version segment of a
+     * legacy SICI DOI (for example <code>3.0.CO;2</code>) always meant.
+     */
     private static final Pattern PATTERN = Pattern.compile("10.\\d{4,9}/[-._;()/:A-Z0-9]+" +
                                                                "|10.1002/[^\\s]+" +
-                                                               "|10.\\d{4}/\\d+-\\d+X?(\\d+)" +
-                                                               "\\d+<[\\d\\w]+:[\\d\\w]*>\\d+.\\d+.\\w+;\\d" +
+                                                               "|10.\\d{4}/\\d+-(?:\\d{3,}|\\d+X\\d{2,})" +
+                                                               "<[\\d\\w]+:[\\d\\w]*>\\d+\\.\\d+\\.\\w+;\\d" +
                                                                "|10.1021/\\w\\w\\d++" +
                                                                "|10.1207/[\\w\\d]+\\&\\d+_\\d+",
                                                            Pattern.CASE_INSENSITIVE);

--- a/dspace-api/src/test/java/org/dspace/discovery/FacetYearRangeTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/FacetYearRangeTest.java
@@ -1,0 +1,91 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.dspace.discovery.configuration.DiscoverySearchFilterFacet;
+import org.junit.Test;
+
+/**
+ * Tests for the year range that {@link FacetYearRange} recovers from previously selected filter
+ * queries.
+ *
+ * @author Bram Luyten (bram at atmire.com)
+ */
+public class FacetYearRangeTest {
+
+    private static final String FACET = "dateIssued";
+
+    /**
+     * Resolve the range from the given filter queries. Every case below finds its range or its
+     * single year in the filter queries themselves, so the search index is never consulted and
+     * the context, scope, search service and parent query are never dereferenced.
+     *
+     * @param filterQueries the filter queries to resolve
+     * @return the resolved range
+     * @throws SearchServiceException never, since the search index is not consulted
+     */
+    private FacetYearRange rangeOf(String... filterQueries) throws SearchServiceException {
+        DiscoverySearchFilterFacet facet = new DiscoverySearchFilterFacet();
+        facet.setIndexFieldName(FACET);
+        FacetYearRange range = new FacetYearRange(facet);
+        range.calculateRange(null, Arrays.asList(filterQueries), null, null, null);
+        return range;
+    }
+
+    @Test
+    public void resolvesRange() throws Exception {
+        FacetYearRange range = rangeOf(FACET + ".year:[2000 TO 2010]");
+        assertEquals(2000, range.getOldestYear());
+        assertEquals(2010, range.getNewestYear());
+    }
+
+    @Test
+    public void resolvesRangePaddedWithSpaces() throws Exception {
+        FacetYearRange range = rangeOf(FACET + ".year:[ 2000 TO 2010 ]");
+        assertEquals(2000, range.getOldestYear());
+        assertEquals(2010, range.getNewestYear());
+    }
+
+    @Test
+    public void resolvesRangeWithRepeatedSpaces() throws Exception {
+        FacetYearRange range = rangeOf(FACET + ".year:[2000  TO  2010]");
+        assertEquals(2000, range.getOldestYear());
+        assertEquals(2010, range.getNewestYear());
+    }
+
+    @Test
+    public void resolvesRangeWithNegativeYears() throws Exception {
+        FacetYearRange range = rangeOf(FACET + ".year:[-500 TO -100]");
+        assertEquals(-500, range.getOldestYear());
+        assertEquals(-100, range.getNewestYear());
+    }
+
+    @Test
+    public void resolvesSingleYear() throws Exception {
+        FacetYearRange range = rangeOf(FACET + ".year:2005 OR " + FACET + ".year:2006");
+        assertEquals(2005, range.getOldestYear());
+        assertEquals(2005, range.getNewestYear());
+    }
+
+    /**
+     * A filter query that opens a range and never closes it has to be rejected promptly. The
+     * wildcard pattern used previously needed time quadratic in the length of the value, where
+     * recognising it as "not a range" is now linear. The bound is therefore a very wide margin
+     * and is not sensitive to a slow CI machine.
+     */
+    @Test(timeout = 5000)
+    public void rejectsUnclosedRangeWithoutBacktracking() throws Exception {
+        FacetYearRange range = rangeOf(FACET + ".year:2005 OR [" + " TO ".repeat(60000) + "x");
+        assertEquals(2005, range.getOldestYear());
+        assertEquals(2005, range.getNewestYear());
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/discovery/SolrServiceRangeQueryTest.java
+++ b/dspace-api/src/test/java/org/dspace/discovery/SolrServiceRangeQueryTest.java
@@ -1,0 +1,72 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.discovery;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link SolrServiceImpl#isRangeQuery(String)}, which decides whether a filter value is
+ * passed to Solr unescaped.
+ *
+ * @author Bram Luyten (bram at atmire.com)
+ */
+public class SolrServiceRangeQueryTest {
+
+    @Test
+    public void acceptsRangeQueries() {
+        assertTrue(SolrServiceImpl.isRangeQuery("[2000 TO 2010]"));
+        assertTrue(SolrServiceImpl.isRangeQuery("[* TO *]"));
+        assertTrue(SolrServiceImpl.isRangeQuery("[2000-01-01T00:00:00Z TO NOW]"));
+        assertTrue(SolrServiceImpl.isRangeQuery("[TO]"));
+    }
+
+    @Test
+    public void rejectsValuesThatAreNotRangeQueries() {
+        assertFalse(SolrServiceImpl.isRangeQuery(""));
+        assertFalse(SolrServiceImpl.isRangeQuery("[]"));
+        assertFalse(SolrServiceImpl.isRangeQuery("2000 TO 2010"));
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 TO 2010"));
+        assertFalse(SolrServiceImpl.isRangeQuery("2000 TO 2010]"));
+    }
+
+    /**
+     * "TO" is matched case sensitively, as it was by the pattern this replaced.
+     */
+    @Test
+    public void rejectsLowerCaseTo() {
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 to 2010]"));
+    }
+
+    /**
+     * "." never matched a line terminator, so a value containing one was escaped rather than
+     * passed through as a range. That is preserved: loosening it would let a value skip escaping
+     * that did not skip it before.
+     */
+    @Test
+    public void rejectsValuesContainingALineTerminator() {
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 \nTO 2010]"));
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 \rTO 2010]"));
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 " + (char) 0x0085 + "TO 2010]"));
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 " + (char) 0x2028 + "TO 2010]"));
+        assertFalse(SolrServiceImpl.isRangeQuery("[2000 " + (char) 0x2029 + "TO 2010]"));
+    }
+
+    /**
+     * A value that opens a range and never closes it has to be rejected promptly. The pattern
+     * used previously needed time quadratic in the length of the value, where the checks that
+     * replaced it are linear. The bound is therefore a very wide margin and is not sensitive to
+     * a slow CI machine.
+     */
+    @Test(timeout = 5000)
+    public void rejectsUnclosedRangeWithoutBacktracking() {
+        assertFalse(SolrServiceImpl.isRangeQuery("[" + "TO".repeat(60000) + "X"));
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
+++ b/dspace-api/src/test/java/org/dspace/handle/HandleServiceTest.java
@@ -54,6 +54,18 @@ public class HandleServiceTest extends AbstractUnitTest {
         assertEquals("111222333/111", handleService.parseHandle("https://fake.canonical.prefix/111222333/111"));
     }
 
+    /**
+     * A URL that can never yield a handle has to be rejected promptly. The greedy ".+" in the
+     * replaced pattern retried every "/handle/" segment in turn, needing time quadratic in the
+     * length of the identifier, where rejecting it is now linear. The bound is therefore a very
+     * wide margin and is not sensitive to a slow CI machine.
+     */
+    @Test(timeout = 10000)
+    public void testParseHandleRejectsLongUrlWithoutBacktracking() {
+        // a line terminator is what made the URL unmatchable, since "." never matched one
+        assertNull(handleService.parseHandle("http://a/handle/" + "a/handle/a".repeat(40000) + "\n"));
+    }
+
     @Test
     public void testParseHandleByAdditionalPrefix() {
         // note: handle pattern after prefix is not checked
@@ -69,5 +81,10 @@ public class HandleServiceTest extends AbstractUnitTest {
         assertEquals("111222333/111", handleService.parseHandle("http://hdl.handle.net/111222333/111"));
         assertEquals("111222333/111", handleService.parseHandle("https://whatever/handle/111222333/111"));
         assertEquals("111222333/111", handleService.parseHandle("http://whatever/handle/111222333/111"));
+        // a repository deployed under a context path
+        assertEquals("111222333/111", handleService.parseHandle("https://whatever/jspui/handle/111222333/111"));
+        // the replaced pattern was greedy, so a nested "/handle/" resolved to the last one
+        assertEquals("111222333/111",
+                     handleService.parseHandle("https://whatever/handle/x/handle/111222333/111"));
     }
 }

--- a/dspace-api/src/test/java/org/dspace/util/DoiCheckTest.java
+++ b/dspace-api/src/test/java/org/dspace/util/DoiCheckTest.java
@@ -52,6 +52,17 @@ public class DoiCheckTest {
         );
     }
 
+    /**
+     * A value that starts like a DOI but cannot be one has to be rejected promptly. Three
+     * adjacent unbounded digit runs in the pattern needed time cubic in the length of the value,
+     * where rejecting it is now linear. The bound is therefore a very wide margin and is not
+     * sensitive to a slow CI machine.
+     */
+    @Test(timeout = 5000)
+    public void rejectsLongDigitRunWithoutBacktracking() {
+        assertFalse(DoiCheck.isDoi("10.1234/1-" + "00".repeat(2000) + "!"));
+    }
+
     private List<String> wrongDOIsToTest() {
         return Arrays.asList(
             StringUtils.EMPTY,


### PR DESCRIPTION
## References

* Fixes #13089
* Unblocks the `CodeQL` required check on #11810, whose failure is caused entirely by these pre-existing alerts ([analysis](https://github.com/DSpace/DSpace/pull/11810#issuecomment-4770453813))

## Description

Makes four regular expressions that run over user-supplied values unambiguous, so that rejecting a
value that cannot match takes time linear in its length instead of quadratic or cubic. Resolves
CodeQL alerts [#42](https://github.com/DSpace/DSpace/security/code-scanning/42), [#43](https://github.com/DSpace/DSpace/security/code-scanning/43), [#46](https://github.com/DSpace/DSpace/security/code-scanning/46), [#47](https://github.com/DSpace/DSpace/security/code-scanning/47) and [#48](https://github.com/DSpace/DSpace/security/code-scanning/48) (`java/polynomial-redos`, high, open since 2022).

## Instructions for Reviewers

List of changes in this PR:

* **`SolrServiceImpl`** - the two `value.matches("\[.*TO.*\]")` checks that decide whether a filter
  value is passed to Solr unescaped became `isRangeQuery(value)`, a `startsWith` / `endsWith` /
  `contains` test. It accepts exactly the same values, including the case-sensitive `TO` and the
  rejection of values containing a line terminator, which `.` never matched. That last point is
  deliberate: loosening it would let a value skip escaping that did not skip it before.
* **`FacetYearRange`** - `\[(.*? TO .*?)\]` became `\[( *-?\d+ +TO +-?\d+ *)\]`. Both bounds are
  parsed with `Integer.parseInt` two lines below, so only integer bounds were ever usable. Spaces
  around and between the bounds are still accepted, as before.
* **`HandleServiceImpl`** - `^https?://.+/handle/(.*)$` became a scan for the last `/handle/`
  segment. `.+` was greedy, so it already selected the last segment; `lastIndexOf` selects the same
  one in linear time. Identifiers containing a line terminator are still rejected, which is what
  `.` did, and is also what removes the backtracking: it was a trailing line terminator that forced
  the greedy `.+` to retry every `/handle/` segment in turn.
* **`DoiCheck`** - in the third alternative, `\d+X?(\d+)\d+` became the equivalent but unambiguous
  `(?:\d{3,}|\d+X\d{2,})`, and the unescaped dots in `\d+.\d+.\w+` became literal dots. The capture
  group was never read. This is the one intentional narrowing in the PR: those dots are the version
  segment of a legacy SICI DOI such as `3.0.CO;2` and were always meant to be literal. The pattern
  comes from CrossRef's published list, where the escaping had already been lost.

### How to test

The four new or extended test classes are the regression tests:

```
mvn test -pl dspace-api -DskipUnitTests=false \
  -Dtest='DoiCheckTest,FacetYearRangeTest,SolrServiceRangeQueryTest,HandleServiceTest'
```

Each has one `@Test(timeout = ...)` case built from a value that cannot match. I verified each of
those four against the old patterns as well, where every one comfortably exceeds its bound, so
they do fail if a pattern is reverted. On the new code they all complete in under a millisecond,
so the bounds are wide margins rather than tight ones and are not sensitive to a slow CI machine.

The remaining tests in those classes pin the accepted values, including the pre-existing
`HandleServiceTest` cases and the pre-existing list of valid and invalid DOIs in `DoiCheckTest`,
which are unchanged and still pass.

Full `mvn test -DskipUnitTests=false` on this branch: 1710 tests, 0 failures, 0 errors, 11 skipped.
Checkstyle is clean.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Style+Guide).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [ ] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
- [ ] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [ ] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

_The three unchecked items do not apply: no dependency, REST contract or configuration changes._