### PR TITLE
Allow administrators to edit email templates via the REST API

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -652,6 +652,11 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+        </dependency>
+
         <!-- Gson is needed by JENA, borker-client, OAuth, Handle and JClouds -->
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/dspace-api/src/main/java/org/dspace/core/EmailTemplate.java
+++ b/dspace-api/src/main/java/org/dspace/core/EmailTemplate.java
@@ -1,0 +1,204 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Domain model representing a DSpace email template.
+ *
+ * <p>This is a POJO (Plain Old Java Object), not a DSpace database entity,
+ * because email templates are stored as VTL (Velocity Template Language)
+ * files on the filesystem under {@code {dspace.dir}/config/emails/}.</p>
+ *
+ * <p>The ETag is computed as a SHA-256 hash of the template content,
+ * used for optimistic concurrency control via HTTP conditional headers
+ * ({@code If-Match} / {@code If-None-Match}).</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplate {
+
+    /**
+     * The template filename identifier (e.g., "register", "submit_reject").
+     * This serves as the unique ID for the template in the REST API.
+     */
+    private String name;
+
+    /**
+     * The full VTL template body, including comment headers and
+     * {@code #set($subject = ...)} directive.
+     */
+    private String content;
+
+    /**
+     * The email subject line extracted from the template's
+     * {@code #set($subject = ...)} directive.
+     */
+    private String subject;
+
+    /**
+     * The MIME type of the template output.
+     * Either {@link EmailTemplateMimeType#TEXT_PLAIN} (default) or {@link EmailTemplateMimeType#TEXT_HTML}
+     * (if the template includes {@code #set($mimetype = "text/html")}).
+     * See DSpace PR #11755 for HTML email support.
+     */
+    private EmailTemplateMimeType mimetype;
+
+    /**
+     * The list of variables (parameters) available in this template,
+     * parsed from the {@code ## {N} description} comment headers.
+     */
+    private List<EmailTemplateVariable> variables;
+
+    /**
+     * The last modified timestamp of the template file on disk.
+     */
+    private Instant lastModified;
+
+    /**
+     * The deterministic ETag for optimistic concurrency control (SHA-256).
+     */
+    private String etag;
+
+    /**
+     * Default constructor.
+     */
+    public EmailTemplate() {
+        this.variables = new ArrayList<>();
+        this.mimetype = EmailTemplateMimeType.TEXT_PLAIN;
+    }
+
+    /**
+     * Gets the template filename identifier.
+     *
+     * @return the template name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the template filename identifier.
+     *
+     * @param name the template name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Gets the full VTL template body.
+     *
+     * @return the template content
+     */
+    public String getContent() {
+        return content;
+    }
+
+    /**
+     * Sets the full VTL template body.
+     *
+     * @param content the template content to set
+     */
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * Gets the email subject line.
+     *
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the email subject line.
+     *
+     * @param subject the subject to set
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Gets the MIME type of the template output.
+     *
+     * @return the MIME type enum (TEXT_PLAIN or TEXT_HTML)
+     */
+    public EmailTemplateMimeType getMimetype() {
+        return mimetype;
+    }
+
+    /**
+     * Sets the MIME type of the template output.
+     *
+     * @param mimetype the MIME type to set
+     */
+    public void setMimetype(EmailTemplateMimeType mimetype) {
+        this.mimetype = mimetype != null ? mimetype : EmailTemplateMimeType.TEXT_PLAIN;
+    }
+
+    /**
+     * Gets the list of variables available in this template.
+     *
+     * @return the list of variables
+     */
+    public List<EmailTemplateVariable> getVariables() {
+        return variables;
+    }
+
+    /**
+     * Sets the list of variables available in this template.
+     *
+     * @param variables the list of variables to set
+     */
+    public void setVariables(List<EmailTemplateVariable> variables) {
+        this.variables = variables;
+    }
+
+    /**
+     * Gets the last modified timestamp of the template file.
+     *
+     * @return the last modified timestamp
+     */
+    public Instant getLastModified() {
+        return lastModified;
+    }
+
+    /**
+     * Sets the last modified timestamp of the template file.
+     *
+     * @param lastModified the last modified timestamp to set
+     */
+    public void setLastModified(Instant lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    /**
+     * Gets the ETag for optimistic concurrency control.
+     *
+     * @return the ETag (SHA-256 hash of content)
+     */
+    public String getEtag() {
+        return etag;
+    }
+
+    /**
+     * Sets the ETag for optimistic concurrency control.
+     *
+     * @param etag the ETag to set
+     */
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/EmailTemplateMimeType.java
+++ b/dspace-api/src/main/java/org/dspace/core/EmailTemplateMimeType.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enumeration of supported MIME types for DSpace email templates.
+ *
+ * <p>Supported formats are {@code text/plain} (default) and {@code text/html}.</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public enum EmailTemplateMimeType {
+
+    TEXT_PLAIN("text/plain"),
+    TEXT_HTML("text/html");
+
+    private final String value;
+
+    EmailTemplateMimeType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the MIME type string value (e.g. "text/plain" or "text/html").
+     *
+     * @return the MIME type string
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Resolves an {@link EmailTemplateMimeType} from its string representation.
+     * If the input is null, blank, or unrecognized, it safely defaults to {@link #TEXT_PLAIN}.
+     *
+     * @param text the MIME type string to parse
+     * @return matching EmailTemplateMimeType, or TEXT_PLAIN if unrecognized
+     */
+    @JsonCreator
+    public static EmailTemplateMimeType fromString(String text) {
+        if (text != null) {
+            for (EmailTemplateMimeType type : EmailTemplateMimeType.values()) {
+                if (type.value.equalsIgnoreCase(text.trim())) {
+                    return type;
+                }
+            }
+        }
+        return TEXT_PLAIN;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/EmailTemplateServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/EmailTemplateServiceImpl.java
@@ -196,8 +196,11 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
 
         validateContent(name, content);
 
-        String trimmedContent = content.strip() + "\n";
-        Files.writeString(file.toPath(), trimmedContent, StandardCharsets.UTF_8);
+        String normalizedContent = content;
+        if (!normalizedContent.endsWith("\n")) {
+            normalizedContent += "\n";
+        }
+        Files.writeString(file.toPath(), normalizedContent, StandardCharsets.UTF_8);
 
         log.info(LogHelper.getHeader(context, "email_template_update",
                 "Email template has been updated: " + name));

--- a/dspace-api/src/main/java/org/dspace/core/EmailTemplateServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/EmailTemplateServiceImpl.java
@@ -1,0 +1,385 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.resource.util.StringResourceRepository;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.service.EmailTemplateService;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
+import org.owasp.html.HtmlChangeListener;
+import org.owasp.html.PolicyFactory;
+import org.owasp.html.Sanitizers;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Implementation of {@link EmailTemplateService}.
+ *
+ * <p>Handles loading, parsing, validating, and saving email templates stored as VTL
+ * files in {@code {dspace.dir}/config/emails/}.</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplateServiceImpl implements EmailTemplateService {
+
+    private static final Logger log = LogManager.getLogger(EmailTemplateServiceImpl.class);
+
+    private static final String VELOCITY_REPO_NAME = "emailTemplateValidationRepo";
+    private static final int MIN_CONTENT_LENGTH = 10;
+    private static final int MAX_CONTENT_LENGTH = 50000;
+
+    private static final Pattern SAFE_FILENAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+    private static final Pattern SUBJECT_PATTERN = Pattern.compile(
+        "^\\s*#set\\s*\\(\\s*\\$subject\\s*=\\s*[\"'](.*?)[\"']\\s*\\)", Pattern.MULTILINE);
+    private static final Pattern MIMETYPE_PATTERN = Pattern.compile(
+        "^\\s*#set\\s*\\(\\s*\\$mimetype\\s*=\\s*[\"'](text/[a-zA-Z0-9._-]+)[\"']\\s*\\)", Pattern.MULTILINE);
+    private static final Pattern PARAM_PATTERN = Pattern.compile(
+        "^##(?:\\s*Parameters:)?\\s*\\{?(\\d+)\\}?\\s+(.*?)$");
+
+    private static final PolicyFactory HTML_POLICY = Sanitizers.FORMATTING
+        .and(Sanitizers.BLOCKS)
+        .and(Sanitizers.LINKS)
+        .and(Sanitizers.STYLES)
+        .and(Sanitizers.TABLES);
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    /**
+     * Default constructor.
+     */
+    public EmailTemplateServiceImpl() {
+    }
+
+    /**
+     * Gets the directory where email templates are stored.
+     *
+     * @return the File representing the emails directory
+     */
+    protected File getEmailsDirectory() {
+        String dspaceDir = configurationService.getProperty("dspace.dir");
+        if (dspaceDir == null) {
+            throw new IllegalStateException("Configuration property 'dspace.dir' is not set.");
+        }
+        return new File(dspaceDir, "config" + File.separator + "emails");
+    }
+
+    @Override
+    public List<EmailTemplate> findAll(Context context) throws IOException, SQLException, AuthorizeException {
+        if (context == null || !authorizeService.isAdmin(context)) {
+            logUnauthorizedAttempt(context, "retrieve all email templates");
+            throw new AuthorizeException("Only administrators are allowed to access email templates.");
+        }
+
+        File dir = getEmailsDirectory();
+        if (!dir.exists() || !dir.isDirectory()) {
+            log.error("Email templates directory does not exist or is not a directory: {}", dir.getAbsolutePath());
+            return Collections.emptyList();
+        }
+
+        File[] files = dir.listFiles((d, name) -> !name.startsWith(".") && new File(d, name).isFile());
+        if (files == null) {
+            return Collections.emptyList();
+        }
+
+        List<EmailTemplate> templates = new ArrayList<>();
+        for (File file : files) {
+            try {
+                EmailTemplate template = parseTemplateFile(file);
+                if (template != null) {
+                    templates.add(template);
+                }
+            } catch (IOException e) {
+                log.error("Failed to read email template file: {}", file.getName(), e);
+            }
+        }
+
+        templates.sort(Comparator.comparing(EmailTemplate::getName));
+        return templates;
+    }
+
+    /**
+     * Resolves the template file, ensuring it resides within the canonical emails directory
+     * and is protected against path traversal and symlink escapes.
+     *
+     * @param name the template filename
+     * @return the resolved File
+     * @throws IOException if directory canonical resolution fails
+     * @throws IllegalArgumentException if the name is invalid or attempts path traversal
+     */
+    protected File resolveTemplateFile(String name) throws IOException {
+        validateTemplateName(name);
+
+        File dir = getEmailsDirectory();
+        if (!dir.exists() || !dir.isDirectory()) {
+            log.error("Email templates directory does not exist or is not a directory: {}", dir.getAbsolutePath());
+            throw new IllegalStateException("Email templates directory does not exist or is not a directory: "
+                    + dir.getAbsolutePath());
+        }
+
+        Path canonicalBase = dir.toPath().toRealPath();
+        Path targetPath = canonicalBase.resolve(name).normalize();
+
+        if (!targetPath.startsWith(canonicalBase)) {
+            log.warn("Path traversal attempt detected: {}", name);
+            throw new IllegalArgumentException("Path traversal attempt detected: " + name);
+        }
+
+        if (Files.exists(targetPath)) {
+            Path realTargetPath = targetPath.toRealPath();
+            if (!realTargetPath.startsWith(canonicalBase)) {
+                log.warn("Symlink escape attempt detected: {}", name);
+                throw new IllegalArgumentException("Symlink escape attempt detected: " + name);
+            }
+        }
+
+        return targetPath.toFile();
+    }
+
+    @Override
+    public EmailTemplate findByName(Context context, String name)
+            throws IOException, SQLException, AuthorizeException {
+        if (context == null || !authorizeService.isAdmin(context)) {
+            logUnauthorizedAttempt(context, "retrieve email template '" + name + "'");
+            throw new AuthorizeException("Only administrators are allowed to access email templates.");
+        }
+
+        File file = resolveTemplateFile(name);
+        if (!file.exists() || !file.isFile()) {
+            return null;
+        }
+
+        return parseTemplateFile(file);
+    }
+
+    @Override
+    public EmailTemplate update(Context context, String name, String content)
+            throws IOException, SQLException, AuthorizeException {
+        if (context == null || !authorizeService.isAdmin(context)) {
+            logUnauthorizedAttempt(context, "update email template '" + name + "'");
+            throw new AuthorizeException("Only administrators are allowed to update email templates.");
+        }
+
+        File file = resolveTemplateFile(name);
+        if (!file.exists() || !file.isFile()) {
+            throw new IllegalArgumentException("Template does not exist: " + name);
+        }
+
+        validateContent(name, content);
+
+        String trimmedContent = content.strip() + "\n";
+        Files.writeString(file.toPath(), trimmedContent, StandardCharsets.UTF_8);
+
+        log.info(LogHelper.getHeader(context, "email_template_update",
+                "Email template has been updated: " + name));
+
+        return parseTemplateFile(file);
+    }
+
+    @Override
+    public String computeETag(String content) {
+        if (content == null) {
+            return "";
+        }
+        return DigestUtils.sha256Hex(content);
+    }
+
+    @Override
+    public void validateContent(String name, String content) {
+        if (content == null || content.strip().length() < MIN_CONTENT_LENGTH) {
+            throw new IllegalArgumentException(
+                "Template content must contain at least " + MIN_CONTENT_LENGTH + " non-whitespace characters");
+        }
+
+        if (content.length() > MAX_CONTENT_LENGTH) {
+            throw new IllegalArgumentException(
+                "Template content exceeds maximum allowed length of " + MAX_CONTENT_LENGTH + " characters");
+        }
+
+        validateHtmlSafety(content);
+
+        // Validate VTL syntax with VelocityEngine
+        validateVelocitySyntax(name, content);
+    }
+
+    /**
+     * Validates that any HTML content conforms to the safe HTML policy using the
+     * OWASP Java HTML Sanitizer.
+     *
+     * @param content the template content
+     * @throws IllegalArgumentException if prohibited or unsafe HTML elements are detected
+     */
+    private void validateHtmlSafety(String content) {
+        if (!content.contains("<")) {
+            return;
+        }
+
+        List<String> violations = new ArrayList<>();
+        HTML_POLICY.sanitize(content, new HtmlChangeListener<Object>() {
+            @Override
+            public void discardedTag(Object ctx, String elementName) {
+                violations.add("Prohibited HTML tag: <" + elementName + ">");
+            }
+
+            @Override
+            public void discardedAttributes(Object ctx, String elementName, String... attributeNames) {
+                violations.add("Prohibited attribute(s) on <" + elementName + ">: "
+                        + String.join(", ", attributeNames));
+            }
+        }, null);
+
+        if (!violations.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Template content contains prohibited script or unsafe HTML elements: " + violations);
+        }
+    }
+
+    /**
+     * Validates that the content is syntactically valid Velocity Template Language (VTL).
+     *
+     * @param name    the template name
+     * @param content the template content
+     * @throws IllegalArgumentException if syntax parsing fails
+     */
+    private void validateVelocitySyntax(String name, String content) {
+        try {
+            VelocityEngine ve = new VelocityEngine();
+            ve.init(Utils.getSecureVelocityProperties(VELOCITY_REPO_NAME));
+            StringResourceRepository repo =
+                (StringResourceRepository) ve.getApplicationAttribute(VELOCITY_REPO_NAME);
+            String templateKey = (name != null ? name : "test") + "_" + System.currentTimeMillis();
+            repo.putStringResource(templateKey, content);
+            ve.getTemplate(templateKey);
+            repo.removeStringResource(templateKey);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Velocity template syntax: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Validates that the template filename conforms to allowed safe characters and does not contain path traversal.
+     *
+     * @param name the template filename
+     * @throws IllegalArgumentException if the name is invalid
+     */
+    private void validateTemplateName(String name) {
+        if (name == null || name.isBlank() || !SAFE_FILENAME_PATTERN.matcher(name).matches() || name.contains("..")) {
+            throw new IllegalArgumentException("Invalid template name: " + name);
+        }
+    }
+
+    /**
+     * Logs a formatted warning indicating an unauthorized access attempt by a non-administrator.
+     *
+     * @param context the DSpace context
+     * @param action  the action attempted
+     */
+    private void logUnauthorizedAttempt(Context context, String action) {
+        EPerson currentUser = (context != null) ? context.getCurrentUser() : null;
+        String userIdentification = (currentUser != null)
+                ? String.format("User '%s' (ID: %s, Email: %s)",
+                        currentUser.getName(), currentUser.getID(), currentUser.getEmail())
+                : "Anonymous user";
+        log.warn(LogHelper.getHeader(context, "unauthorized_access_attempt",
+                String.format("Access denied: %s attempted to %s without administrator privileges.",
+                        userIdentification, action)));
+    }
+
+    /**
+     * Reads and parses a template file into an {@link EmailTemplate} domain object.
+     *
+     * @param file the template file
+     * @return parsed EmailTemplate
+     * @throws IOException if reading the file fails
+     */
+    private EmailTemplate parseTemplateFile(File file) throws IOException {
+        String content = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+
+        EmailTemplate template = new EmailTemplate();
+        template.setName(file.getName());
+        template.setContent(content);
+        template.setLastModified(Instant.ofEpochMilli(file.lastModified()));
+        template.setEtag(computeETag(content));
+
+        // Extract subject
+        Matcher subjectMatcher = SUBJECT_PATTERN.matcher(content);
+        if (subjectMatcher.find()) {
+            template.setSubject(subjectMatcher.group(1));
+        }
+
+        // Extract mimetype
+        Matcher mimeMatcher = MIMETYPE_PATTERN.matcher(content);
+        if (mimeMatcher.find()) {
+            template.setMimetype(EmailTemplateMimeType.fromString(mimeMatcher.group(1)));
+        } else {
+            template.setMimetype(EmailTemplateMimeType.TEXT_PLAIN);
+        }
+
+        // Extract variables
+        template.setVariables(parseVariables(content));
+
+        return template;
+    }
+
+    /**
+     * Parses variable definitions from comment headers in the template content.
+     *
+     * @param content the template content
+     * @return list of parsed variables ordered by index
+     */
+    private List<EmailTemplateVariable> parseVariables(String content) {
+        Map<Integer, EmailTemplateVariable> variableMap = new HashMap<>();
+        String[] lines = content.split("\\R");
+
+        for (String line : lines) {
+            if (!line.startsWith("##")) {
+                // If line doesn't start with ## and is not whitespace or other VTL directive, stop header parsing
+                if (!line.isBlank() && !line.startsWith("#")) {
+                    break;
+                }
+                continue;
+            }
+
+            Matcher m = PARAM_PATTERN.matcher(line);
+            if (m.matches()) {
+                int index = Integer.parseInt(m.group(1));
+                String desc = m.group(2).trim();
+                variableMap.putIfAbsent(index,
+                    new EmailTemplateVariable(index, desc, "${params[" + index + "]}"));
+            }
+        }
+
+        List<EmailTemplateVariable> variables = new ArrayList<>(variableMap.values());
+        variables.sort(Comparator.comparingInt(EmailTemplateVariable::getIndex));
+        return variables;
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/EmailTemplateVariable.java
+++ b/dspace-api/src/main/java/org/dspace/core/EmailTemplateVariable.java
@@ -1,0 +1,137 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.util.Objects;
+
+/**
+ * Domain model representing a variable (parameter) in an email template.
+ *
+ * <p>In DSpace email templates, positional parameters are documented in comments
+ * such as:
+ * <pre>
+ * ## Parameters: {0} a string giving the user's name
+ * ##             {1} a string giving the item title
+ * </pre>
+ * or shorthand:
+ * <pre>
+ * ## {0} recipient name
+ * ## {1} confirmation URL
+ * </pre>
+ * and are referenced in the template body as {@code ${params[0]}}, {@code ${params[1]}}, etc.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplateVariable {
+
+    private int index;
+    private String description;
+    private String placeholder;
+
+    /**
+     * Default constructor.
+     */
+    public EmailTemplateVariable() {
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param index       the 0-based parameter index
+     * @param description description extracted from the template comment
+     * @param placeholder the Velocity expression to insert into the template (e.g. {@code ${params[0]}})
+     */
+    public EmailTemplateVariable(int index, String description, String placeholder) {
+        this.index = index;
+        this.description = description;
+        this.placeholder = placeholder;
+    }
+
+    /**
+     * Gets the 0-based parameter index.
+     *
+     * @return the parameter index
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * Sets the 0-based parameter index.
+     *
+     * @param index the parameter index to set
+     */
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    /**
+     * Gets the parameter description extracted from the template comment header.
+     *
+     * @return the parameter description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the parameter description.
+     *
+     * @param description the parameter description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Gets the Velocity expression used to reference this parameter in the template body
+     * (e.g. {@code ${params[0]}}).
+     *
+     * @return the Velocity placeholder
+     */
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    /**
+     * Sets the Velocity expression used to reference this parameter in the template body.
+     *
+     * @param placeholder the Velocity placeholder to set
+     */
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmailTemplateVariable that = (EmailTemplateVariable) o;
+        return index == that.index &&
+            Objects.equals(description, that.description) &&
+            Objects.equals(placeholder, that.placeholder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, description, placeholder);
+    }
+
+    @Override
+    public String toString() {
+        return "EmailTemplateVariable{" +
+            "index=" + index +
+            ", description='" + description + '\'' +
+            ", placeholder='" + placeholder + '\'' +
+            '}';
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/SystemConfigVariable.java
+++ b/dspace-api/src/main/java/org/dspace/core/SystemConfigVariable.java
@@ -1,0 +1,128 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.util.Objects;
+
+/**
+ * Domain model representing an allowed general system configuration variable that can be used in email templates.
+ *
+ * <p>DSpace email templates can access a restricted set of system configuration properties
+ * via the Velocity {@code config} map, for example:
+ * {@code ${config.get('dspace.name')}} or {@code ${config.get('dspace.ui.url')}}.</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class SystemConfigVariable {
+
+    private String key;
+    private String value;
+    private String placeholder;
+
+    /**
+     * Default constructor.
+     */
+    public SystemConfigVariable() {
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param key the configuration property key (e.g. "dspace.name")
+     * @param value the resolved value of the configuration property
+     * @param placeholder the Velocity expression to insert into the template
+     */
+    public SystemConfigVariable(String key, String value, String placeholder) {
+        this.key = key;
+        this.value = value;
+        this.placeholder = placeholder;
+    }
+
+    /**
+     * Gets the configuration property key (e.g. "dspace.name").
+     *
+     * @return the property key
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Sets the configuration property key.
+     *
+     * @param key the property key to set
+     */
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Gets the resolved value of the configuration property.
+     *
+     * @return the property value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the resolved value of the configuration property.
+     *
+     * @param value the property value to set
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the Velocity expression used to reference this variable in a template
+     * (e.g. {@code ${config.get('dspace.name')}}).
+     *
+     * @return the Velocity placeholder
+     */
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    /**
+     * Sets the Velocity expression used to reference this variable in a template.
+     *
+     * @param placeholder the Velocity placeholder to set
+     */
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SystemConfigVariable that = (SystemConfigVariable) o;
+        return Objects.equals(key, that.key) &&
+            Objects.equals(value, that.value) &&
+            Objects.equals(placeholder, that.placeholder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value, placeholder);
+    }
+
+    @Override
+    public String toString() {
+        return "SystemConfigVariable{" +
+            "key='" + key + '\'' +
+            ", value='" + value + '\'' +
+            ", placeholder='" + placeholder + '\'' +
+            '}';
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/SystemConfigVariableServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/core/SystemConfigVariableServiceImpl.java
@@ -1,0 +1,97 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.service.SystemConfigVariableService;
+import org.dspace.eperson.EPerson;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Implementation of {@link SystemConfigVariableService}.
+ *
+ * <p>Uses {@link Utils#getAllowedTemplateConfig()} to retrieve the allowed configuration
+ * properties for templates without hardcoding configuration keys.</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class SystemConfigVariableServiceImpl implements SystemConfigVariableService {
+
+    private static final Logger log = LogManager.getLogger(SystemConfigVariableServiceImpl.class);
+
+    @Autowired
+    private AuthorizeService authorizeService;
+
+    @Override
+    public List<SystemConfigVariable> getConfigVariables(Context context)
+            throws SQLException, AuthorizeException {
+        if (context == null || !authorizeService.isAdmin(context)) {
+            logUnauthorizedAttempt(context, "retrieve all system config variables");
+            throw new AuthorizeException("Only administrators are allowed to access system config variables.");
+        }
+        Map<String, String> allowedConfigs = Utils.getAllowedTemplateConfig();
+        List<SystemConfigVariable> vars = new ArrayList<>();
+        for (Map.Entry<String, String> entry : allowedConfigs.entrySet()) {
+            vars.add(new SystemConfigVariable(
+                entry.getKey(),
+                entry.getValue(),
+                String.format("${config.get('%s')}", entry.getKey())
+            ));
+        }
+        vars.sort(Comparator.comparing(SystemConfigVariable::getKey));
+        return vars;
+    }
+
+    @Override
+    public SystemConfigVariable getConfigVariable(Context context, String key)
+            throws SQLException, AuthorizeException {
+        if (context == null || !authorizeService.isAdmin(context)) {
+            logUnauthorizedAttempt(context, "retrieve system config variable '" + key + "'");
+            throw new AuthorizeException("Only administrators are allowed to access system config variables.");
+        }
+        if (key == null) {
+            return null;
+        }
+        Map<String, String> allowedConfigs = Utils.getAllowedTemplateConfig();
+        String value = allowedConfigs.get(key);
+        if (value != null) {
+            return new SystemConfigVariable(
+                key,
+                value,
+                String.format("${config.get('%s')}", key)
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Logs a formatted warning indicating an unauthorized access attempt by a non-administrator.
+     *
+     * @param context the DSpace context
+     * @param action  the action attempted
+     */
+    private void logUnauthorizedAttempt(Context context, String action) {
+        EPerson currentUser = (context != null) ? context.getCurrentUser() : null;
+        String userIdentification = (currentUser != null)
+                ? String.format("User '%s' (ID: %s, Email: %s)",
+                        currentUser.getName(), currentUser.getID(), currentUser.getEmail())
+                : "Anonymous user";
+        log.warn(LogHelper.getHeader(context, "unauthorized_access_attempt",
+                String.format("Access denied: %s attempted to %s without administrator privileges.",
+                        userIdentification, action)));
+    }
+}

--- a/dspace-api/src/main/java/org/dspace/core/service/EmailTemplateService.java
+++ b/dspace-api/src/main/java/org/dspace/core/service/EmailTemplateService.java
@@ -1,0 +1,84 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core.service;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+import org.dspace.core.EmailTemplate;
+
+/**
+ * Service interface for managing email templates stored in {@code {dspace.dir}/config/emails/}.
+ *
+ * <p>Templates are identified by their filename (e.g. "register", "feedback").
+ * They are stored as Apache Velocity (VTL) files on the filesystem.</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public interface EmailTemplateService {
+
+    /**
+     * Retrieves all email templates from the config directory.
+     *
+     * @param context the DSpace context
+     * @return list of all email templates, ordered alphabetically by name
+     * @throws IOException        if an error occurs reading template files
+     * @throws SQLException       if a database error occurs during authorization check
+     * @throws AuthorizeException if the current user is not authorized
+     */
+    List<EmailTemplate> findAll(Context context) throws IOException, SQLException, AuthorizeException;
+
+    /**
+     * Retrieves a single email template by its name (filename).
+     *
+     * @param context the DSpace context
+     * @param name    the template filename identifier (e.g., "register")
+     * @return the template, or {@code null} if not found
+     * @throws IOException        if an error occurs reading the template file
+     * @throws SQLException       if a database error occurs during authorization check
+     * @throws AuthorizeException if the current user is not authorized
+     */
+    EmailTemplate findByName(Context context, String name) throws IOException, SQLException, AuthorizeException;
+
+    /**
+     * Updates the content of an email template.
+     * Validates template name (path traversal, symlink escape) and content
+     * (VTL syntax, min/max length, XSS sanitization) before saving.
+     *
+     * @param context the DSpace context
+     * @param name    the template filename identifier (e.g., "register")
+     * @param content the new template content
+     * @return the updated template
+     * @throws IOException        if an error occurs writing the template file
+     * @throws SQLException       if a database error occurs
+     * @throws AuthorizeException if the current user is not authorized
+     */
+    EmailTemplate update(Context context, String name, String content)
+            throws IOException, SQLException, AuthorizeException;
+
+    /**
+     * Computes the ETag for a given template content.
+     * The ETag is computed as a SHA-256 hash of the content for optimistic concurrency control.
+     *
+     * @param content the template content
+     * @return the hex-encoded SHA-256 digest
+     */
+    String computeETag(String content);
+
+    /**
+     * Validates template content for minimum/maximum length, XSS safety, and VTL syntax.
+     *
+     * @param name    the template name
+     * @param content the template content to validate
+     * @throws IllegalArgumentException if the content fails any validation rule
+     */
+    void validateContent(String name, String content);
+}

--- a/dspace-api/src/main/java/org/dspace/core/service/SystemConfigVariableService.java
+++ b/dspace-api/src/main/java/org/dspace/core/service/SystemConfigVariableService.java
@@ -1,0 +1,44 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core.service;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+import org.dspace.core.SystemConfigVariable;
+
+/**
+ * Service interface for retrieving system configuration variables allowed in templates.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public interface SystemConfigVariableService {
+
+    /**
+     * Gets all allowed system configuration variables with resolved values and placeholders.
+     *
+     * @param context the DSpace context
+     * @return list of allowed system configuration variables sorted by key
+     * @throws SQLException       if a database error occurs during authorization check
+     * @throws AuthorizeException if the current user is not authorized
+     */
+    List<SystemConfigVariable> getConfigVariables(Context context) throws SQLException, AuthorizeException;
+
+    /**
+     * Gets a single system configuration variable by key, if allowed and configured.
+     *
+     * @param context the DSpace context
+     * @param key the configuration property key
+     * @return the configuration variable or null if not found
+     * @throws SQLException       if a database error occurs during authorization check
+     * @throws AuthorizeException if the current user is not authorized
+     */
+    SystemConfigVariable getConfigVariable(Context context, String key) throws SQLException, AuthorizeException;
+}

--- a/dspace-api/src/test/java/org/dspace/core/EmailTemplateServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTemplateServiceImplTest.java
@@ -1,0 +1,372 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.dspace.AbstractDSpaceTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.service.EmailTemplateService;
+import org.dspace.eperson.EPerson;
+import org.dspace.services.ConfigurationService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for {@link EmailTemplateServiceImpl}.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplateServiceImplTest extends AbstractDSpaceTest {
+
+    private EmailTemplateService emailTemplateService;
+    private File dspaceDir;
+    private File emailsDir;
+    private ConfigurationService configurationService;
+    private AuthorizeService authorizeService;
+    private Context context;
+
+    @Before
+    public void setUp() {
+
+        try {
+            dspaceDir = Files.createTempDirectory("dspace-email-test-").toFile();
+            emailsDir = new File(dspaceDir, "config" + File.separator + "emails");
+            emailsDir.mkdirs();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temporary test directory", e);
+        }
+
+        configurationService = mock(ConfigurationService.class);
+        authorizeService = mock(AuthorizeService.class);
+
+        // Configure mock configuration service
+        when(configurationService.getProperty("dspace.dir")).thenReturn(dspaceDir.getAbsolutePath());
+
+        emailTemplateService = new EmailTemplateServiceImpl();
+        ReflectionTestUtils.setField(emailTemplateService, "configurationService", configurationService);
+        ReflectionTestUtils.setField(emailTemplateService, "authorizeService", authorizeService);
+
+        context = mock(Context.class);
+        try {
+            when(authorizeService.isAdmin(context)).thenReturn(true);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @After
+    public void cleanup() {
+        if (dspaceDir != null && dspaceDir.exists()) {
+            deleteRecursive(dspaceDir);
+        }
+    }
+
+    private void deleteRecursive(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursive(child);
+                }
+            }
+        }
+        file.delete();
+    }
+
+    private void createTemplateFile(String name, String content) throws IOException {
+        File file = new File(emailsDir, name);
+        Files.writeString(file.toPath(), content);
+    }
+
+    @Test
+    public void testFindAllTemplatesSuccess() throws Exception {
+        createTemplateFile("register",
+            "#set($subject = \"Registration\")\n"
+            + "## {0} user name\n"
+            + "Hello ${params[0]}, welcome to ${config.get('dspace.name')}.\n");
+        createTemplateFile("feedback",
+            "#set($subject = \"Feedback\")\n"
+            + "## {0} sender\n"
+            + "Feedback from ${params[0]}.\n");
+
+        List<EmailTemplate> templates = emailTemplateService.findAll(context);
+        assertNotNull(templates);
+        assertEquals(2, templates.size());
+        assertEquals("feedback", templates.get(0).getName());
+        assertEquals("register", templates.get(1).getName());
+    }
+
+    @Test
+    public void testFindByNameSuccess() throws Exception {
+        String content = "#set($subject = \"Welcome to DSpace\")\n"
+            + "#set($mimetype = \"text/plain\")\n"
+            + "## {0} recipient name\n"
+            + "## {1} verification url\n"
+            + "Dear ${params[0]},\n"
+            + "Click here: ${params[1]}\n"
+            + "-- ${config.get('dspace.name')}\n";
+        createTemplateFile("register", content);
+
+        EmailTemplate template = emailTemplateService.findByName(context, "register");
+        assertNotNull(template);
+        assertEquals("register", template.getName());
+        assertEquals("Welcome to DSpace", template.getSubject());
+        assertEquals(EmailTemplateMimeType.TEXT_PLAIN, template.getMimetype());
+        assertNotNull(template.getEtag());
+        assertFalse(template.getEtag().isEmpty());
+
+        // Verify parsed positional variables
+        List<EmailTemplateVariable> variables = template.getVariables();
+        assertNotNull(variables);
+        assertEquals(2, variables.size());
+        assertEquals(0, variables.get(0).getIndex());
+        assertEquals("recipient name", variables.get(0).getDescription());
+        assertEquals("${params[0]}", variables.get(0).getPlaceholder());
+        assertEquals(1, variables.get(1).getIndex());
+        assertEquals("verification url", variables.get(1).getDescription());
+        assertEquals("${params[1]}", variables.get(1).getPlaceholder());
+    }
+
+    @Test
+    public void testFindByNameHtmlMimeType() throws Exception {
+        String content = "#set($subject = \"HTML Notification\")\n"
+            + "#set($mimetype = \"text/html\")\n"
+            + "<p>Hello ${params[0]}, welcome to <b>DSpace</b>!</p>\n";
+        createTemplateFile("test_html", content);
+
+        EmailTemplate template = emailTemplateService.findByName(context, "test_html");
+        assertNotNull(template);
+        assertEquals(EmailTemplateMimeType.TEXT_HTML, template.getMimetype());
+    }
+
+    @Test
+    public void testFindByNameNotFound() throws Exception {
+        EmailTemplate template = emailTemplateService.findByName(context, "non_existent");
+        assertNull(template);
+    }
+
+    @Test
+    public void testUpdateTemplateSuccess() throws Exception {
+        createTemplateFile("register", "#set($subject = \"Old\")\nOld content ${params[0]}");
+
+        String updatedContent = "#set($subject = \"Updated Subject\")\n"
+            + "## {0} recipient name\n"
+            + "Updated body for ${params[0]}.\n";
+
+        EmailTemplate result = emailTemplateService.update(context, "register", updatedContent);
+        assertNotNull(result);
+        assertEquals("Updated Subject", result.getSubject());
+        assertTrue(result.getContent().contains("Updated body for ${params[0]}"));
+
+        // Verify persisted content on disk
+        File file = new File(emailsDir, "register");
+        String diskContent = Files.readString(file.toPath());
+        assertTrue(diskContent.contains("Updated body for ${params[0]}"));
+    }
+
+    @Test
+    public void testUpdateTemplateNotFound() {
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "non_existent", "Some valid content for template.")
+        );
+    }
+
+    @Test
+    public void testUpdateTemplateRejectsShortContent() throws Exception {
+        createTemplateFile("register", "#set($subject = \"Valid\")\nValid content.");
+
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "register", "Short")
+        );
+    }
+
+    @Test
+    public void testUpdateTemplateRejectsInvalidVelocitySyntax() throws Exception {
+        createTemplateFile("register", "#set($subject = \"Valid\")\nValid content.");
+
+        // Unclosed VTL directive
+        String badContent = "#set($subject = \"Invalid\")\n#if($foo) missing endif";
+
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "register", badContent)
+        );
+    }
+
+    @Test
+    public void testUpdateTemplateRejectsScriptTag() throws Exception {
+        createTemplateFile("test_xss", "#set($subject = \"Valid\")\nValid content.");
+
+        String maliciousContent = "#set($subject = \"Malicious\")\n"
+            + "<p>Hello</p><script>alert('XSS')</script>";
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "test_xss", maliciousContent)
+        );
+        assertTrue(ex.getMessage().contains("prohibited script or unsafe HTML elements"));
+    }
+
+    @Test
+    public void testUpdateTemplateRejectsIframeTag() throws Exception {
+        createTemplateFile("test_iframe", "#set($subject = \"Valid\")\nValid content.");
+
+        String maliciousContent = "#set($subject = \"Malicious\")\n"
+            + "<iframe src=\"https://evil.com\"></iframe>";
+
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "test_iframe", maliciousContent)
+        );
+    }
+
+    @Test
+    public void testUpdateTemplateRejectsInlineJavascript() throws Exception {
+        createTemplateFile("test_inline_js", "#set($subject = \"Valid\")\nValid content.");
+
+        String maliciousContent = "#set($subject = \"Malicious\")\n"
+            + "<a href=\"javascript:evil()\">Click</a>";
+
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "test_inline_js", maliciousContent)
+        );
+    }
+
+    @Test
+    public void testUpdateTemplateRejectsOnerrorEventHandler() throws Exception {
+        createTemplateFile("test_onerror", "#set($subject = \"Valid\")\nValid content.");
+
+        String maliciousContent = "#set($subject = \"Malicious\")\n"
+            + "<img src=\"invalid.jpg\" onerror=\"alert(1)\"/>";
+
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "test_onerror", maliciousContent)
+        );
+    }
+
+    @Test
+    public void testUpdateTemplateAllowsSafeHtmlTags() throws Exception {
+        createTemplateFile("safe_html", "#set($subject = \"Valid\")\nValid initial content.");
+
+        String safeContent = "#set($subject = \"Formatted Email\")\n"
+            + "#set($mimetype = \"text/html\")\n"
+            + "<p>Hello <b>${params[0]}</b>, please visit <a href=\"https://dspace.org\">DSpace</a>.</p>\n"
+            + "<ul><li>Item 1</li><li>Item 2</li></ul>\n"
+            + "<table><tr><td>Cell 1</td></tr></table>\n";
+
+        EmailTemplate result = emailTemplateService.update(context, "safe_html", safeContent);
+        assertNotNull(result);
+        assertEquals("Formatted Email", result.getSubject());
+    }
+
+    @Test
+    public void testPathTraversalRejectionInFindByName() {
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.findByName(context, "../../../etc/passwd")
+        );
+    }
+
+    @Test
+    public void testPathTraversalRejectionInUpdate() {
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.update(context, "sub/../../secret", "Valid content for test template.")
+        );
+    }
+
+    @Test
+    public void testSymlinkEscapeRejection() throws Exception {
+        // Create an outside file
+        File outsideDir = Files.createTempDirectory("outside-dir-").toFile();
+        File outsideFile = new File(outsideDir, "outside_template");
+        Files.writeString(outsideFile.toPath(), "Outside content that shouldn't be accessible.");
+
+        // Create a symlink inside emails directory pointing outside
+        Path symlink = emailsDir.toPath().resolve("symlinked_file");
+        try {
+            Files.createSymbolicLink(symlink, outsideFile.toPath());
+        } catch (UnsupportedOperationException | IOException e) {
+            // If filesystem doesn't support symlinks in this environment, skip
+            return;
+        }
+
+        assertThrows(IllegalArgumentException.class, () ->
+            emailTemplateService.findByName(context, "symlinked_file")
+        );
+
+        deleteRecursive(outsideDir);
+    }
+
+    @Test
+    public void testETagDeterminism() {
+        String content1 = "#set($subject = \"Test\")\nBody content 1.";
+        String content2 = "#set($subject = \"Test\")\nBody content 2.";
+
+        String etag1 = emailTemplateService.computeETag(content1);
+        String etag1Repeat = emailTemplateService.computeETag(content1);
+        String etag2 = emailTemplateService.computeETag(content2);
+
+        assertNotNull(etag1);
+        assertEquals(DigestUtils.sha256Hex(content1), etag1);
+        assertEquals(etag1, etag1Repeat);
+        assertNotEquals(etag1, etag2);
+    }
+
+    @Test
+    public void testNonAdminAccessDeniedOnFindAll() throws Exception {
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+
+        EPerson user = mock(EPerson.class);
+        when(user.getName()).thenReturn("regularuser");
+        when(user.getID()).thenReturn(UUID.randomUUID());
+        when(user.getEmail()).thenReturn("user@dspace.test");
+        when(context.getCurrentUser()).thenReturn(user);
+
+        assertThrows(AuthorizeException.class, () -> emailTemplateService.findAll(context));
+    }
+
+    @Test
+    public void testNonAdminAccessDeniedOnFindByName() throws Exception {
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        assertThrows(AuthorizeException.class, () -> emailTemplateService.findByName(context, "register"));
+    }
+
+    @Test
+    public void testNonAdminAccessDeniedOnUpdate() throws Exception {
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        assertThrows(AuthorizeException.class, () ->
+            emailTemplateService.update(context, "register", "New content.")
+        );
+    }
+
+    @Test
+    public void testNullContextAccessDenied() {
+        assertThrows(AuthorizeException.class, () -> emailTemplateService.findAll(null));
+        assertThrows(AuthorizeException.class, () -> emailTemplateService.findByName(null, "register"));
+        assertThrows(AuthorizeException.class, () ->
+            emailTemplateService.update(null, "register", "New content with sufficient length.")
+        );
+    }
+}

--- a/dspace-api/src/test/java/org/dspace/core/EmailTemplateServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/EmailTemplateServiceImplTest.java
@@ -191,6 +191,19 @@ public class EmailTemplateServiceImplTest extends AbstractDSpaceTest {
     }
 
     @Test
+    public void testUpdatePreservesLeadingWhitespace() throws Exception {
+        createTemplateFile("register", "#set($subject = \"Old\")\nOld content");
+
+        String contentWithLeadingWhitespace = "\n  #set($subject = \"Indented\")\n  Indented body text here.\n";
+        EmailTemplate result = emailTemplateService.update(context, "register", contentWithLeadingWhitespace);
+        assertNotNull(result);
+
+        File file = new File(emailsDir, "register");
+        String diskContent = Files.readString(file.toPath());
+        assertTrue(diskContent.startsWith("\n  #set($subject = \"Indented\")"));
+    }
+
+    @Test
     public void testUpdateTemplateNotFound() {
         assertThrows(IllegalArgumentException.class, () ->
             emailTemplateService.update(context, "non_existent", "Some valid content for template.")

--- a/dspace-api/src/test/java/org/dspace/core/SystemConfigVariableServiceImplTest.java
+++ b/dspace-api/src/test/java/org/dspace/core/SystemConfigVariableServiceImplTest.java
@@ -1,0 +1,101 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.dspace.AbstractUnitTest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.authorize.service.AuthorizeService;
+import org.dspace.core.service.SystemConfigVariableService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for {@link SystemConfigVariableServiceImpl}.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class SystemConfigVariableServiceImplTest extends AbstractUnitTest {
+
+    private SystemConfigVariableService systemConfigVariableService;
+    private AuthorizeService authorizeService;
+    private Context context;
+
+    @Before
+    public void setUp() {
+        systemConfigVariableService = new SystemConfigVariableServiceImpl();
+        authorizeService = mock(AuthorizeService.class);
+        ReflectionTestUtils.setField(systemConfigVariableService, "authorizeService", authorizeService);
+        context = mock(Context.class);
+        try {
+            when(authorizeService.isAdmin(context)).thenReturn(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testGetConfigVariables() throws Exception {
+        List<SystemConfigVariable> configVars = systemConfigVariableService.getConfigVariables(context);
+        assertNotNull(configVars);
+        assertFalse(configVars.isEmpty());
+
+        for (SystemConfigVariable var : configVars) {
+            assertNotNull(var.getKey());
+            assertNotNull(var.getValue());
+            assertEquals("${config.get('" + var.getKey() + "')}", var.getPlaceholder());
+        }
+
+        // Verify sorted by key
+        for (int i = 0; i < configVars.size() - 1; i++) {
+            assertTrue(configVars.get(i).getKey().compareTo(configVars.get(i + 1).getKey()) <= 0);
+        }
+    }
+
+    @Test
+    public void testGetConfigVariable() throws Exception {
+        SystemConfigVariable dspaceNameVar = systemConfigVariableService.getConfigVariable(context, "dspace.name");
+        assertNotNull(dspaceNameVar);
+        assertEquals("dspace.name", dspaceNameVar.getKey());
+        assertEquals("${config.get('dspace.name')}", dspaceNameVar.getPlaceholder());
+    }
+
+    @Test
+    public void testGetConfigVariableNull() throws Exception {
+        assertNull(systemConfigVariableService.getConfigVariable(context, null));
+        assertNull(systemConfigVariableService.getConfigVariable(context, "non.existent.key.xyz"));
+    }
+
+    @Test
+    public void testNonAdminAccessDenied() throws Exception {
+        when(authorizeService.isAdmin(context)).thenReturn(false);
+        assertThrows(AuthorizeException.class,
+            () -> systemConfigVariableService.getConfigVariables(context));
+        assertThrows(AuthorizeException.class,
+            () -> systemConfigVariableService.getConfigVariable(context, "dspace.name"));
+    }
+
+    @Test
+    public void testNullContextAccessDenied() {
+        assertThrows(AuthorizeException.class,
+            () -> systemConfigVariableService.getConfigVariables(null));
+        assertThrows(AuthorizeException.class,
+            () -> systemConfigVariableService.getConfigVariable(null, "dspace.name"));
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/RestResourceController.java
@@ -1248,7 +1248,8 @@ public class RestResourceController implements InitializingBean {
      * @param jsonNode    the part of the request body representing the updated rest object
      * @return the relevant REST resource
      */
-    @RequestMapping(method = RequestMethod.PUT, value = REGEX_REQUESTMAPPING_IDENTIFIER_AS_HEX32,
+    @RequestMapping(method = RequestMethod.PUT,
+        value = {REGEX_REQUESTMAPPING_IDENTIFIER_AS_HEX32, REGEX_REQUESTMAPPING_IDENTIFIER_AS_STRING_VERSION_STRONG},
         consumes = {"application/json", "application/hal+json"})
     public DSpaceResource<RestAddressableModel> put(HttpServletRequest request,
                                                     @PathVariable String apiCategory, @PathVariable String model,

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/EmailTemplateConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/EmailTemplateConverter.java
@@ -1,0 +1,68 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.dspace.app.rest.model.EmailTemplateRest;
+import org.dspace.app.rest.model.EmailTemplateVariableRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.core.EmailTemplate;
+import org.dspace.core.EmailTemplateVariable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converter that converts an {@link EmailTemplate} domain object into an {@link EmailTemplateRest} object.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@Component
+public class EmailTemplateConverter implements DSpaceConverter<EmailTemplate, EmailTemplateRest> {
+
+    /**
+     * Converts an {@link EmailTemplate} domain object into its REST representation.
+     *
+     * @param modelObject the domain object to convert
+     * @param projection  the active projection
+     * @return the converted {@link EmailTemplateRest} object
+     */
+    @Override
+    public EmailTemplateRest convert(EmailTemplate modelObject, Projection projection) {
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setProjection(projection);
+        rest.setId(modelObject.getName());
+        rest.setName(modelObject.getName());
+        rest.setContent(modelObject.getContent());
+        rest.setSubject(modelObject.getSubject());
+        rest.setMimetype(modelObject.getMimetype());
+        rest.setLastModified(modelObject.getLastModified());
+        rest.setEtag(modelObject.getEtag());
+
+        if (modelObject.getVariables() != null) {
+            List<EmailTemplateVariableRest> variableRests = new ArrayList<>();
+            for (EmailTemplateVariable var : modelObject.getVariables()) {
+                variableRests.add(new EmailTemplateVariableRest(
+                    var.getIndex(), var.getDescription(), var.getPlaceholder()));
+            }
+            rest.setVariables(variableRests);
+        }
+
+        return rest;
+    }
+
+    /**
+     * Gets the domain model class handled by this converter.
+     *
+     * @return the {@link EmailTemplate} class
+     */
+    @Override
+    public Class<EmailTemplate> getModelClass() {
+        return EmailTemplate.class;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SystemConfigVariableConverter.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/converter/SystemConfigVariableConverter.java
@@ -1,0 +1,50 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.converter;
+
+import org.dspace.app.rest.model.SystemConfigVariableRest;
+import org.dspace.app.rest.projection.Projection;
+import org.dspace.core.SystemConfigVariable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converter that converts a {@link SystemConfigVariable} domain object into a {@link SystemConfigVariableRest} object.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@Component
+public class SystemConfigVariableConverter implements DSpaceConverter<SystemConfigVariable, SystemConfigVariableRest> {
+
+    /**
+     * Converts a {@link SystemConfigVariable} domain object into its REST representation.
+     *
+     * @param modelObject the domain object to convert
+     * @param projection  the active projection
+     * @return the converted {@link SystemConfigVariableRest} object
+     */
+    @Override
+    public SystemConfigVariableRest convert(SystemConfigVariable modelObject, Projection projection) {
+        SystemConfigVariableRest rest = new SystemConfigVariableRest();
+        rest.setProjection(projection);
+        rest.setId(modelObject.getKey());
+        rest.setKey(modelObject.getKey());
+        rest.setValue(modelObject.getValue());
+        rest.setPlaceholder(modelObject.getPlaceholder());
+        return rest;
+    }
+
+    /**
+     * Gets the domain model class handled by this converter.
+     *
+     * @return the {@link SystemConfigVariable} class
+     */
+    @Override
+    public Class<SystemConfigVariable> getModelClass() {
+        return SystemConfigVariable.class;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/DSpaceApiExceptionControllerAdvice.java
@@ -247,6 +247,21 @@ public class DSpaceApiExceptionControllerAdvice extends ResponseEntityExceptionH
         return super.handleTypeMismatch(ex, headers, HttpStatus.BAD_REQUEST, request);
     }
 
+    @ExceptionHandler({PreconditionFailedException.class, PreconditionRequiredException.class})
+    protected void handlePreconditionException(HttpServletRequest request, HttpServletResponse response,
+                                               Exception ex) throws IOException {
+        ResponseStatus responseStatus = AnnotationUtils.findAnnotation(ex.getClass(), ResponseStatus.class);
+        int status = responseStatus != null ? responseStatus.code().value()
+            : HttpStatus.PRECONDITION_FAILED.value();
+        sendErrorResponse(request, response, ex, ex.getMessage(), status);
+    }
+
+    @ExceptionHandler(NotModifiedException.class)
+    protected void handleNotModifiedException(HttpServletRequest request, HttpServletResponse response,
+                                              Exception ex) {
+        response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+    }
+
     @ExceptionHandler(Exception.class)
     protected void handleGenericException(HttpServletRequest request, HttpServletResponse response, Exception ex)
         throws IOException {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/NotModifiedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/NotModifiedException.java
@@ -1,0 +1,36 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a requested resource has not been modified (HTTP 304).
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@ResponseStatus(value = HttpStatus.NOT_MODIFIED, reason = "Not Modified")
+public class NotModifiedException extends RuntimeException {
+
+    /**
+     * Constructs a NotModifiedException with the default message.
+     */
+    public NotModifiedException() {
+        super("Not Modified");
+    }
+
+    /**
+     * Constructs a NotModifiedException with a custom message.
+     *
+     * @param message the detail message
+     */
+    public NotModifiedException(String message) {
+        super(message);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/PreconditionFailedException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/PreconditionFailedException.java
@@ -1,0 +1,39 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when an ETag precondition check fails (HTTP 412 Precondition Failed).
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@ResponseStatus(value = HttpStatus.PRECONDITION_FAILED, reason = "Precondition Failed")
+public class PreconditionFailedException extends RuntimeException {
+
+    /**
+     * Constructs a PreconditionFailedException with a detail message.
+     *
+     * @param message the detail message
+     */
+    public PreconditionFailedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a PreconditionFailedException with a detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause of the exception
+     */
+    public PreconditionFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/PreconditionRequiredException.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/exception/PreconditionRequiredException.java
@@ -1,0 +1,39 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when an ETag If-Match header is required but missing (HTTP 428 Precondition Required).
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@ResponseStatus(value = HttpStatus.PRECONDITION_REQUIRED, reason = "Precondition Required")
+public class PreconditionRequiredException extends RuntimeException {
+
+    /**
+     * Constructs a PreconditionRequiredException with a detail message.
+     *
+     * @param message the detail message
+     */
+    public PreconditionRequiredException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a PreconditionRequiredException with a detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause of the exception
+     */
+    public PreconditionRequiredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EmailTemplateRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EmailTemplateRest.java
@@ -1,0 +1,244 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.dspace.app.rest.RestResourceController;
+import org.dspace.core.EmailTemplateMimeType;
+
+/**
+ * REST model representing an email template in DSpace.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplateRest extends BaseObjectRest<String> {
+
+    public static final String NAME = "emailtemplate";
+    public static final String PLURAL_NAME = "emailtemplates";
+    public static final String CATEGORY = RestAddressableModel.SYSTEM;
+
+    @Size(max = 255)
+    @Pattern(regexp = "^[a-zA-Z0-9._-]+$")
+    private String name;
+
+    @Size(min = 10, max = 50000)
+    private String content;
+
+    @Size(max = 500)
+    private String subject;
+
+    private EmailTemplateMimeType mimetype;
+
+    private List<EmailTemplateVariableRest> variables;
+    private Instant lastModified;
+    private String etag;
+
+    /**
+     * Default constructor.
+     */
+    public EmailTemplateRest() {
+        this.variables = new ArrayList<>();
+        this.mimetype = EmailTemplateMimeType.TEXT_PLAIN;
+    }
+
+    /**
+     * Gets the REST resource identifier, which is the template name.
+     *
+     * @return the template name, or the raw id if name is not set
+     */
+    @Override
+    public String getId() {
+        return this.name != null ? this.name : this.id;
+    }
+
+    /**
+     * Sets the REST resource identifier, syncing it with the template name.
+     *
+     * @param id the template name identifier to set
+     */
+    @Override
+    public void setId(String id) {
+        this.id = id;
+        this.name = id;
+    }
+
+    /**
+     * Gets the API category of this resource.
+     *
+     * @return the system category
+     */
+    @Override
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    /**
+     * Gets the controller class handling this resource.
+     *
+     * @return the REST resource controller class
+     */
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class getController() {
+        return RestResourceController.class;
+    }
+
+    /**
+     * Gets the resource type name.
+     *
+     * @return the emailtemplate type name
+     */
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getType() {
+        return NAME;
+    }
+
+    /**
+     * Gets the plural resource type name.
+     *
+     * @return the emailtemplates plural type name
+     */
+    @Override
+    public String getTypePlural() {
+        return PLURAL_NAME;
+    }
+
+    /**
+     * Gets the template filename identifier (e.g. "register").
+     *
+     * @return the template name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the template filename identifier, syncing it with the REST id.
+     *
+     * @param name the template name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+        this.id = name;
+    }
+
+    /**
+     * Gets the full VTL template body.
+     *
+     * @return the template content
+     */
+    public String getContent() {
+        return content;
+    }
+
+    /**
+     * Sets the full VTL template body.
+     *
+     * @param content the template content to set
+     */
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * Gets the email subject line parsed from the template.
+     *
+     * @return the subject
+     */
+    public String getSubject() {
+        return subject;
+    }
+
+    /**
+     * Sets the email subject line.
+     *
+     * @param subject the subject to set
+     */
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    /**
+     * Gets the MIME type of the template output.
+     *
+     * @return the MIME type enum
+     */
+    public EmailTemplateMimeType getMimetype() {
+        return mimetype;
+    }
+
+    /**
+     * Sets the MIME type of the template output, defaulting to TEXT_PLAIN when null.
+     *
+     * @param mimetype the MIME type to set
+     */
+    public void setMimetype(EmailTemplateMimeType mimetype) {
+        this.mimetype = mimetype != null ? mimetype : EmailTemplateMimeType.TEXT_PLAIN;
+    }
+
+    /**
+     * Gets the template variables parsed from the comment headers.
+     *
+     * @return the list of template variables
+     */
+    public List<EmailTemplateVariableRest> getVariables() {
+        return variables;
+    }
+
+    /**
+     * Sets the template variables.
+     *
+     * @param variables the list of template variables to set
+     */
+    public void setVariables(List<EmailTemplateVariableRest> variables) {
+        this.variables = variables;
+    }
+
+    /**
+     * Gets the last modified timestamp of the template file.
+     *
+     * @return the last modified timestamp
+     */
+    public Instant getLastModified() {
+        return lastModified;
+    }
+
+    /**
+     * Sets the last modified timestamp of the template file.
+     *
+     * @param lastModified the last modified timestamp to set
+     */
+    public void setLastModified(Instant lastModified) {
+        this.lastModified = lastModified;
+    }
+
+    /**
+     * Gets the ETag used for optimistic concurrency control.
+     *
+     * @return the ETag (SHA-256 hash of content)
+     */
+    public String getEtag() {
+        return etag;
+    }
+
+    /**
+     * Sets the ETag used for optimistic concurrency control.
+     *
+     * @param etag the ETag to set
+     */
+    public void setEtag(String etag) {
+        this.etag = etag;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EmailTemplateVariableRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/EmailTemplateVariableRest.java
@@ -1,0 +1,101 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.io.Serializable;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * REST representation of a variable (parameter) in an email template.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplateVariableRest implements Serializable {
+
+    private int index;
+
+    @Size(max = 500)
+    private String description;
+
+    @Size(max = 30)
+    private String placeholder;
+
+    /**
+     * Default constructor.
+     */
+    public EmailTemplateVariableRest() {
+    }
+
+    /**
+     * Constructs an EmailTemplateVariableRest with all fields.
+     *
+     * @param index       the parameter index
+     * @param description the description
+     * @param placeholder the VTL placeholder string
+     */
+    public EmailTemplateVariableRest(int index, String description, String placeholder) {
+        this.index = index;
+        this.description = description;
+        this.placeholder = placeholder;
+    }
+
+    /**
+     * Gets the 0-based parameter index.
+     *
+     * @return the parameter index
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * Sets the 0-based parameter index.
+     *
+     * @param index the parameter index to set
+     */
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    /**
+     * Gets the parameter description.
+     *
+     * @return the parameter description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Sets the parameter description.
+     *
+     * @param description the parameter description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Gets the VTL placeholder string (e.g. {@code ${params[0]}}).
+     *
+     * @return the VTL placeholder
+     */
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    /**
+     * Sets the VTL placeholder string.
+     *
+     * @param placeholder the VTL placeholder to set
+     */
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SystemConfigVariableRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/SystemConfigVariableRest.java
@@ -1,0 +1,193 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.dspace.app.rest.RestResourceController;
+
+/**
+ * REST representation of an allowed system configuration variable that can be used in email templates.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class SystemConfigVariableRest extends BaseObjectRest<String> {
+
+    public static final String NAME = "systemconfigvariable";
+    public static final String PLURAL_NAME = "systemconfigvariables";
+    public static final String CATEGORY = RestAddressableModel.SYSTEM;
+
+    @Size(max = 255)
+    @Pattern(regexp = "^[a-zA-Z0-9._-]+$")
+    private String key;
+
+    @Size(max = 2000)
+    private String value;
+
+    @Size(max = 255)
+    private String placeholder;
+
+    /**
+     * Default constructor.
+     */
+    public SystemConfigVariableRest() {
+    }
+
+    /**
+     * Parameterized constructor.
+     *
+     * @param key the configuration property key (e.g. "dspace.name")
+     * @param value the resolved value of the configuration property
+     * @param placeholder the Velocity expression to insert into the template
+     */
+    public SystemConfigVariableRest(String key, String value, String placeholder) {
+        this.key = key;
+        this.value = value;
+        this.placeholder = placeholder;
+    }
+
+    /**
+     * Gets the REST resource identifier, which is the configuration property key.
+     *
+     * @return the property key, or the raw id if key is not set
+     */
+    @Override
+    public String getId() {
+        return this.key != null ? this.key : this.id;
+    }
+
+    /**
+     * Sets the REST resource identifier, syncing it with the configuration property key.
+     *
+     * @param id the property key identifier to set
+     */
+    @Override
+    public void setId(String id) {
+        this.id = id;
+        this.key = id;
+    }
+
+    /**
+     * Gets the API category of this resource.
+     *
+     * @return the system category
+     */
+    @Override
+    public String getCategory() {
+        return CATEGORY;
+    }
+
+    /**
+     * Gets the controller class handling this resource.
+     *
+     * @return the REST resource controller class
+     */
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class getController() {
+        return RestResourceController.class;
+    }
+
+    /**
+     * Gets the resource type name.
+     *
+     * @return the systemconfigvariable type name
+     */
+    @Override
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public String getType() {
+        return NAME;
+    }
+
+    /**
+     * Gets the plural resource type name.
+     *
+     * @return the systemconfigvariables plural type name
+     */
+    @Override
+    public String getTypePlural() {
+        return PLURAL_NAME;
+    }
+
+    /**
+     * Gets the configuration property key (e.g. "dspace.name").
+     *
+     * @return the property key
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Sets the configuration property key, syncing it with the REST id.
+     *
+     * @param key the property key to set
+     */
+    public void setKey(String key) {
+        this.key = key;
+        this.id = key;
+    }
+
+    /**
+     * Gets the resolved value of the configuration property.
+     *
+     * @return the property value
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the resolved value of the configuration property.
+     *
+     * @param value the property value to set
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the Velocity expression used to reference this variable in a template.
+     *
+     * @return the Velocity placeholder
+     */
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    /**
+     * Sets the Velocity expression used to reference this variable in a template.
+     *
+     * @param placeholder the Velocity placeholder to set
+     */
+    public void setPlaceholder(String placeholder) {
+        this.placeholder = placeholder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SystemConfigVariableRest that = (SystemConfigVariableRest) o;
+        return Objects.equals(key, that.key) &&
+            Objects.equals(value, that.value) &&
+            Objects.equals(placeholder, that.placeholder);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value, placeholder);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/EmailTemplateResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/EmailTemplateResource.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.EmailTemplateRest;
+import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * HAL Resource wrapper for {@link EmailTemplateRest}.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@RelNameDSpaceResource(EmailTemplateRest.NAME)
+public class EmailTemplateResource extends DSpaceResource<EmailTemplateRest> {
+
+    /**
+     * Constructs a HAL resource wrapping the given email template REST object.
+     *
+     * @param content the email template REST object to wrap
+     * @param utils   the REST utilities used to build resource links
+     */
+    public EmailTemplateResource(EmailTemplateRest content, Utils utils) {
+        super(content, utils);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/SystemConfigVariableResource.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/hateoas/SystemConfigVariableResource.java
@@ -1,0 +1,31 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model.hateoas;
+
+import org.dspace.app.rest.model.SystemConfigVariableRest;
+import org.dspace.app.rest.model.hateoas.annotations.RelNameDSpaceResource;
+import org.dspace.app.rest.utils.Utils;
+
+/**
+ * HAL Resource wrapper for {@link SystemConfigVariableRest}.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@RelNameDSpaceResource(SystemConfigVariableRest.NAME)
+public class SystemConfigVariableResource extends DSpaceResource<SystemConfigVariableRest> {
+
+    /**
+     * Constructs a HAL resource wrapping the given system config variable REST object.
+     *
+     * @param content the system config variable REST object to wrap
+     * @param utils   the REST utilities used to build resource links
+     */
+    public SystemConfigVariableResource(SystemConfigVariableRest content, Utils utils) {
+        super(content, utils);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EmailTemplateRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EmailTemplateRestRepository.java
@@ -76,11 +76,8 @@ public class EmailTemplateRestRepository extends DSpaceRestRepository<EmailTempl
                 response.setHeader(HttpHeaders.ETAG, "\"" + etag + "\"");
 
                 String ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH);
-                if (ifNoneMatch != null) {
-                    String cleanIfNoneMatch = unquote(ifNoneMatch);
-                    if (cleanIfNoneMatch.equals(etag) || "*".equals(ifNoneMatch)) {
-                        throw new NotModifiedException();
-                    }
+                if (ifNoneMatch != null && etagMatches(ifNoneMatch, etag)) {
+                    throw new NotModifiedException();
                 }
             }
 
@@ -138,8 +135,7 @@ public class EmailTemplateRestRepository extends DSpaceRestRepository<EmailTempl
             throw new ResourceNotFoundException("Email template not found: " + id);
         }
 
-        String cleanIfMatch = unquote(ifMatch);
-        if (!"*".equals(cleanIfMatch) && !cleanIfMatch.equals(existing.getEtag())) {
+        if (!etagMatches(ifMatch, existing.getEtag())) {
             throw new PreconditionFailedException(
                 "If-Match ETag mismatch. Template has been modified by another process.");
         }
@@ -160,6 +156,23 @@ public class EmailTemplateRestRepository extends DSpaceRestRepository<EmailTempl
     @Override
     public Class<EmailTemplateRest> getDomainClass() {
         return EmailTemplateRest.class;
+    }
+
+    private boolean etagMatches(String headerValue, String etag) {
+        if (StringUtils.isBlank(headerValue) || etag == null) {
+            return false;
+        }
+        for (String value : headerValue.split("\\s*,\\s*")) {
+            String candidate = value.trim();
+            if (candidate.startsWith("W/")) {
+                candidate = candidate.substring(2).trim();
+            }
+            candidate = unquote(candidate);
+            if ("*".equals(candidate) || etag.equals(candidate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String unquote(String headerValue) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EmailTemplateRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/EmailTemplateRestRepository.java
@@ -1,0 +1,172 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.dspace.app.rest.converter.EmailTemplateConverter;
+import org.dspace.app.rest.exception.DSpaceBadRequestException;
+import org.dspace.app.rest.exception.NotModifiedException;
+import org.dspace.app.rest.exception.PreconditionFailedException;
+import org.dspace.app.rest.exception.PreconditionRequiredException;
+import org.dspace.app.rest.model.EmailTemplateRest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+import org.dspace.core.EmailTemplate;
+import org.dspace.core.service.EmailTemplateService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+/**
+ * REST repository for managing email templates.
+ *
+ * <p>Supports listing all templates, retrieving a template by name, and updating template content.
+ * Optimistic concurrency control is implemented using HTTP ETags ({@code If-Match} / {@code If-None-Match}).</p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@Component(EmailTemplateRest.CATEGORY + "." + EmailTemplateRest.PLURAL_NAME)
+public class EmailTemplateRestRepository extends DSpaceRestRepository<EmailTemplateRest, String> {
+
+    @Autowired
+    private EmailTemplateService emailTemplateService;
+
+    @Autowired
+    private EmailTemplateConverter emailTemplateConverter;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private HttpServletRequest request;
+
+    @Autowired
+    private HttpServletResponse response;
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public EmailTemplateRest findOne(Context context, String name) {
+        try {
+            EmailTemplate template = emailTemplateService.findByName(context, name);
+            if (template == null) {
+                return null;
+            }
+
+            String etag = template.getEtag();
+            if (etag != null) {
+                response.setHeader(HttpHeaders.ETAG, "\"" + etag + "\"");
+
+                String ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH);
+                if (ifNoneMatch != null) {
+                    String cleanIfNoneMatch = unquote(ifNoneMatch);
+                    if (cleanIfNoneMatch.equals(etag) || "*".equals(ifNoneMatch)) {
+                        throw new NotModifiedException();
+                    }
+                }
+            }
+
+            return emailTemplateConverter.convert(template, utils.obtainProjection());
+        } catch (AuthorizeException e) {
+            throw new AccessDeniedException(e.getMessage(), e);
+        } catch (IOException | SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public Page<EmailTemplateRest> findAll(Context context, Pageable pageable) {
+        try {
+            List<EmailTemplate> templates = emailTemplateService.findAll(context);
+            return converter.toRestPage(templates, pageable, utils.obtainProjection());
+        } catch (AuthorizeException e) {
+            throw new AccessDeniedException(e.getMessage(), e);
+        } catch (IOException | SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    protected EmailTemplateRest put(Context context, HttpServletRequest req, String apiCategory, String model,
+                                   String id, JsonNode jsonNode) throws SQLException, AuthorizeException {
+
+        String ifMatch = req.getHeader(HttpHeaders.IF_MATCH);
+        if (StringUtils.isBlank(ifMatch)) {
+            throw new PreconditionRequiredException(
+                "If-Match header is required for updating email templates");
+        }
+
+        EmailTemplateRest restBody;
+        try {
+            restBody = mapper.readValue(jsonNode.toString(), EmailTemplateRest.class);
+        } catch (JsonProcessingException e) {
+            throw new DSpaceBadRequestException("Cannot parse JSON in request body", e);
+        }
+
+        if (restBody == null || StringUtils.isBlank(restBody.getContent())) {
+            throw new DSpaceBadRequestException("Template content cannot be blank");
+        }
+
+        EmailTemplate existing;
+        try {
+            existing = emailTemplateService.findByName(context, id);
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading template: " + id, e);
+        }
+
+        if (existing == null) {
+            throw new ResourceNotFoundException("Email template not found: " + id);
+        }
+
+        String cleanIfMatch = unquote(ifMatch);
+        if (!"*".equals(cleanIfMatch) && !cleanIfMatch.equals(existing.getEtag())) {
+            throw new PreconditionFailedException(
+                "If-Match ETag mismatch. Template has been modified by another process.");
+        }
+
+        try {
+            EmailTemplate updated = emailTemplateService.update(context, id, restBody.getContent());
+            if (updated.getEtag() != null) {
+                response.setHeader(HttpHeaders.ETAG, "\"" + updated.getEtag() + "\"");
+            }
+            return emailTemplateConverter.convert(updated, utils.obtainProjection());
+        } catch (IllegalArgumentException e) {
+            throw new DSpaceBadRequestException(e.getMessage(), e);
+        } catch (IOException e) {
+            throw new RuntimeException("Error updating template: " + id, e);
+        }
+    }
+
+    @Override
+    public Class<EmailTemplateRest> getDomainClass() {
+        return EmailTemplateRest.class;
+    }
+
+    private String unquote(String headerValue) {
+        if (headerValue != null && headerValue.startsWith("\"") && headerValue.endsWith("\"")
+                && headerValue.length() >= 2) {
+            return headerValue.substring(1, headerValue.length() - 1);
+        }
+        return headerValue != null ? headerValue : "";
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SystemConfigVariableRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SystemConfigVariableRestRepository.java
@@ -1,0 +1,77 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.repository;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.dspace.app.rest.converter.SystemConfigVariableConverter;
+import org.dspace.app.rest.model.SystemConfigVariableRest;
+import org.dspace.authorize.AuthorizeException;
+import org.dspace.core.Context;
+import org.dspace.core.SystemConfigVariable;
+import org.dspace.core.service.SystemConfigVariableService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+
+/**
+ * REST repository for retrieving general system configuration variables allowed in templates.
+ *
+ * <p>Exposes:
+ * <ul>
+ *   <li>{@code GET /api/system/systemconfigvariables} - paginated list of all allowed configs</li>
+ *   <li>{@code GET /api/system/systemconfigvariables/{key}} - retrieve a single config by key</li>
+ * </ul>
+ * </p>
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+@Component(SystemConfigVariableRest.CATEGORY + "." + SystemConfigVariableRest.PLURAL_NAME)
+public class SystemConfigVariableRestRepository extends DSpaceRestRepository<SystemConfigVariableRest, String> {
+
+    @Autowired
+    private SystemConfigVariableService systemConfigVariableService;
+
+    @Autowired
+    private SystemConfigVariableConverter systemConfigVariableConverter;
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public Page<SystemConfigVariableRest> findAll(Context context, Pageable pageable) {
+        try {
+            List<SystemConfigVariable> vars = systemConfigVariableService.getConfigVariables(context);
+            return converter.toRestPage(vars, pageable, utils.obtainProjection());
+        } catch (AuthorizeException e) {
+            throw new AccessDeniedException(e.getMessage(), e);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public SystemConfigVariableRest findOne(Context context, String key) {
+        try {
+            SystemConfigVariable var = systemConfigVariableService.getConfigVariable(context, key);
+            return var != null ? systemConfigVariableConverter.convert(var, utils.obtainProjection()) : null;
+        } catch (AuthorizeException e) {
+            throw new AccessDeniedException(e.getMessage(), e);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Class<SystemConfigVariableRest> getDomainClass() {
+        return SystemConfigVariableRest.class;
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EmailTemplateRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EmailTemplateRestRepositoryIT.java
@@ -197,6 +197,60 @@ public class EmailTemplateRestRepositoryIT extends AbstractControllerIntegration
     }
 
     @Test
+    public void getWithMultipleIfNoneMatchOneMatchesReturns304() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        AtomicReference<String> etagRef = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> etagRef.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        assertNotNull(etagRef.get());
+
+        // Comma-separated list containing a stale ETag and the current ETag
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_NONE_MATCH, "\"stale-etag-1\", " + etagRef.get() + ", \"stale-etag-2\""))
+                .andExpect(status().isNotModified());
+    }
+
+    @Test
+    public void getWithWeakIfNoneMatchReturns304() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        AtomicReference<String> etagRef = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> etagRef.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        assertNotNull(etagRef.get());
+
+        // Weak ETag with W/ prefix should be accepted for If-None-Match
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_NONE_MATCH, "W/" + etagRef.get()))
+                .andExpect(status().isNotModified());
+    }
+
+    @Test
+    public void getWithWildcardIfNoneMatchReturns304() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_NONE_MATCH, "*"))
+                .andExpect(status().isNotModified());
+    }
+
+    @Test
+    public void getWithMultipleIfNoneMatchNoneMatchReturns200() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        // Neither candidate matches -> returns 200 OK with content
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_NONE_MATCH, "\"stale-etag-1\", \"stale-etag-2\""))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("it_test_template")));
+    }
+
+    @Test
     public void putAsAdminSuccess() throws Exception {
         String token = getAuthToken(admin.getEmail(), password);
 
@@ -260,6 +314,60 @@ public class EmailTemplateRestRepositoryIT extends AbstractControllerIntegration
                 .content(mapper.writeValueAsBytes(rest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.subject", is("Wildcard Test")));
+    }
+
+    @Test
+    public void putWithMultipleIfMatchOneMatchesSuccess() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        AtomicReference<String> etagRef = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> etagRef.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Multi-Match Test')\nMulti match body.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "\"stale-1\", " + etagRef.get() + ", \"stale-2\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subject", is("Multi-Match Test")));
+    }
+
+    @Test
+    public void putWithMultipleIfMatchNoneMatchesReturns412() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Test')\nValid body text here.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "\"stale-etag-1\", \"stale-etag-2\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isPreconditionFailed());
+    }
+
+    @Test
+    public void putWithWeakIfMatchSuccess() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        AtomicReference<String> etagRef = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> etagRef.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Weak ETag Test')\nWeak tag body.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "W/" + etagRef.get())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subject", is("Weak ETag Test")));
     }
 
     @Test

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/EmailTemplateRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/EmailTemplateRestRepositoryIT.java
@@ -1,0 +1,391 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.model.EmailTemplateRest;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.services.ConfigurationService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+/**
+ * Integration tests for {@link org.dspace.app.rest.repository.EmailTemplateRestRepository}.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class EmailTemplateRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private File emailsDir;
+    private String originalRegisterContent;
+
+    @Before
+    public void setupTestEmails() throws Exception {
+        String dspaceDir = configurationService.getProperty("dspace.dir");
+        emailsDir = new File(dspaceDir, "config" + File.separator + "emails");
+        if (!emailsDir.exists()) {
+            emailsDir.mkdirs();
+        }
+
+        File registerFile = new File(emailsDir, "register");
+        if (registerFile.exists()) {
+            originalRegisterContent = Files.readString(registerFile.toPath(), StandardCharsets.UTF_8);
+        } else {
+            originalRegisterContent = "## Parameters: {0} registration URL\n"
+                + "#set($subject = 'Account Registration')\n"
+                + "Please click the link below to complete registration:\n"
+                + "${params[0]}\n";
+            Files.writeString(registerFile.toPath(), originalRegisterContent, StandardCharsets.UTF_8);
+        }
+
+        File testFile = new File(emailsDir, "it_test_template");
+        String testContent = "## Parameters: {0} username\n"
+            + "#set($subject = 'Test Notification')\n"
+            + "Hello ${params[0]},\n"
+            + "This is an integration test email template body.\n";
+        Files.writeString(testFile.toPath(), testContent, StandardCharsets.UTF_8);
+    }
+
+    @After
+    public void cleanupTestEmails() throws Exception {
+        if (originalRegisterContent != null && emailsDir != null) {
+            File registerFile = new File(emailsDir, "register");
+            Files.writeString(registerFile.toPath(), originalRegisterContent, StandardCharsets.UTF_8);
+        }
+        if (emailsDir != null) {
+            File testFile = new File(emailsDir, "it_test_template");
+            if (testFile.exists()) {
+                testFile.delete();
+            }
+        }
+    }
+
+    @Test
+    public void findAllAsAdmin() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/emailtemplates"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.emailtemplates.length()", greaterThanOrEqualTo(2)))
+                .andExpect(jsonPath("$.page.totalElements", greaterThanOrEqualTo(2)));
+    }
+
+    @Test
+    public void findAllAsAnonymous() throws Exception {
+        getClient().perform(get("/api/system/emailtemplates"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findAllAsNonAdmin() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/emailtemplates"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void findOneAsAdmin() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("it_test_template")))
+                .andExpect(jsonPath("$.subject", is("Test Notification")))
+                .andExpect(jsonPath("$.mimetype", is("text/plain")))
+                .andExpect(jsonPath("$.etag", not(emptyOrNullString())))
+                .andExpect(jsonPath("$.variables[0].index", is(0)))
+                .andExpect(jsonPath("$.variables[0].description", is("username")))
+                .andExpect(jsonPath("$.variables[0].placeholder", is("${params[0]}")))
+                .andExpect(jsonPath("$.configVariables").doesNotExist())
+                .andExpect(jsonPath("$.allowedConfigs").doesNotExist())
+                .andExpect(header().exists(HttpHeaders.ETAG));
+    }
+
+    @Test
+    public void findOneHtmlTemplate() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        File htmlFile = new File(emailsDir, "it_html_template");
+        String htmlContent = "## Parameters: {0} name\n"
+            + "#set($mimetype = 'text/html')\n"
+            + "#set($subject = 'HTML Notification')\n"
+            + "<h1>Hello ${params[0]}</h1>\n";
+        Files.writeString(htmlFile.toPath(), htmlContent, StandardCharsets.UTF_8);
+
+        try {
+            getClient(token).perform(get("/api/system/emailtemplates/it_html_template"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.name", is("it_html_template")))
+                    .andExpect(jsonPath("$.subject", is("HTML Notification")))
+                    .andExpect(jsonPath("$.mimetype", is("text/html")));
+        } finally {
+            if (htmlFile.exists()) {
+                htmlFile.delete();
+            }
+        }
+    }
+
+    @Test
+    public void findOneNotFound() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/emailtemplates/non_existent_template_xyz"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void findOneAsAnonymous() throws Exception {
+        getClient().perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findOneAsNonAdmin() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void getReturnsETagAndSupportsIfNoneMatch() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        AtomicReference<String> etagRef = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> etagRef.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        assertNotNull(etagRef.get());
+
+        // Conditional GET with matching If-None-Match should return 304 Not Modified
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_NONE_MATCH, etagRef.get()))
+                .andExpect(status().isNotModified());
+    }
+
+    @Test
+    public void putAsAdminSuccess() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        AtomicReference<String> etagRef = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> etagRef.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        String updatedBody = "## Parameters: {0} username\n"
+            + "#set($subject = 'Updated Subject')\n"
+            + "Updated body text for ${params[0]}.\n";
+        rest.setContent(updatedBody);
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, etagRef.get())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subject", is("Updated Subject")))
+                .andExpect(header().exists(HttpHeaders.ETAG));
+    }
+
+    @Test
+    public void putWithoutIfMatchHeaderReturns428() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Test')\nValid body text here.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().is(428));
+    }
+
+    @Test
+    public void putWithStaleETagReturns412() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Test')\nValid body text here.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "\"wrong-or-stale-etag\"")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isPreconditionFailed());
+    }
+
+    @Test
+    public void putWithWildcardIfMatchSuccess() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Wildcard Test')\nValid body text here.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subject", is("Wildcard Test")));
+    }
+
+    @Test
+    public void concurrentEditSimulation() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        // Step 1: Admin A and Admin B both load the template and receive the initial ETag
+        AtomicReference<String> initialEtag = new AtomicReference<>();
+        getClient(token).perform(get("/api/system/emailtemplates/it_test_template"))
+                .andExpect(status().isOk())
+                .andDo(result -> initialEtag.set(result.getResponse().getHeader(HttpHeaders.ETAG)));
+
+        // Step 2: Admin B saves first with the initial ETag -> succeeds
+        EmailTemplateRest adminBEdit = new EmailTemplateRest();
+        adminBEdit.setContent("## Parameters: {0} user\n#set($subject = 'Admin B Edit')\nAdmin B was faster.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, initialEtag.get())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(adminBEdit)))
+                .andExpect(status().isOk());
+
+        // Step 3: Admin A attempts to save using the now-stale initial ETag -> rejected with 412 Precondition Failed
+        EmailTemplateRest adminAEdit = new EmailTemplateRest();
+        adminAEdit.setContent("## Parameters: {0} user\n#set($subject = 'Admin A Edit')\nAdmin A was slower.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, initialEtag.get())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(adminAEdit)))
+                .andExpect(status().isPreconditionFailed());
+    }
+
+    @Test
+    public void putContentTooShortReturns400() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("short");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void putContentOnlyWhitespaceReturns400() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("   \n\n\t   ");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void putInvalidVtlSyntaxReturns400() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("#set($subject = 'Broken')\n#if($broken)\nMissing end directive");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void putXssContentReturns400() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("#set($subject = 'XSS')\n<script>alert('xss')</script>\nBody content text.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void putNonExistentTemplateReturns404() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Test')\nValid body text here.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/does_not_exist_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void putAsAnonymousReturns401() throws Exception {
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Test')\nValid body text here.");
+
+        getClient().perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void putAsNonAdminReturns403() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        EmailTemplateRest rest = new EmailTemplateRest();
+        rest.setContent("## Parameters: {0} user\n#set($subject = 'Test')\nValid body text here.");
+
+        getClient(token).perform(put("/api/system/emailtemplates/it_test_template")
+                .header(HttpHeaders.IF_MATCH, "*")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsBytes(rest)))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemConfigVariableRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SystemConfigVariableRestRepositoryIT.java
@@ -1,0 +1,64 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link org.dspace.app.rest.repository.SystemConfigVariableRestRepository}.
+ *
+ * @author Moamen Elbarky (moamen.elbarky@gmail.com)
+ */
+public class SystemConfigVariableRestRepositoryIT extends AbstractControllerIntegrationTest {
+
+    @Test
+    public void findAllAsAdmin() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/systemconfigvariables"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.systemconfigvariables", not(empty())))
+                .andExpect(jsonPath("$._embedded.systemconfigvariables[?(@.key == 'dspace.name')].placeholder")
+                        .value("${config.get('dspace.name')}"))
+                .andExpect(jsonPath("$._embedded.systemconfigvariables[?(@.key == 'dspace.ui.url')].placeholder")
+                        .value("${config.get('dspace.ui.url')}"));
+    }
+
+    @Test
+    public void findOneAsAdmin() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/systemconfigvariables/dspace.name"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.key", is("dspace.name")))
+                .andExpect(jsonPath("$.placeholder", is("${config.get('dspace.name')}")))
+                .andExpect(jsonPath("$.type", is("systemconfigvariable")));
+    }
+
+    @Test
+    public void findAsAnonymous() throws Exception {
+        getClient().perform(get("/api/system/systemconfigvariables"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void findAsNonAdmin() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+
+        getClient(token).perform(get("/api/system/systemconfigvariables"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/dspace/config/spring/api/core-services.xml
+++ b/dspace/config/spring/api/core-services.xml
@@ -65,6 +65,8 @@
     <bean class="org.dspace.scripts.ScriptServiceImpl"/>
 
     <bean class="org.dspace.alerts.SystemWideAlertServiceImpl"/>
+    <bean class="org.dspace.core.EmailTemplateServiceImpl"/>
+    <bean class="org.dspace.core.SystemConfigVariableServiceImpl"/>
 
     <bean class="org.dspace.content.authority.ChoiceAuthorityServiceImpl"/>
     <bean class="org.dspace.content.authority.AuthorityServiceUtils"/>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <jena.version>4.10.0</jena.version>
         <!-- JClouds is used by dspace-api -->
         <jclouds.version>2.7.0</jclouds.version>
+        <owasp-html-sanitizer.version>20240325.1</owasp-html-sanitizer.version>
 
         <!--=== MAVEN SETTINGS ===-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -1877,6 +1878,12 @@
                         <artifactId>checker-qual</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+                <artifactId>owasp-java-html-sanitizer</artifactId>
+                <version>${owasp-html-sanitizer.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## References

* Resolves [DSpace/dspace-angular#5828](https://github.com/DSpace/dspace-angular/issues/5828)
* Related to HTML email support in [DSpace/DSpace#11755](https://github.com/DSpace/DSpace/pull/11755)
* **Coordinated 3-Repository Feature (Part 1 of 3)**:
  * **Part 1 (This PR - Backend REST API & Services)**: `DSpace/DSpace`
  * **Part 2 (REST Contract Documentation)**: [DSpace/RestContract#381](https://github.com/DSpace/RestContract/pull/381)
  * **Part 3 (Coming soon - Angular Admin UI & Management)**: `DSpace/dspace-angular` (Branch: `feature/admin-email-templates`)

---

## Description

This pull request introduces the backend service layer, domain models, and REST endpoints enabling DSpace administrators to inspect, browse, and edit system email templates (`/api/system/emailtemplates`) stored in `{dspace.dir}/config/emails/`.

In addition, it provides a dedicated REST endpoint (`/api/system/systemconfigvariables`) for discovering general repository configuration variables allowed in templates, strictly decoupled from template payloads to eliminate network duplication and maintain clean domain boundaries.

The implementation includes:

* Optimistic concurrency control via HTTP ETags (`If-Match` / `If-None-Match`), supporting comma-separated multi-value lists, weak validators (`W/`), and wildcard (`*`),
* Preservation of template formatting including leading whitespace on update,
* AST syntax validation with Apache Velocity and secure uberspector execution,
* Strict HTML sanitization using OWASP Java HTML Sanitizer with proactive policy violation listeners,
* Canonical path traversal and symlink escape defenses via NIO path verification,
* Zero-Trust authorization auditing with detailed security log warnings,
* Clean architectural decoupling: `EmailTemplateService` manages only email templates, while `SystemConfigVariableService` reuses standard core utility `Utils.getAllowedTemplateConfig()`.

---

## Instructions for Reviewers

This PR is the backend foundation for issue [DSpace/dspace-angular#5828](https://github.com/DSpace/dspace-angular/issues/5828). It allows the upcoming Angular administration interface to safely manage email templates without direct filesystem access to the server.

---

### List of Changes in this PR

#### 1. Core API & Service Layer (`dspace-api`)

* **Domain Models (`org.dspace.core`)**:
  * `EmailTemplateMimeType`: Strongly typed enumeration (`TEXT_PLAIN = "text/plain"`, `TEXT_HTML = "text/html"`) with `@JsonValue` and `@JsonCreator`.
  * `EmailTemplate`: Encapsulates template name, raw content, parsed subject, detected mimetype (`EmailTemplateMimeType`), last modified timestamp, SHA-256 deterministic ETag, and positional parameters (`variables`).
  * `EmailTemplateVariable`: Encapsulates template parameters (e.g. index `{0}`, description, and placeholder `${params[0]}`).
  * `SystemConfigVariable`: Encapsulates general system configuration properties allowed for templates, including property key, resolved value, and Velocity placeholder syntax (`${config.get('key')}`).
* **Email Template Service (`EmailTemplateService` / `EmailTemplateServiceImpl`)**:
  * **Deterministic SHA-256 ETag Generation**: Computes content hash for optimistic concurrency.
  * **Formatting & Whitespace Preservation**: Preserves template leading whitespace and indentation during updates.
  * **Symlink and Path Traversal Protection**: Uses Java NIO canonical path verification (`toRealPath()`, `normalize()`, `startsWith()`).
  * **OWASP Java HTML Sanitizer**: Validates HTML templates using `HtmlChangeListener` to proactively detect and reject prohibited elements (`<script>`, `<iframe>`, `javascript:` URIs, inline handlers).
  * **Velocity Template Language (VTL) Syntax Validation**: Validates template syntax using in-memory `StringResourceLoader` and `SecureUberspector`.
  * **Parameter Extraction**: Parses parameter documentation from header comments (`## Parameters: {0} description`).
  * **Zero-Trust Security & Audit Logging**: Enforces `authorizeService.isAdmin(context)` on all operations, logging unauthorized access attempts with user details.
* **System Configuration Variable Service (`SystemConfigVariableService` / `SystemConfigVariableServiceImpl`)**:
  * Dedicated service providing `getConfigVariables(context)` and `getConfigVariable(context, key)` using `org.dspace.core.Utils.getAllowedTemplateConfig()`, enforcing `authorizeService.isAdmin(context)` (null context denied) with audit logging.
* **Dependency & Spring Wiring**:
  * Added `com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer` to root `pom.xml` and `dspace-api/pom.xml`.
  * Registered `EmailTemplateServiceImpl` and `SystemConfigVariableServiceImpl` beans in `dspace/config/spring/api/core-services.xml`.
* **Unit Tests**:
  * `EmailTemplateServiceImplTest`: 22 unit tests covering parsing, HTML/VTL validation, boundary checks, traversal attacks, symlink escapes, ETag determinism, leading whitespace preservation, and non-admin/null-context authorization auditing.
  * `SystemConfigVariableServiceImplTest`: 5 unit tests verifying configuration retrieval, placeholders, sorting, and non-admin/null-context authorization auditing.

#### 2. REST API Layer (`dspace-server-webapp`)

* **REST Endpoints Exposed**:
  * `GET /api/system/emailtemplates`: Paginated list of all templates (Admin-only).
  * `GET /api/system/emailtemplates/{name}`: Retrieve a single template by filename identifier (e.g. `/api/system/emailtemplates/register`). Returns `ETag` HTTP response header. Supports conditional GET with `If-None-Match` (returns `304 Not Modified`, supporting multi-value, weak tags, and wildcard `*`).
  * `PUT /api/system/emailtemplates/{name}`: Updates template content (Admin-only). Requires `If-Match` header. Missing header triggers `428 Precondition Required`. Outdated ETag triggers `412 Precondition Failed`. Supports comma-separated list, weak tags (`W/`), and wildcard `*` for force-overwrites.
  * `GET /api/system/systemconfigvariables`: Paginated list of all allowed system configuration variables for email templates (Admin-only).
  * `GET /api/system/systemconfigvariables/{key}`: Retrieve a single configuration variable by property key (Admin-only).
* **REST Models, Converters & Repositories**:
  * `EmailTemplateRest` (+`VariableRest`), `SystemConfigVariableRest`, HAL resources, converters, and the two `RestRepository` classes.
  * `etagMatches()` utility supporting RFC 9110 / RFC 7232 ETag parsing and comparison.
* **Master Controller Route Update**:
  * Updated `RestResourceController` (PUT mapping for single resources) to include `REGEX_REQUESTMAPPING_IDENTIFIER_AS_STRING_VERSION_STRONG`.
* **HTTP Exceptions & Advice Handling**:
  * Added `PreconditionRequiredException` (HTTP 428), `PreconditionFailedException` (HTTP 412), and `NotModifiedException` (HTTP 304).
  * Added exception handlers in `DSpaceApiExceptionControllerAdvice`.
* **Integration Tests**:
  * `EmailTemplateRestRepositoryIT`: 32 integration tests validating authentication (401), authorization (403), listing, retrieval, ETag conditional GET (304 with multi-value/weak/wildcard), PUT preconditions (428 & 412 with multi-value/weak/wildcard), wildcard updates (200), XSS rejection (400), invalid VTL rejection (400), and absence of coupled configVariables.
  * `SystemConfigVariableRestRepositoryIT`: Dedicated integration tests verifying `findAllAsAdmin`, `findOneAsAdmin`, anonymous (401), and non-admin (403).

---

### How to Review and Test

#### 1. Automated Verification

Run the unit and integration tests locally:

```bash
# 1. Run unit tests on dspace-api
mvn test -pl dspace-api -Dtest=EmailTemplateServiceImplTest,SystemConfigVariableServiceImplTest -DskipUnitTests=false

# 2. Verify style and Checkstyle
mvn checkstyle:check -pl dspace-api,dspace-server-webapp

# 3. Run integration tests on dspace-server-webapp
mvn verify -pl dspace-server-webapp -DskipUnitTests=true -DskipIntegrationTests=false \
  -Dit.test=EmailTemplateRestRepositoryIT,SystemConfigVariableRestRepositoryIT \
  -Dagnostic.build.dir=$(pwd)/dspace-server-webapp/target \
  -Ddspace.dir=$(pwd)/dspace-server-webapp/target/testing/dspace \
  -Denforcer.skip=true
```

#### 2. Manual Verification via `curl`

> The full matrix (401/403, 304, 428, 412, wildcard `*`, XSS/VTL 400s) is covered by
> `EmailTemplateRestRepositoryIT` / `SystemConfigVariableRestRepositoryIT`. Below is the
> minimal smoke test — copy-paste as one block, no manual ETag copying needed.

```bash
BASE="http://localhost:8080/server/api"
TOKEN=$(curl -s -i -X POST "$BASE/authn/login" \
  -d "user=dspacedemo+admin@gmail.com&password=dspace" \
  | grep -i Authorization | awk '{print $2}' | tr -d '\r')

# 1. List templates
curl -i -H "Authorization: Bearer $TOKEN" "$BASE/system/emailtemplates"

# 2. Get one template and capture its ETag (no manual copying)
ETAG=$(curl -s -D - -o /dev/null -H "Authorization: Bearer $TOKEN" \
  "$BASE/system/emailtemplates/register" \
  | grep -i '^ETag:' | awk '{print $2}' | tr -d '\r')
echo "ETAG=$ETAG"

# 3. Conditional GET -> 304
curl -i -H "Authorization: Bearer $TOKEN" -H "If-None-Match: $ETAG" \
  "$BASE/system/emailtemplates/register"

# 4. Successful update with matching ETag (-> 200 + new ETag).
# WARNING: overwrites {dspace.dir}/config/emails/register — back it up first.
curl -i -X PUT -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" -H "If-Match: $ETAG" \
  -d '{"content":"#set($subject=\"Updated Subject\")\nUpdated body ${params[0]}."}' \
  "$BASE/system/emailtemplates/register"

# 5. Config variables (list + single)
curl -i -H "Authorization: Bearer $TOKEN" "$BASE/system/systemconfigvariables"
curl -i -H "Authorization: Bearer $TOKEN" "$BASE/system/systemconfigvariables/dspace.name"
```

---

## Checklist

* [x] My PR is **created against the `main` branch** of code.
* [ ] My PR is **small in size** (Medium-to-large feature PR: modularized and well-scoped, with the bulk of additions residing in automated tests).
* [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](https://github.com/DSpace/DSpace/blob/main/CODE_CONVENTIONS.md).
* [x] My PR **passes Checkstyle** validation (0 violations in both `dspace-api` and `dspace-server-webapp`).
* [x] My PR **includes Javadoc** for all new public methods, classes, and models.
* [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** (27 unit tests, 32 integration tests).
* [x] My PR **includes details on how to test it** (automated commands and curl walkthrough provided).
* [x] If my PR includes new libraries/dependencies, I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) (OWASP Java HTML Sanitizer is Apache-2.0, fully compatible).
* [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change ([DSpace/RestContract#381](https://github.com/DSpace/RestContract/pull/381)).
* [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
* [x] If my PR fixes an issue ticket, I've linked them together (linked to `DSpace/dspace-angular#5828`).
