### PR TITLE
Stage large uploads in bounded chunks and start scripts from staged uploads (SAF import first)

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/ScriptProcessesController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/ScriptProcessesController.java
@@ -7,19 +7,29 @@
  */
 package org.dspace.app.rest;
 
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
 import java.util.List;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dspace.app.rest.converter.ConverterService;
 import org.dspace.app.rest.exception.DSpaceBadRequestException;
 import org.dspace.app.rest.model.ProcessRest;
 import org.dspace.app.rest.model.ScriptRest;
+import org.dspace.app.rest.model.StagedScriptInvocationRest;
 import org.dspace.app.rest.model.hateoas.ProcessResource;
+import org.dspace.app.rest.projection.Projection;
 import org.dspace.app.rest.repository.ScriptRestRepository;
 import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.rest.utils.StagedUploadService;
+import org.dspace.authorize.AuthorizeException;
 import org.dspace.core.Context;
+import org.dspace.scripts.Process;
 import org.dspace.scripts.configuration.ScriptConfiguration;
+import org.dspace.scripts.service.ProcessService;
 import org.dspace.scripts.service.ScriptService;
 import org.dspace.services.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +42,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -59,6 +70,15 @@ public class ScriptProcessesController {
     @Autowired
     private RequestService requestService;
 
+    @Autowired
+    private StagedUploadService stagedUploads;
+
+    @Autowired
+    private ProcessService processService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
     /**
      * This method can be called by sending a POST request to the system/scripts/{name}/processes endpoint
      * This will start a process for the script that matches the given name
@@ -83,7 +103,70 @@ public class ScriptProcessesController {
         return ControllerUtils.toResponseEntity(HttpStatus.ACCEPTED, new HttpHeaders(), processResource);
     }
 
-    @RequestMapping(method = RequestMethod.POST, consumes = "!" + MediaType.MULTIPART_FORM_DATA_VALUE)
+    /**
+     * Start a process for the script with the given name from a JSON body, optionally attaching previously
+     * staged uploads (see {@link StagedUploadsController}) as input files. Repeating the request for
+     * uploads that were already consumed returns the process created then; it never starts a second one.
+     * @param scriptName    The name of the script that we want to start a process for
+     * @param invocation    The script parameters and the identifiers of the staged uploads to attach
+     * @return              The ProcessResource object for the created process
+     * @throws Exception    If something goes wrong
+     */
+    @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    public ResponseEntity<RepresentationModel<?>> startProcessFromStagedUploads(
+        @PathVariable(name = "name") String scriptName,
+        @Valid @RequestBody StagedScriptInvocationRest invocation)
+        throws Exception {
+        Context context = ContextUtil.obtainContext(requestService.getCurrentRequest().getHttpServletRequest());
+        ScriptConfiguration scriptToExecute = scriptService.getScriptConfiguration(scriptName);
+        if (scriptToExecute == null) {
+            throw new ResourceNotFoundException("The script for name: " + scriptName + " wasn't found");
+        }
+        String properties = mapper.writeValueAsString(invocation.properties());
+        int processId;
+        if (invocation.uploads().isEmpty()) {
+            processId = scriptRestRepository.startProcess(context, scriptName, List.of(), properties, id -> { })
+                                            .getProcessId();
+        } else {
+            // Refuse before touching the uploads, so an unauthorized attempt leaves them resumable
+            if (!scriptToExecute.isAllowedToExecute(context,
+                scriptRestRepository.toCommandLineParameters(invocation.properties()))) {
+                throw new AuthorizeException("Current user is not eligible to execute script with name: "
+                                                 + scriptName);
+            }
+            String result = stagedUploads.consume(context.getCurrentUser().getID(), invocation.uploads(),
+                (files, record) -> {
+                    ProcessRest process = scriptRestRepository.startProcess(context, scriptName, files, properties,
+                        id -> record.accept(processLink(id)));
+                    context.commit();
+                    return processLink(process.getProcessId());
+                });
+            processId = processIdOf(result);
+        }
+        Process process = processService.find(context, processId);
+        if (process == null) {
+            throw new ResourceNotFoundException("The process no longer exists");
+        }
+        ProcessResource processResource = converter.toResource(converter.toRest(process, Projection.DEFAULT));
+        context.complete();
+        return ControllerUtils.toResponseEntity(HttpStatus.ACCEPTED, new HttpHeaders(), processResource);
+    }
+
+    private String processLink(int processId) {
+        return linkTo(RestResourceController.class, ProcessRest.CATEGORY, ProcessRest.PLURAL_NAME)
+            .slash(processId).toString();
+    }
+
+    private int processIdOf(String link) {
+        try {
+            return Integer.parseInt(link.substring(link.lastIndexOf('/') + 1));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("The staged uploads were not consumed by a script process: " + link);
+        }
+    }
+
+    @RequestMapping(method = RequestMethod.POST)
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     public ResponseEntity<RepresentationModel<?>> startProcessInvalidMimeType(
         @PathVariable(name = "name") String scriptName)

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/StagedUploadsController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/StagedUploadsController.java
@@ -1,0 +1,112 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import org.dspace.app.rest.model.RestModel;
+import org.dspace.app.rest.model.StagedUploadRest;
+import org.dspace.app.rest.utils.ContextUtil;
+import org.dspace.app.rest.utils.StagedUploadService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Staging of large files in bounded, individually authenticated requests, for any authenticated user.
+ * A staged upload is consumed later by a target endpoint, for example
+ * {@code POST /api/system/scripts/{name}/processes} with a JSON body. Raw chunk bodies are read inside
+ * the authorized method, so authentication happens before body consumption when proxies stream requests.
+ */
+@RestController
+@RequestMapping(StagedUploadsController.PATH)
+public class StagedUploadsController {
+    public static final String PATH = "/api/" + RestModel.CORE + "/uploads";
+    @Autowired
+    private StagedUploadService uploads;
+    @Autowired
+    private DiscoverableEndpointsService discoverableEndpointsService;
+
+    /** Advertise the resource as the {@code uploads} link of the API root. */
+    @PostConstruct
+    public void registerEndpoint() {
+        discoverableEndpointsService.register(this, List.of(Link.of(PATH, "uploads")));
+    }
+
+    /** Create an owner-bound upload after validating the complete file size; no data is received yet. */
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    public ResponseEntity<EntityModel<StagedUploadRest>> create(@Valid @RequestBody CreateStagedUploadRest input,
+                                                               HttpServletRequest request) throws Exception {
+        StagedUploadRest upload = uploads.create(owner(request), input.name(), input.size());
+        EntityModel<StagedUploadRest> resource = resource(upload);
+        return ResponseEntity.created(resource.getRequiredLink("self").toUri()).body(resource);
+    }
+
+    /** Read committed progress, or discover the result of an earlier handoff. */
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    public EntityModel<StagedUploadRest> get(@PathVariable UUID id, HttpServletRequest request) throws Exception {
+        return resource(uploads.get(owner(request), id));
+    }
+
+    /** Commit a bounded chunk at a byte offset; identical retries are idempotent. */
+    @PutMapping(value = "/{id}/chunks/{offset}", consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    public EntityModel<StagedUploadRest> put(@PathVariable UUID id, @PathVariable long offset,
+                                             HttpServletRequest request) throws Exception {
+        UUID user = owner(request);
+        return resource(uploads.put(user, id, offset, request.getInputStream()));
+    }
+
+    /** Cancel staging without affecting anything an earlier handoff created. */
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('AUTHENTICATED')")
+    public ResponseEntity<Void> delete(@PathVariable UUID id, HttpServletRequest request) throws Exception {
+        uploads.delete(owner(request), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    private UUID owner(HttpServletRequest request) {
+        return ContextUtil.obtainContext(request).getCurrentUser().getID();
+    }
+
+    private EntityModel<StagedUploadRest> resource(StagedUploadRest upload) {
+        String self = linkTo(StagedUploadsController.class).slash(upload.id()).toString();
+        EntityModel<StagedUploadRest> resource = EntityModel.of(upload,
+            Link.of(self).withSelfRel(), Link.of(self + "/chunks/{offset}").withRel("chunks"));
+        if (upload.result() != null) {
+            resource.add(Link.of(upload.result()).withRel("result"));
+        }
+        return resource;
+    }
+
+    /** Upload metadata; filenames are also validated by the staging service. */
+    public record CreateStagedUploadRest(@NotBlank @Size(max = 255) String name, @Positive long size) {
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/StagedScriptInvocationRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/StagedScriptInvocationRest.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * JSON body that starts a script process from previously staged uploads instead of a multipart request.
+ * @param properties the script parameters, as for a multipart invocation
+ * @param uploads identifiers of staged uploads to attach as input files, in order; may be empty
+ */
+public record StagedScriptInvocationRest(List<ParameterValueRest> properties, List<UUID> uploads) {
+    /** Treat absent lists as empty. */
+    public StagedScriptInvocationRest {
+        properties = properties == null ? List.of() : List.copyOf(properties);
+        uploads = uploads == null ? List.of() : List.copyOf(uploads);
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/StagedUploadRest.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/StagedUploadRest.java
@@ -1,0 +1,24 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.model;
+
+import java.util.UUID;
+
+/**
+ * Status of a staged upload. Received bytes are committed bytes, not progress of whatever consumes the file.
+ * @param id upload identifier
+ * @param name original file name
+ * @param size total file length
+ * @param chunkSize maximum bytes in one request
+ * @param receivedBytes committed file bytes
+ * @param state UPLOADING, CONSUMING, CONSUMED or FAILED
+ * @param result link of the resource created from this upload, once its handoff recorded one
+ */
+public record StagedUploadRest(UUID id, String name, long size, int chunkSize, long receivedBytes,
+                               String state, String result) {
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/ScriptRestRepository.java
@@ -8,12 +8,14 @@
 package org.dspace.app.rest.repository;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.IntConsumer;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -100,6 +102,23 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
     public ProcessRest startProcess(Context context, String scriptName, List<MultipartFile> files) throws SQLException,
         IOException, AuthorizeException, IllegalAccessException, InstantiationException {
         String properties = requestService.getCurrentRequest().getServletRequest().getParameter("properties");
+        return startProcess(context, scriptName, files, properties, id -> { });
+    }
+
+    /**
+     * Start a script with explicit properties, recording its process ID before file attachment and scheduling.
+     * The recorder allows a staged upload to retain the handoff identity across HTTP retries.
+     * @param context request context
+     * @param scriptName script to execute
+     * @param files staged input files
+     * @param properties serialized command line parameters
+     * @param recorder called once after process creation, before execution
+     * @return created process
+     * @throws Exception if process creation or scheduling fails
+     */
+    public ProcessRest startProcess(Context context, String scriptName, List<MultipartFile> files,
+                                    String properties, IntConsumer recorder) throws SQLException, IOException,
+        AuthorizeException, IllegalAccessException, InstantiationException {
         List<DSpaceCommandLineParameter> dSpaceCommandLineParameters =
             processPropertiesToDSpaceCommandLineParameters(properties);
         ScriptConfiguration scriptToExecute = scriptService.getScriptConfiguration(scriptName);
@@ -118,6 +137,7 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
         RestDSpaceRunnableHandler restDSpaceRunnableHandler = new RestDSpaceRunnableHandler(
             context.getCurrentUser(), scriptToExecute.getName(), dSpaceCommandLineParameters,
             new HashSet<>(context.getSpecialGroups()));
+        recorder.accept(restDSpaceRunnableHandler.getProcess(context).getID());
         List<String> args = constructArgs(dSpaceCommandLineParameters);
         runDSpaceScript(files, context, scriptToExecute, restDSpaceRunnableHandler, args);
         return converter.toRest(restDSpaceRunnableHandler.getProcess(context), utils.obtainProjection());
@@ -129,11 +149,19 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
         if (StringUtils.isNotBlank(propertiesJson)) {
             parameterValueRestList = Arrays.asList(mapper.readValue(propertiesJson, ParameterValueRest[].class));
         }
+        return toCommandLineParameters(parameterValueRestList);
+    }
 
+    /**
+     * Convert REST parameter values to the command line parameters a script configuration understands.
+     * @param parameters the parameter values
+     * @return the command line parameters, in order
+     */
+    public List<DSpaceCommandLineParameter> toCommandLineParameters(List<ParameterValueRest> parameters) {
         List<DSpaceCommandLineParameter> dSpaceCommandLineParameters = new LinkedList<>();
         dSpaceCommandLineParameters.addAll(
-            parameterValueRestList.stream().map(x -> dSpaceRunnableParameterConverter.toModel(x))
-                                  .collect(Collectors.toList()));
+            parameters.stream().map(x -> dSpaceRunnableParameterConverter.toModel(x))
+                      .collect(Collectors.toList()));
         return dSpaceCommandLineParameters;
     }
 
@@ -176,8 +204,9 @@ public class ScriptRestRepository extends DSpaceRestRepository<ScriptRest, Strin
                               List<MultipartFile> files)
         throws IOException, SQLException, AuthorizeException {
         for (MultipartFile file : files) {
-            restDSpaceRunnableHandler
-                .writeFilestream(context, file.getOriginalFilename(), file.getInputStream(), "inputfile");
+            try (InputStream input = file.getInputStream()) {
+                restDSpaceRunnableHandler.writeFilestream(context, file.getOriginalFilename(), input, "inputfile");
+            }
         }
     }
 

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/StagedUploadService.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/StagedUploadService.java
@@ -1,0 +1,503 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.dspace.app.rest.model.StagedUploadRest;
+import org.dspace.services.ConfigurationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Disk-backed, bounded staging of uploads for any authenticated user. A file arrives in sequential
+ * chunks and is later consumed by a target endpoint (a script process, a workspace item, ...) that
+ * reads it as a {@link MultipartFile}. Every operation locks its upload on disk, so retries and
+ * backend nodes sharing a filesystem cannot modify the same upload concurrently. Upload directories
+ * and their contents are exclusively managed by this service.
+ */
+@Service
+public class StagedUploadService {
+    public static final String UPLOADING = "UPLOADING";
+    public static final String CONSUMING = "CONSUMING";
+    public static final String CONSUMED = "CONSUMED";
+    public static final String FAILED = "FAILED";
+    private static final Logger log = LogManager.getLogger();
+    private final Path root;
+    private final long maxSize;
+    private final int chunkSize;
+    private final int maxPerUser;
+    private final Duration retention;
+    private final Clock clock;
+
+    /** Initialize staging from DSpace configuration. */
+    @Autowired
+    public StagedUploadService(ConfigurationService configuration, MultipartProperties multipart) {
+        this(Path.of(configuration.getProperty("staged-upload.directory",
+                 configuration.getProperty("dspace.dir") + "/var/staged-uploads")),
+             multipart.getMaxFileSize().toBytes() < 0 ? Long.MAX_VALUE : multipart.getMaxFileSize().toBytes(),
+             (int) Math.min(configuration.getIntProperty("staged-upload.chunk-size", 8 * 1024 * 1024),
+                 multipart.getMaxRequestSize().toBytes() < 0 ? Integer.MAX_VALUE
+                     : multipart.getMaxRequestSize().toBytes()),
+             configuration.getIntProperty("staged-upload.max-active-per-user", 8),
+             Duration.ofHours(configuration.getIntProperty("staged-upload.retention-hours", 24)),
+             Clock.systemUTC());
+    }
+
+    /** Initialize an isolated store, also used by filesystem tests. */
+    public StagedUploadService(Path root, long maxSize, int chunkSize, int maxPerUser, Duration retention,
+                               Clock clock) {
+        if (maxSize <= 0 || chunkSize <= 0 || maxPerUser <= 0 || retention.isNegative() || retention.isZero()) {
+            throw new IllegalArgumentException("Staged upload limits must be positive");
+        }
+        this.root = root;
+        this.maxSize = maxSize;
+        this.chunkSize = chunkSize;
+        this.maxPerUser = maxPerUser;
+        this.retention = retention;
+        this.clock = clock;
+    }
+
+    /** Create an upload owned by the authenticated user, reserving one of that user's staging slots. */
+    public StagedUploadRest create(UUID owner, String name, long size) throws IOException {
+        if (name == null || name.isBlank() || name.length() > 255 || name.contains("..")
+            || name.contains("/") || name.contains("\\") || name.chars().anyMatch(Character::isISOControl)) {
+            throw failure(HttpStatus.BAD_REQUEST, "Invalid filename");
+        }
+        if (size <= 0 || size > maxSize) {
+            throw failure(HttpStatus.PAYLOAD_TOO_LARGE, "Maximum file size is " + maxSize + " bytes");
+        }
+        Files.createDirectories(root);
+        try (FileChannel channel = FileChannel.open(root.resolve("creation.lock"),
+                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock lock = acquire(channel)) {
+            if (activeUploadsOf(owner) >= maxPerUser) {
+                throw failure(HttpStatus.TOO_MANY_REQUESTS, "Too many active uploads for this user");
+            }
+            UUID id = UUID.randomUUID();
+            Path directory = Files.createDirectory(root.resolve(id.toString()));
+            Properties metadata = new Properties();
+            metadata.setProperty("owner", owner.toString());
+            metadata.setProperty("name", name);
+            metadata.setProperty("size", Long.toString(size));
+            metadata.setProperty("chunkSize", Integer.toString(chunkSize));
+            try (OutputStream output = Files.newOutputStream(directory.resolve("metadata"))) {
+                metadata.store(output, "Staged upload");
+            }
+            touch(directory);
+            return status(directory, id, metadata);
+        }
+    }
+
+    /** Read committed progress, enforcing ownership even for administrators. */
+    public StagedUploadRest get(UUID owner, UUID id) throws Exception {
+        return locked(owner, id, (directory, metadata) -> status(directory, id, metadata));
+    }
+
+    /**
+     * Commit the next chunk atomically. A retry at an earlier offset must have identical bytes.
+     * Partial bodies are never counted as committed progress.
+     */
+    public StagedUploadRest put(UUID owner, UUID id, long offset, InputStream input) throws Exception {
+        return locked(owner, id, (directory, metadata) -> {
+            StagedUploadRest current = status(directory, id, metadata);
+            if (!UPLOADING.equals(current.state())) {
+                throw failure(HttpStatus.CONFLICT, "Upload is already being consumed");
+            }
+            if (offset < 0 || offset >= current.size() || offset % current.chunkSize() != 0
+                || offset > current.receivedBytes()) {
+                throw failure(HttpStatus.CONFLICT, "Chunk offset does not match committed upload data");
+            }
+            long expected = Math.min(current.chunkSize(), current.size() - offset);
+            Path temporary = Files.createTempFile(directory, "chunk-", ".tmp");
+            try {
+                try (OutputStream output = Files.newOutputStream(temporary)) {
+                    copyExactly(input, output, expected);
+                }
+                Path chunk = directory.resolve(offset + ".part");
+                if (Files.exists(chunk)) {
+                    if (Files.mismatch(temporary, chunk) != -1) {
+                        throw failure(HttpStatus.CONFLICT, "Retried chunk differs from committed data");
+                    }
+                } else {
+                    Files.move(temporary, chunk, StandardCopyOption.ATOMIC_MOVE);
+                }
+                touch(directory);
+                return status(directory, id, metadata);
+            } finally {
+                Files.deleteIfExists(temporary);
+            }
+        });
+    }
+
+    /**
+     * Hand complete uploads to a target once. The target records the link of what it created as soon
+     * as that exists, before anything that can still fail, so a repeated request returns the same
+     * result instead of consuming again. Uploads are locked in identifier order. A crash between the
+     * target's action and its receipt leaves CONSUMING markers that are deliberately never retried.
+     * @param owner the authenticated user
+     * @param ids uploads to consume together, all complete and owned by the user
+     * @param target the consumer of the staged files
+     * @return the recorded result link
+     * @throws Exception whatever the target throws; the uploads are then marked FAILED
+     */
+    public String consume(UUID owner, List<UUID> ids, Target target) throws Exception {
+        List<UUID> ordered = ids == null ? List.of() : ids.stream().distinct().sorted().toList();
+        if (ordered.isEmpty()) {
+            throw failure(HttpStatus.BAD_REQUEST, "No uploads to consume");
+        }
+        return lockedAll(owner, ordered, new ArrayList<>(), uploads -> {
+            List<String> results = uploads.stream().map(upload -> readMarker(upload.directory(), "result")).toList();
+            if (results.stream().allMatch(Objects::nonNull) && results.stream().distinct().count() == 1) {
+                return results.get(0);
+            }
+            for (Locked upload : uploads) {
+                StagedUploadRest current = status(upload.directory(), upload.id(), upload.metadata());
+                if (!UPLOADING.equals(current.state()) || current.receivedBytes() != current.size()) {
+                    throw failure(HttpStatus.CONFLICT,
+                                  "Upload " + upload.id() + " is incomplete or has already been consumed");
+                }
+            }
+            List<MultipartFile> files = new ArrayList<>();
+            for (Locked upload : uploads) {
+                StagedUploadRest current = status(upload.directory(), upload.id(), upload.metadata());
+                Path assembled = upload.directory().resolve("bundle");
+                try (OutputStream output = Files.newOutputStream(assembled)) {
+                    for (long offset = 0; offset < current.size(); offset += current.chunkSize()) {
+                        Files.copy(upload.directory().resolve(offset + ".part"), output);
+                    }
+                }
+                writeMarker(upload.directory().resolve("state"), CONSUMING);
+                touch(upload.directory());
+                files.add(new StagedFile(assembled, current.name()));
+            }
+            try {
+                String result = target.consume(files, value -> {
+                    try {
+                        if (value == null || value.isBlank()) {
+                            throw new IOException("Invalid result receipt");
+                        }
+                        for (Locked upload : uploads) {
+                            if (Files.exists(upload.directory().resolve("result"))) {
+                                throw new IOException("Duplicate result receipt for upload " + upload.id());
+                            }
+                            writeMarker(upload.directory().resolve("result"), value);
+                        }
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+                for (Locked upload : uploads) {
+                    if (!Objects.equals(result, readMarker(upload.directory(), "result"))) {
+                        throw new IOException("Result receipt does not match the target's result");
+                    }
+                    removeData(upload.directory());
+                    writeMarker(upload.directory().resolve("state"), CONSUMED);
+                }
+                return result;
+            } catch (Exception e) {
+                for (Locked upload : uploads) {
+                    writeMarker(upload.directory().resolve("state"), FAILED);
+                }
+                throw e;
+            }
+        });
+    }
+
+    /** Cancel staging; this never deletes what an earlier handoff created. */
+    public void delete(UUID owner, UUID id) throws Exception {
+        locked(owner, id, (directory, metadata) -> {
+            if (Files.exists(directory.resolve("state"))) {
+                throw failure(HttpStatus.CONFLICT, "Uploads that are being or have been consumed cannot be cancelled");
+            }
+            removeData(directory);
+            Files.delete(directory.resolve("metadata"));
+            return null;
+        });
+    }
+
+    /** Remove expired staging data and handoff receipts, skipping uploads a request currently holds. */
+    @Scheduled(fixedDelay = 3600000)
+    public void cleanup() throws IOException {
+        if (!Files.isDirectory(root)) {
+            return;
+        }
+        try (FileChannel channel = FileChannel.open(root.resolve("creation.lock"),
+                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock lock = acquire(channel);
+             Stream<Path> entries = Files.list(root)) {
+            for (Path directory : entries.filter(Files::isDirectory).toList()) {
+                try {
+                    UUID id = UUID.fromString(directory.getFileName().toString());
+                    locked(null, id, (path, metadata) -> {
+                        if (Files.exists(path.resolve("metadata"))
+                            && Files.getLastModifiedTime(path.resolve("metadata"))
+                            .toInstant().plus(retention).isAfter(clock.instant())) {
+                            return null;
+                        }
+                        removeData(path);
+                        Files.deleteIfExists(path.resolve("metadata"));
+                        Files.deleteIfExists(path.resolve("state"));
+                        Files.deleteIfExists(path.resolve("result"));
+                        return null;
+                    });
+                    // Keep the lock inode until no metadata remains; identifiers are never reused.
+                    if (!Files.exists(directory.resolve("metadata"))) {
+                        Files.deleteIfExists(directory.resolve("lock"));
+                        Files.deleteIfExists(directory);
+                    }
+                } catch (ResponseStatusException e) {
+                    // Busy or already removed by another node.
+                } catch (Exception e) {
+                    log.warn("Could not clean staged upload {}", directory.getFileName(), e);
+                }
+            }
+        }
+    }
+
+    private long activeUploadsOf(UUID owner) throws IOException {
+        try (Stream<Path> entries = Files.list(root)) {
+            return entries.filter(Files::isDirectory).filter(path -> Files.exists(path.resolve("metadata")))
+                          .filter(path -> owner.toString().equals(readOwner(path)))
+                          .filter(path -> !CONSUMED.equals(readMarker(path, "state"))).count();
+        }
+    }
+
+    private String readOwner(Path directory) {
+        Properties metadata = new Properties();
+        try (InputStream input = Files.newInputStream(directory.resolve("metadata"))) {
+            metadata.load(input);
+        } catch (IOException e) {
+            return null;
+        }
+        return metadata.getProperty("owner");
+    }
+
+    private <T> T locked(UUID owner, UUID id, Operation<T> operation) throws Exception {
+        Path directory = root.resolve(id.toString());
+        if (!Files.isDirectory(directory)) {
+            throw failure(HttpStatus.NOT_FOUND, "Upload not found");
+        }
+        try (FileChannel channel = FileChannel.open(directory.resolve("lock"),
+                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock lock = acquire(channel)) {
+            Properties metadata = new Properties();
+            if (Files.exists(directory.resolve("metadata"))) {
+                try (InputStream input = Files.newInputStream(directory.resolve("metadata"))) {
+                    metadata.load(input);
+                }
+            }
+            if (owner != null && !owner.toString().equals(metadata.getProperty("owner"))) {
+                throw failure(HttpStatus.NOT_FOUND, "Upload not found");
+            }
+            return operation.run(directory, metadata);
+        }
+    }
+
+    private <T> T lockedAll(UUID owner, List<UUID> ids, List<Locked> acquired, MultiOperation<T> operation)
+        throws Exception {
+        if (acquired.size() == ids.size()) {
+            return operation.run(acquired);
+        }
+        UUID id = ids.get(acquired.size());
+        return locked(owner, id, (directory, metadata) -> {
+            acquired.add(new Locked(id, directory, metadata));
+            return lockedAll(owner, ids, acquired, operation);
+        });
+    }
+
+    private FileLock acquire(FileChannel channel) throws IOException {
+        try {
+            FileLock lock = channel.tryLock();
+            if (lock != null) {
+                return lock;
+            }
+        } catch (OverlappingFileLockException e) {
+            // Another thread in this JVM is operating on this upload.
+        }
+        throw failure(HttpStatus.CONFLICT, "Upload is busy; retry later");
+    }
+
+    private StagedUploadRest status(Path directory, UUID id, Properties metadata) throws IOException {
+        long size = Long.parseLong(metadata.getProperty("size"));
+        int blockSize = Integer.parseInt(metadata.getProperty("chunkSize"));
+        String result = readMarker(directory, "result");
+        String state = readMarker(directory, "state");
+        if (state == null) {
+            state = UPLOADING;
+        }
+        long received = 0;
+        while (received < size && Files.exists(directory.resolve(received + ".part"))) {
+            long length = Files.size(directory.resolve(received + ".part"));
+            if (length != Math.min(blockSize, size - received)) {
+                throw new IOException("Invalid stored chunk length");
+            }
+            received += length;
+        }
+        return new StagedUploadRest(id, metadata.getProperty("name"), size, blockSize,
+                                    CONSUMED.equals(state) ? size : received, state, result);
+    }
+
+    private void touch(Path directory) throws IOException {
+        Files.setLastModifiedTime(directory.resolve("metadata"), FileTime.from(clock.instant()));
+    }
+
+    private String readMarker(Path directory, String name) {
+        try {
+            return Files.exists(directory.resolve(name)) ? Files.readString(directory.resolve(name)) : null;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /** Publish complete markers atomically, never a partially written receipt. */
+    private void writeMarker(Path destination, String value) throws IOException {
+        Path temporary = Files.createTempFile(destination.getParent(), "marker-", ".tmp");
+        try {
+            Files.writeString(temporary, value);
+            try (FileChannel channel = FileChannel.open(temporary, StandardOpenOption.WRITE)) {
+                channel.force(true);
+            }
+            Files.move(temporary, destination, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private void removeData(Path directory) throws IOException {
+        try (Stream<Path> entries = Files.list(directory)) {
+            for (Path file : entries.toList()) {
+                String name = file.getFileName().toString();
+                if (name.endsWith(".part") || name.endsWith(".tmp") || name.equals("bundle")) {
+                    Files.deleteIfExists(file);
+                }
+            }
+        }
+    }
+
+    private void copyExactly(InputStream input, OutputStream output, long expected) throws IOException {
+        byte[] buffer = new byte[8192];
+        long remaining = expected;
+        while (remaining > 0) {
+            int length = input.read(buffer, 0, (int) Math.min(buffer.length, remaining));
+            if (length == -1) {
+                throw failure(HttpStatus.BAD_REQUEST, "Incomplete chunk");
+            }
+            output.write(buffer, 0, length);
+            remaining -= length;
+        }
+        if (input.read() != -1) {
+            throw failure(HttpStatus.PAYLOAD_TOO_LARGE, "Chunk exceeds expected length");
+        }
+    }
+
+    private static ResponseStatusException failure(HttpStatus status, String message) {
+        return new ResponseStatusException(status, message);
+    }
+
+    @FunctionalInterface
+    private interface Operation<T> {
+        T run(Path directory, Properties metadata) throws Exception;
+    }
+
+    @FunctionalInterface
+    private interface MultiOperation<T> {
+        T run(List<Locked> uploads) throws Exception;
+    }
+
+    private record Locked(UUID id, Path directory, Properties metadata) {
+    }
+
+    /** Adapter to whatever consumes staged files. */
+    @FunctionalInterface
+    public interface Target {
+        /**
+         * Consume the files. Record the link of the created resource as soon as it exists, before any step
+         * that can still fail, so a retried handoff can return it.
+         * @param files the staged files, in the order of the requested upload identifiers
+         * @param recordResult receives the link of the created resource, exactly once
+         * @return that same link
+         * @throws Exception if consuming fails
+         */
+        String consume(List<MultipartFile> files, Consumer<String> recordResult) throws Exception;
+    }
+
+    private record StagedFile(Path path, String filename) implements MultipartFile {
+        @Override
+        public String getName() {
+            return "file";
+        }
+
+        @Override
+        public String getOriginalFilename() {
+            return filename;
+        }
+
+        @Override
+        public String getContentType() {
+            return "application/octet-stream";
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return getSize() == 0;
+        }
+
+        @Override
+        public long getSize() {
+            try {
+                return Files.size(path);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public byte[] getBytes() throws IOException {
+            return Files.readAllBytes(path);
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return Files.newInputStream(path);
+        }
+
+        @Override
+        public void transferTo(File destination) throws IOException {
+            Files.copy(path, destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StagedUploadsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StagedUploadsControllerIT.java
@@ -1,0 +1,250 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest;
+
+import static com.jayway.jsonpath.JsonPath.read;
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.Assert.assertArrayEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dspace.app.rest.model.StagedUploadRest;
+import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.app.rest.utils.StagedUploadService;
+import org.dspace.builder.CollectionBuilder;
+import org.dspace.builder.CommunityBuilder;
+import org.dspace.builder.ProcessBuilder;
+import org.dspace.content.Collection;
+import org.dspace.content.service.BitstreamService;
+import org.dspace.scripts.Process;
+import org.dspace.scripts.service.ProcessService;
+import org.dspace.services.ConfigurationService;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+
+/** Exercise staging with real REST authentication and the JSON script invocation that consumes it. */
+@Import(StagedUploadsControllerIT.UploadConfiguration.class)
+public class StagedUploadsControllerIT extends AbstractControllerIntegrationTest {
+    private static final String ENDPOINT = "/api/core/uploads";
+    private static final String IMPORT = "/api/system/scripts/import/processes";
+    @ClassRule
+    public static TemporaryFolder temporary = new TemporaryFolder();
+    @Autowired
+    private StagedUploadService uploads;
+    @Autowired
+    private ObjectMapper mapper;
+    @Autowired
+    private ProcessService processes;
+    @Autowired
+    private BitstreamService bitstreams;
+    @Autowired
+    private ConfigurationService configuration;
+
+    @Test
+    public void creationValidatesSizeAndIsDiscoverableFromTheApiRoot() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+        getClient(token).perform(get("/api"))
+            .andExpect(jsonPath("$._links.uploads.href", endsWith(ENDPOINT)));
+        getClient(token).perform(post(ENDPOINT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"too-large.zip\",\"size\":1048577}"))
+            .andExpect(status().isPayloadTooLarge());
+        getClient(token).perform(post(ENDPOINT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"../unsafe.zip\",\"size\":4}"))
+            .andExpect(status().isBadRequest());
+        String receipt = getClient(token).perform(post(ENDPOINT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"batch.zip\",\"size\":4}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.receivedBytes").value(0))
+            .andExpect(jsonPath("$.chunkSize").value(1024))
+            .andExpect(jsonPath("$.state").value("UPLOADING"))
+            .andExpect(jsonPath("$._links.chunks.templated").value(true))
+            .andExpect(jsonPath("$._links.result").doesNotExist())
+            .andReturn().getResponse().getContentAsString();
+        String id = read(receipt, "$.id");
+        getClient(token).perform(delete(ENDPOINT + "/" + id)).andExpect(status().isNoContent());
+        getClient(token).perform(get(ENDPOINT + "/" + id)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void everyOperationRequiresAuthentication() throws Exception {
+        String path = ENDPOINT + "/" + UUID.randomUUID();
+        getClient().perform(post(ENDPOINT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"name\":\"batch.zip\",\"size\":4}")).andExpect(status().isUnauthorized());
+        getClient().perform(get(path)).andExpect(status().isUnauthorized());
+        getClient().perform(put(path + "/chunks/0").contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .content(new byte[] {1, 2, 3, 4})).andExpect(status().isUnauthorized());
+        getClient().perform(delete(path)).andExpect(status().isUnauthorized());
+        getClient().perform(post(IMPORT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"properties\":[],\"uploads\":[\"" + UUID.randomUUID() + "\"]}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void ownershipIsEnforcedEvenForAnAdministrator() throws Exception {
+        StagedUploadRest upload = uploads.create(eperson.getID(), "private.zip", 4);
+        String path = ENDPOINT + "/" + upload.id();
+        String token = getAuthToken(admin.getEmail(), password);
+        getClient(token).perform(get(path)).andExpect(status().isNotFound());
+        getClient(token).perform(put(path + "/chunks/0").contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .content(new byte[] {1, 2, 3, 4})).andExpect(status().isNotFound());
+        getClient(token).perform(delete(path)).andExpect(status().isNotFound());
+        getClient(token).perform(post(IMPORT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"properties\":[{\"name\":\"--add\"}],\"uploads\":[\"" + upload.id() + "\"]}"))
+            .andExpect(status().isNotFound());
+        uploads.delete(eperson.getID(), upload.id());
+    }
+
+    @Test
+    public void incompleteAndOversizedChunksCannotAdvanceOrBeConsumed() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        StagedUploadRest upload = uploads.create(admin.getID(), "batch.zip", 4);
+        String path = ENDPOINT + "/" + upload.id();
+        getClient(token).perform(put(path + "/chunks/0").contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .content(new byte[] {1, 2})).andExpect(status().isBadRequest());
+        getClient(token).perform(put(path + "/chunks/0").contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .content(new byte[] {1, 2, 3, 4, 5})).andExpect(status().isPayloadTooLarge());
+        getClient(token).perform(get(path)).andExpect(jsonPath("$.receivedBytes").value(0));
+        getClient(token).perform(post(IMPORT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"properties\":[{\"name\":\"--add\"}],\"uploads\":[\"" + upload.id() + "\"]}"))
+            .andExpect(status().isConflict());
+        uploads.delete(admin.getID(), upload.id());
+    }
+
+    @Test
+    public void aUserWhoMayNotRunTheScriptKeepsTheUploadResumable() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+        StagedUploadRest upload = uploads.create(eperson.getID(), "batch.zip", 4);
+        String path = ENDPOINT + "/" + upload.id();
+        getClient(token).perform(put(path + "/chunks/0").contentType(MediaType.APPLICATION_OCTET_STREAM)
+            .content(new byte[] {1, 2, 3, 4})).andExpect(status().isOk());
+        getClient(token).perform(post(IMPORT).contentType(MediaType.APPLICATION_JSON)
+            .content("{\"properties\":[{\"name\":\"--add\"}],\"uploads\":[\"" + upload.id() + "\"]}"))
+            .andExpect(status().isForbidden());
+        getClient(token).perform(get(path))
+            .andExpect(jsonPath("$.state").value("UPLOADING"))
+            .andExpect(jsonPath("$.receivedBytes").value(4));
+        uploads.delete(eperson.getID(), upload.id());
+    }
+
+    @Test
+    public void stagedFileBecomesOneNormalProcessWithItsInputFile() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context).withName("SAF community").build();
+        Collection collection = CollectionBuilder.createCollection(context, parentCommunity)
+            .withName("SAF collection").build();
+        context.restoreAuthSystemState();
+        Files.createDirectories(Path.of(configuration.getProperty("org.dspace.app.batchitemimport.work.dir")));
+        byte[] file;
+        try (InputStream input = getClass().getResourceAsStream("/org/dspace/app/itemimport/saf-bitstreams.zip")) {
+            file = input.readAllBytes();
+        }
+        String token = getAuthToken(admin.getEmail(), password);
+        String receipt = getClient(token).perform(post(ENDPOINT).contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsString(Map.of("name", "batch.zip", "size", file.length))))
+            .andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
+        String id = read(receipt, "$.id");
+        String path = ENDPOINT + "/" + id;
+        for (int offset = 0; offset < file.length; offset += 1024) {
+            byte[] chunk = Arrays.copyOfRange(file, offset, Math.min(offset + 1024, file.length));
+            // Repeat every PUT to simulate a lost acknowledgement.
+            for (int attempt = 0; attempt < 2; attempt++) {
+                getClient(token).perform(put(path + "/chunks/" + offset)
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM).content(chunk))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.receivedBytes").value(offset + chunk.length));
+            }
+        }
+        String body = mapper.writeValueAsString(Map.of(
+            "properties", List.of(Map.of("name", "--add"), Map.of("name", "--zip", "value", "batch.zip"),
+                Map.of("name", "-v"), Map.of("name", "--collection", "value", collection.getID().toString())),
+            "uploads", List.of(id)));
+        Integer processId = null;
+        try {
+            String response = getClient(token).perform(post(IMPORT)
+                .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isAccepted()).andReturn().getResponse().getContentAsString();
+            processId = read(response, "$.processId");
+            getClient(token).perform(post(IMPORT).contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isAccepted()).andExpect(jsonPath("$.processId").value(processId));
+            getClient(token).perform(get("/api/system/processes/" + processId))
+                .andExpect(status().isOk()).andExpect(jsonPath("$.processStatus").value("COMPLETED"));
+            getClient(token).perform(get(path))
+                .andExpect(jsonPath("$.state").value("CONSUMED"))
+                .andExpect(jsonPath("$.receivedBytes").value(file.length))
+                .andExpect(jsonPath("$._links.result.href", endsWith("/api/system/processes/" + processId)));
+            Process process = processes.find(context, processId);
+            // Process input files are readable by their creator; the test context user is a plain eperson.
+            context.turnOffAuthorisationSystem();
+            try (InputStream input = bitstreams.retrieve(context,
+                processes.getBitstreamByName(context, process, "batch.zip"))) {
+                assertArrayEquals(file, input.readAllBytes());
+            } finally {
+                context.restoreAuthSystemState();
+            }
+        } finally {
+            if (processId != null) {
+                ProcessBuilder.deleteProcess(processId);
+            }
+        }
+    }
+
+    @Test
+    public void jsonInvocationWithoutUploadsStartsAProcess() throws Exception {
+        String token = getAuthToken(admin.getEmail(), password);
+        String body = mapper.writeValueAsString(Map.of(
+            "properties", List.of(Map.of("name", "-r", "value", "test"), Map.of("name", "-i")),
+            "uploads", List.of()));
+        Integer processId = null;
+        try {
+            String response = getClient(token).perform(post("/api/system/scripts/mock-script/processes")
+                .contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.scriptName").value("mock-script"))
+                .andReturn().getResponse().getContentAsString();
+            processId = read(response, "$.processId");
+        } finally {
+            if (processId != null) {
+                ProcessBuilder.deleteProcess(processId);
+            }
+        }
+    }
+
+    /** Isolated staging, with deliberately small chunks to exercise the complete HTTP flow. */
+    @TestConfiguration
+    public static class UploadConfiguration {
+        /** Keep test staging outside the normal test installation's configuration. */
+        @Bean
+        @Primary
+        public StagedUploadService testStagedUploads() {
+            return new StagedUploadService(temporary.getRoot().toPath(), 1048576, 1024, 10,
+                                           Duration.ofHours(1), Clock.systemUTC());
+        }
+    }
+}

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/StagedUploadServiceTest.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/StagedUploadServiceTest.java
@@ -1,0 +1,262 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.app.rest.utils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.dspace.app.rest.model.StagedUploadRest;
+import org.dspace.services.ConfigurationService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.server.ResponseStatusException;
+
+public class StagedUploadServiceTest {
+    private static final String RESULT = "/api/system/processes/42";
+    @Rule
+    public TemporaryFolder temporary = new TemporaryFolder();
+    private final UUID owner = UUID.randomUUID();
+    private final Clock clock = Clock.fixed(Instant.parse("2026-01-01T00:00:00Z"), ZoneOffset.UTC);
+    private Path directory;
+    private StagedUploadService service;
+
+    @Before
+    public void setUp() {
+        directory = temporary.getRoot().toPath();
+        service = store(clock);
+    }
+
+    private StagedUploadService store(Clock time) {
+        return new StagedUploadService(directory, 20, 4, 2, Duration.ofHours(1), time);
+    }
+
+    @Test
+    public void existingMultipartLimitsApplyBeforeReservingAnUpload() throws Exception {
+        ConfigurationService configuration = mock(ConfigurationService.class);
+        when(configuration.getProperty(anyString(), anyString())).thenReturn(directory.toString());
+        when(configuration.getIntProperty(anyString(), anyInt())).thenAnswer(call -> call.getArgument(1));
+        MultipartProperties multipart = new MultipartProperties();
+        multipart.setMaxFileSize(DataSize.ofBytes(6));
+        multipart.setMaxRequestSize(DataSize.ofBytes(4));
+        StagedUploadService configured = new StagedUploadService(configuration, multipart);
+        assertEquals(413, assertThrows(ResponseStatusException.class,
+            () -> configured.create(owner, "too-large.zip", 7)).getStatusCode().value());
+        try (var entries = Files.list(directory)) {
+            assertEquals(0, entries.count());
+        }
+        StagedUploadRest upload = configured.create(owner, "allowed.zip", 6);
+        assertEquals(4, upload.chunkSize());
+        assertEquals(0, upload.receivedBytes());
+    }
+
+    @Test
+    public void retriesAndRestartPreserveCommittedBytes() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 6);
+        assertEquals(4, service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4)).receivedBytes());
+        service = store(clock);
+        assertEquals(4, service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4)).receivedBytes());
+        assertEquals(6, service.put(owner, upload.id(), 4, bytes(5, 6)).receivedBytes());
+        AtomicInteger calls = new AtomicInteger();
+        assertEquals(RESULT, service.consume(owner, List.of(upload.id()), (files, record) -> {
+            calls.incrementAndGet();
+            assertEquals(1, files.size());
+            assertEquals("bundle.zip", files.get(0).getOriginalFilename());
+            try (InputStream input = files.get(0).getInputStream()) {
+                assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 6}, input.readAllBytes());
+            }
+            record.accept(RESULT);
+            return RESULT;
+        }));
+        service = store(clock);
+        assertEquals(RESULT, service.consume(owner, List.of(upload.id()), (files, record) -> {
+            calls.incrementAndGet();
+            return "/api/system/processes/99";
+        }));
+        assertEquals(1, calls.get());
+        StagedUploadRest consumed = service.get(owner, upload.id());
+        assertEquals(StagedUploadService.CONSUMED, consumed.state());
+        assertEquals(RESULT, consumed.result());
+        assertFalse(Files.exists(directory.resolve(upload.id().toString()).resolve("bundle")));
+    }
+
+    @Test
+    public void severalUploadsAreConsumedTogetherAndOnlyOnce() throws Exception {
+        StagedUploadRest first = service.create(owner, "first.bin", 4);
+        StagedUploadRest second = service.create(owner, "second.bin", 2);
+        service.put(owner, first.id(), 0, bytes(1, 2, 3, 4));
+        service.put(owner, second.id(), 0, bytes(5, 6));
+        AtomicInteger calls = new AtomicInteger();
+        List<UUID> ordered = List.of(first.id(), second.id()).stream().sorted().toList();
+        assertEquals(RESULT, service.consume(owner, List.of(second.id(), first.id()), (files, record) -> {
+            calls.incrementAndGet();
+            assertEquals(2, files.size());
+            assertEquals(ordered.get(0).equals(first.id()) ? "first.bin" : "second.bin",
+                         files.get(0).getOriginalFilename());
+            record.accept(RESULT);
+            return RESULT;
+        }));
+        assertEquals(RESULT, service.consume(owner, List.of(first.id(), second.id()), (files, record) -> RESULT));
+        assertEquals(RESULT, service.consume(owner, List.of(second.id()), (files, record) -> RESULT));
+        assertEquals(1, calls.get());
+        // a consumed upload cannot be combined with a fresh one
+        service = new StagedUploadService(directory, 20, 4, 3, Duration.ofHours(1), clock);
+        StagedUploadRest third = service.create(owner, "third.bin", 4);
+        service.put(owner, third.id(), 0, bytes(7, 8, 9, 0));
+        assertEquals(409, assertThrows(ResponseStatusException.class, () -> service.consume(owner,
+            List.of(first.id(), third.id()), (files, record) -> RESULT)).getStatusCode().value());
+        assertEquals(StagedUploadService.UPLOADING, service.get(owner, third.id()).state());
+    }
+
+    @Test
+    public void partialAndOversizedBodiesNeverCommit() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 6);
+        assertEquals(400, assertThrows(ResponseStatusException.class,
+            () -> service.put(owner, upload.id(), 0, bytes(1, 2))).getStatusCode().value());
+        assertEquals(413, assertThrows(ResponseStatusException.class,
+            () -> service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4, 5))).getStatusCode().value());
+        assertEquals(0, service.get(owner, upload.id()).receivedBytes());
+    }
+
+    @Test
+    public void changedRetriesAndOutOfOrderChunksAreRejected() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 6);
+        assertThrows(ResponseStatusException.class, () -> service.put(owner, upload.id(), 4, bytes(5, 6)));
+        service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4));
+        assertEquals(409, assertThrows(ResponseStatusException.class,
+            () -> service.put(owner, upload.id(), 0, bytes(4, 3, 2, 1))).getStatusCode().value());
+        assertThrows(ResponseStatusException.class, () -> service.put(owner, upload.id(), -4, bytes(1, 2, 3, 4)));
+        assertThrows(ResponseStatusException.class, () -> service.put(owner, upload.id(), 1, bytes(1, 2, 3, 4)));
+        assertEquals(4, service.get(owner, upload.id()).receivedBytes());
+    }
+
+    @Test
+    public void anotherUserCannotReadWriteConsumeOrDelete() throws Exception {
+        UUID stranger = UUID.randomUUID();
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 4);
+        service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4));
+        assertEquals(404, assertThrows(ResponseStatusException.class,
+            () -> service.get(stranger, upload.id())).getStatusCode().value());
+        assertThrows(ResponseStatusException.class, () -> service.put(stranger, upload.id(), 0, bytes(1, 2, 3, 4)));
+        assertThrows(ResponseStatusException.class, () -> service.delete(stranger, upload.id()));
+        assertEquals(404, assertThrows(ResponseStatusException.class, () -> service.consume(stranger,
+            List.of(upload.id()), (files, record) -> RESULT)).getStatusCode().value());
+        assertEquals(StagedUploadService.UPLOADING, service.get(owner, upload.id()).state());
+    }
+
+    @Test
+    public void incompleteUploadCannotBeConsumed() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 6);
+        service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4));
+        AtomicInteger calls = new AtomicInteger();
+        assertEquals(409, assertThrows(ResponseStatusException.class, () -> service.consume(owner,
+            List.of(upload.id()), (files, record) -> {
+                calls.incrementAndGet();
+                return RESULT;
+            })).getStatusCode().value());
+        assertEquals(0, calls.get());
+        assertEquals(400, assertThrows(ResponseStatusException.class,
+            () -> service.consume(owner, List.of(), (files, record) -> RESULT)).getStatusCode().value());
+    }
+
+    @Test
+    public void failedHandoffWithKnownResultReturnsThatResult() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 4);
+        service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4));
+        assertThrows(IOException.class, () -> service.consume(owner, List.of(upload.id()), (files, record) -> {
+            record.accept(RESULT);
+            throw new IOException("Connection lost after the process was created");
+        }));
+        assertEquals(StagedUploadService.FAILED, service.get(owner, upload.id()).state());
+        assertEquals(RESULT, service.consume(owner, List.of(upload.id()), (files, record) -> "other"));
+    }
+
+    @Test
+    public void uncertainHandoffNeverConsumesAgain() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 4);
+        service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4));
+        assertThrows(IOException.class, () -> service.consume(owner, List.of(upload.id()), (files, record) -> {
+            throw new IOException("Outcome unknown");
+        }));
+        assertEquals(409, assertThrows(ResponseStatusException.class, () -> service.consume(owner,
+            List.of(upload.id()), (files, record) -> RESULT)).getStatusCode().value());
+        assertEquals(409, assertThrows(ResponseStatusException.class,
+            () -> service.delete(owner, upload.id())).getStatusCode().value());
+    }
+
+    @Test
+    public void cancelledAndExpiredUploadsAreRemoved() throws Exception {
+        StagedUploadRest cancelled = service.create(owner, "cancel.zip", 4);
+        service.delete(owner, cancelled.id());
+        assertThrows(ResponseStatusException.class, () -> service.get(owner, cancelled.id()));
+        StagedUploadRest expired = service.create(owner, "expire.zip", 4);
+        service.put(owner, expired.id(), 0, bytes(1, 2, 3, 4));
+        store(Clock.offset(clock, Duration.ofHours(2))).cleanup();
+        assertFalse(Files.exists(directory.resolve(expired.id().toString())));
+        assertFalse(Files.exists(directory.resolve(cancelled.id().toString())));
+    }
+
+    @Test
+    public void locksPreventConcurrentWritesAndCleanup() throws Exception {
+        StagedUploadRest upload = service.create(owner, "bundle.zip", 4);
+        try (FileChannel channel = FileChannel.open(directory.resolve(upload.id().toString()).resolve("lock"),
+                 StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+             FileLock lock = channel.lock()) {
+            assertEquals(409, assertThrows(ResponseStatusException.class,
+                () -> service.put(owner, upload.id(), 0, bytes(1, 2, 3, 4))).getStatusCode().value());
+            store(Clock.offset(clock, Duration.ofHours(2))).cleanup();
+        }
+        assertEquals(0, service.get(owner, upload.id()).receivedBytes());
+    }
+
+    @Test
+    public void limitsAndFilenamesAreValidatedPerUser() throws Exception {
+        assertThrows(ResponseStatusException.class, () -> service.create(owner, "../bundle.zip", 4));
+        assertThrows(ResponseStatusException.class, () -> service.create(owner, "bundle.zip", 21));
+        assertThrows(ResponseStatusException.class, () -> service.create(owner, "bundle.zip", 0));
+        service.create(owner, "first.zip", 4);
+        service.create(owner, "second.zip", 4);
+        assertEquals(429, assertThrows(ResponseStatusException.class,
+            () -> service.create(owner, "third.zip", 4)).getStatusCode().value());
+        // the quota is per user, not global
+        service.create(UUID.randomUUID(), "other.zip", 4);
+    }
+
+    private ByteArrayInputStream bytes(int... values) {
+        byte[] data = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            data[i] = (byte) values[i];
+        }
+        return new ByteArrayInputStream(data);
+    }
+}

--- a/dspace/config/modules/staged-upload.cfg
+++ b/dspace/config/modules/staged-upload.cfg
@@ -1,0 +1,20 @@
+# Staging for chunked uploads through the REST API (/api/core/uploads).
+# Use a dedicated directory, shared by all backend nodes serving this repository.
+# The filesystem must support Java file locks and atomic rename within a directory.
+staged-upload.directory = ${dspace.dir}/var/staged-uploads
+
+# The complete file is checked against the existing spring.servlet.multipart.max-file-size
+# setting BEFORE any file data is sent. No separate total-size limit is introduced.
+# Staging temporarily needs up to twice the file size while chunks are assembled,
+# plus whatever storage the consuming endpoint needs.
+
+# Size of each upload request (bytes); the last chunk may be smaller. Capped at the
+# existing spring.servlet.multipart.max-request-size setting when that limit is finite.
+staged-upload.chunk-size = 8388608
+
+# Maximum uploads one user may have in progress, including failed handoffs awaiting cleanup.
+staged-upload.max-active-per-user = 8
+
+# Abandoned uploads and handoff receipts expire after this many hours.
+# Cleanup runs hourly and skips uploads currently being written or consumed.
+staged-upload.retention-hours = 24


### PR DESCRIPTION
## References

* Fixes #13103
* First phase of #13106 (generic resumable uploads); related to #12351 (JWT expiry during long SAF uploads)
* REST Contract: DSpace/RestContract#382
* Companion UI PR: DSpace/dspace-angular#6247

## Description

Adds a generic staging resource under `/api/core/uploads` so any authenticated user can send a large file in bounded sequential requests, each authenticated with the current JWT, and adds a JSON form of `POST /api/system/scripts/{name}/processes` that attaches staged uploads as input files. The SAF batch import is the first consumer; the submission form is the next one (#13106, phase 2). No new dependencies (no TUS library or separate upload server). The multipart and URL-based import paths are unchanged.

## Instructions for Reviewers

This PR was reworked from a SAF-specific resource (`/api/system/scripts/import/uploads`) to the target-agnostic design proposed in #13106, so that the submission form can reuse it without a second protocol. Design questions for reviewers are listed in that issue (resource name and category, JSON variants on existing endpoints versus new sub-resources, quota defaults).

List of changes in this PR:

* `StagedUploadsController` (new, `/api/core/uploads`, advertised as the `uploads` link of the API root). `POST /uploads` is a metadata-only preflight that validates the complete file size against the existing `spring.servlet.multipart.max-file-size` before any file data is sent. `GET /uploads/{id}` returns committed progress and, once consumed, the link of what was created. `PUT /uploads/{id}/chunks/{offset}` stores one raw `application/octet-stream` chunk and is idempotent when a retry carries identical bytes. `DELETE /uploads/{id}` cancels staging. Uploads are bound to their creator; anyone else, including administrators, gets `404`.
* `StagedUploadService` (new). Disk-backed staging under `staged-upload.directory` with one file lock per upload (safe for several backend nodes sharing the directory), exact chunk-length checks, a per-user quota, hourly cleanup of expired uploads, and `consume(...)`: a target consumes one or more complete uploads once, records the link of what it created as soon as it exists, and a repeated request returns that link instead of consuming again.
* `ScriptProcessesController`: `POST /api/system/scripts/{name}/processes` with `application/json` `{ "properties": [...], "uploads": ["<uuid>"] }` starts the script with the staged files as input; the script's own authorization is checked before the uploads are touched, so a refused request leaves them resumable. Repeating the request after a lost response returns the same process. The multipart handler is untouched; the invalid-content-type handler is now the fallback mapping without a `consumes` condition, which keeps its `400` behaviour.
* `ScriptRestRepository`: `startProcess` overload with explicit properties and a process-ID recorder (the multipart overload delegates to it and behaves as before); `toCommandLineParameters` exposed for the authorization pre-check; input streams closed after attachment.
* `StagedUploadRest`, `StagedScriptInvocationRest` (new) and `dspace/config/modules/staged-upload.cfg` (new).
* Tests: `StagedUploadServiceTest` (12 unit tests: limits and filenames, per-user quota, retries after restart, partial and oversized bodies, changed retries and out-of-order chunks, ownership, incomplete upload, several uploads consumed together and only once, known and uncertain handoff failures, cleanup, locking) and `StagedUploadsControllerIT` (7 integration tests: discovery from the API root and preflight, authentication, ownership, malformed chunks, a non-administrator refused by the script with the upload left resumable, a full upload of `saf-bitstreams.zip` in 1 KiB chunks with every PUT sent twice ending in one COMPLETED process whose input bitstream matches the file, and a JSON invocation without uploads).

Configuration, all optional, in `dspace/config/modules/staged-upload.cfg`:

| Property | Default | Meaning |
| --- | --- | --- |
| `staged-upload.directory` | `${dspace.dir}/var/staged-uploads` | Staging directory. Must be shared by all backend nodes serving the repository, support file locks and atomic rename, and not be exposed by a web server. |
| `staged-upload.chunk-size` | `8388608` | Bytes per chunk request, capped by a finite `spring.servlet.multipart.max-request-size`. |
| `staged-upload.max-active-per-user` | `8` | Uploads one user may have in progress, including failed handoffs awaiting cleanup. |
| `staged-upload.retention-hours` | `24` | Abandoned uploads and receipts expire after this many hours. |

Staging temporarily needs up to twice the file size while chunks are assembled, plus the normal process input-file storage.

Behaviour worth reviewing:

* The whole-file limit is the existing multipart limit; chunking does not bypass it. Chunk requests are not multipart requests, so the staging service enforces the limits itself.
* Every request is authenticated on its own, so a JWT renewed between chunks is used by the next chunk. A chunk can still fail on expiry; the client then retries only that chunk or reads the committed offset.
* There is a narrow crash window between database process creation and writing the receipt. Such an upload is deliberately not retried automatically: consuming it again returns `409` and an administrator should inspect existing processes before starting over. This is not an exactly-once guarantee across arbitrary storage failure.

How to test:

1. Build and deploy this PR together with DSpace/dspace-angular#6247. Log in as an administrator, open Import Batch, select a collection and a SAF ZIP, and click Proceed. The page shows upload progress and speed, then navigates to the process page where the import runs as usual.
2. To see the preflight, choose a ZIP larger than `spring.servlet.multipart.max-file-size` (lower the limit in `local.cfg` for convenience). The error appears immediately and the browser's network tab shows only the metadata `POST`.
3. To see token renewal across chunks, set `jwt.login.token.expiration` in `modules/authentication.cfg` to less than the upload takes and use a large ZIP with a small `staged-upload.chunk-size`. Later chunk requests carry the renewed token.
4. Without the UI, the request sequence is documented in the REST Contract PR and can be driven with curl.

Local validation: Checkstyle clean; `StagedUploadServiceTest` green; the integration test classes `StagedUploadsControllerIT`, `ScriptRestRepositoryIT`, `ItemImportIT`, `ItemExportIT`, `BulkImportIT`, `MetadataImportIT`, `CsvImportIT`, `CsvExportIT`, `CsvSearchExportIT`, `CurationScriptIT` and `DSpaceObjectDeletionProcessIT` green.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (No new dependencies.)
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself.
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

https://claude.ai/code/session_01HtPYmqfFzg7fmZgovGWP5A
