### PR TITLE
Expose and enforce the submission upload size limit

### DIFF
--- a/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
+++ b/dspace-api/src/main/java/org/dspace/submit/model/UploadConfiguration.java
@@ -69,12 +69,13 @@ public class UploadConfiguration {
     }
 
     /**
-     * Limit on the maximum size of an uploaded Bitstream.
-     * @return maximum upload size in bytes.
+     * Limit on the maximum size of an uploaded Bitstream: the configured {@code maxSize} of this
+     * configuration, or otherwise the current value of {@code upload.max}.
+     * @return maximum upload size in bytes; zero or negative when no limit is configured.
      */
     public Long getMaxSize() {
         if (maxSize == null) {
-            maxSize = configurationService.getLongProperty("upload.max");
+            return configurationService.getLongProperty("upload.max");
         }
         return maxSize;
     }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionUploadRestRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/repository/SubmissionUploadRestRepository.java
@@ -26,10 +26,12 @@ import org.dspace.submit.model.UploadConfigurationService;
 import org.dspace.util.DateMathParser;
 import org.dspace.util.TimeHelpers;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
 
 /**
  * This is the repository responsible to manage Configuration Upload section
@@ -48,6 +50,9 @@ public class SubmissionUploadRestRepository extends DSpaceRestRepository<Submiss
 
     @Autowired
     private UploadConfigurationService uploadConfigurationService;
+
+    @Autowired
+    private MultipartProperties multipartProperties;
 
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
     @Override
@@ -116,9 +121,26 @@ public class SubmissionUploadRestRepository extends DSpaceRestRepository<Submiss
             result.getAccessConditionOptions().add(optionRest);
         }
         result.setMetadata(submissionFormRestRepository.findOne(context, config.getMetadata()));
-        result.setMaxSize(config.getMaxSize());
+        result.setMaxSize(effectiveMaxSize(config));
         result.setRequired(config.isRequired());
         result.setName(config.getName());
         return result;
+    }
+
+    /**
+     * The largest file the upload step accepts: the configured limit, capped by the servlet container's
+     * multipart file-size limit when that limit is finite. Clients can check a file against it before
+     * sending any data.
+     * @param config the upload configuration
+     * @return the effective limit in bytes, or null when neither limit applies
+     */
+    private Long effectiveMaxSize(UploadConfiguration config) {
+        Long configured = config.getMaxSize();
+        boolean limited = configured != null && configured > 0;
+        DataSize multipart = multipartProperties.getMaxFileSize();
+        if (multipart == null || multipart.toBytes() < 0) {
+            return limited ? configured : null;
+        }
+        return limited ? Math.min(configured, multipart.toBytes()) : multipart.toBytes();
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/submit/step/UploadStep.java
@@ -38,6 +38,9 @@ import org.dspace.content.InProgressSubmission;
 import org.dspace.content.Item;
 import org.dspace.core.Constants;
 import org.dspace.core.Context;
+import org.dspace.services.factory.DSpaceServicesFactory;
+import org.dspace.submit.model.UploadConfiguration;
+import org.dspace.submit.model.UploadConfigurationService;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
@@ -123,6 +126,14 @@ public class UploadStep extends AbstractProcessingStep
         Bitstream source = null;
         BitstreamFormat bf = null;
 
+        Long maxSize = maxSize(stepConfig);
+        if (maxSize != null && maxSize > 0 && file.getSize() > maxSize) {
+            ErrorRest result = new ErrorRest();
+            result.setMessage("error.validation.filesize");
+            result.getPaths().add("/" + WorkspaceItemRestRepository.OPERATION_PATH_SECTIONS + "/" + stepConfig.getId());
+            return Pair.of(null, result);
+        }
+
         Item item = wsi.getItem();
         List<Bundle> bundles = null;
         try {
@@ -164,5 +175,18 @@ public class UploadStep extends AbstractProcessingStep
             return Pair.of(source, result);
         }
         return Pair.of(source, null);
+    }
+
+    /**
+     * The size limit of the upload configuration that shares this step's id, if any.
+     * @param stepConfig the upload step
+     * @return the limit in bytes, or null when the step has no upload configuration
+     */
+    private Long maxSize(SubmissionStepConfig stepConfig) {
+        UploadConfigurationService uploadConfigurations = DSpaceServicesFactory.getInstance().getServiceManager()
+            .getServiceByName("uploadConfigurationService", UploadConfigurationService.class);
+        UploadConfiguration configuration = uploadConfigurations == null || uploadConfigurations.getMap() == null
+            ? null : uploadConfigurations.getMap().get(stepConfig.getId());
+        return configuration == null ? null : configuration.getMaxSize();
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionUploadsControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/SubmissionUploadsControllerIT.java
@@ -16,14 +16,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.dspace.app.rest.test.AbstractControllerIntegrationTest;
+import org.dspace.services.ConfigurationService;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.servlet.MultipartProperties;
 
 /**
  * Integration test to test the /api/config/submissionforms endpoint
  * (Class has to start or end with IT to be picked up by the failsafe plugin)
  */
 public class SubmissionUploadsControllerIT extends AbstractControllerIntegrationTest {
+
+    @Autowired
+    private ConfigurationService configurationService;
+
+    @Autowired
+    private MultipartProperties multipartProperties;
 
     @Test
     public void findAll() throws Exception {
@@ -68,5 +77,32 @@ public class SubmissionUploadsControllerIT extends AbstractControllerIntegration
                    .andExpect(jsonPath("$._links.self.href",
                                        Matchers.startsWith(REST_SERVER_URL + "config/submissionuploads")))
                    .andExpect(jsonPath("$._embedded.submissionuploads", hasSize(greaterThanOrEqualTo(1))));
+    }
+
+    @Test
+    public void maxSizeIsTheConfiguredLimitCappedByTheMultipartLimit() throws Exception {
+        String token = getAuthToken(eperson.getEmail(), password);
+        int multipartLimit = (int) multipartProperties.getMaxFileSize().toBytes();
+        try {
+            // Without upload.max the servlet container's multipart limit is the effective limit
+            configurationService.setProperty("upload.max", null);
+            getClient(token).perform(get("/api/config/submissionuploads/upload"))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.maxSize", is(multipartLimit)));
+
+            // A smaller upload.max applies as is
+            configurationService.setProperty("upload.max", 1024);
+            getClient(token).perform(get("/api/config/submissionuploads/upload"))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.maxSize", is(1024)));
+
+            // A larger upload.max can never exceed what the container accepts
+            configurationService.setProperty("upload.max", 2L * multipartLimit);
+            getClient(token).perform(get("/api/config/submissionuploads/upload"))
+                            .andExpect(status().isOk())
+                            .andExpect(jsonPath("$.maxSize", is(multipartLimit)));
+        } finally {
+            configurationService.setProperty("upload.max", null);
+        }
     }
 }

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/WorkspaceItemRestRepositoryIT.java
@@ -4322,6 +4322,46 @@ public class WorkspaceItemRestRepositoryIT extends AbstractControllerIntegration
     }
 
     @Test
+    public void uploadFileLargerThanTheConfiguredLimitTest() throws Exception {
+        context.turnOffAuthorisationSystem();
+        parentCommunity = CommunityBuilder.createCommunity(context)
+                                          .withName("Parent Community")
+                                          .build();
+        Collection col1 = CollectionBuilder.createCollection(context, parentCommunity).withName("Collection 1")
+                                           .build();
+        WorkspaceItem witem = WorkspaceItemBuilder.createWorkspaceItem(context, col1)
+                .withTitle("Test WorkspaceItem")
+                .withIssueDate("2017-10-17")
+                .build();
+        context.restoreAuthSystemState();
+        String authToken = getAuthToken(eperson.getEmail(), password);
+
+        InputStream pdf = getClass().getResourceAsStream("simple-article.pdf");
+        final MockMultipartFile pdfFile = new MockMultipartFile("file", "/local/path/simple-article.pdf",
+                "application/pdf", pdf);
+        try {
+            // The upload configuration falls back to upload.max, which is now smaller than the file
+            configurationService.setProperty("upload.max", 1024);
+
+            getClient(authToken).perform(multipart("/api/submission/workspaceitems/" + witem.getID())
+                    .file(pdfFile))
+                    .andExpect(status().isCreated())
+                    // the mandatory-upload validation error is reported too, so match by message
+                    .andExpect(jsonPath("$.errors[*].message", hasItem("error.validation.filesize")))
+                    .andExpect(jsonPath("$.errors[?(@.message=='error.validation.filesize')].paths[0]",
+                            contains("/sections/upload")))
+                    .andExpect(jsonPath("$.sections.upload.files[0]").doesNotExist());
+
+            // nothing was stored
+            getClient(authToken).perform(get("/api/submission/workspaceitems/" + witem.getID()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sections.upload.files[0]").doesNotExist());
+        } finally {
+            configurationService.setProperty("upload.max", null);
+        }
+    }
+
+    @Test
     public void uploadUnAuthenticatedTest() throws Exception {
         context.turnOffAuthorisationSystem();
 


### PR DESCRIPTION
## References

* Related to DSpace/dspace-angular#2848 (`upload.max` not applied in the submission form) and #13106 (phase 0 of the generic upload proposal)
* Companion UI PR: DSpace/dspace-angular#6248
* REST Contract: DSpace/RestContract#383

## Description

The submission upload size limit (`maxSize` of an upload configuration, or `upload.max`) was exposed to clients but never enforced, and the limit that did apply, `spring.servlet.multipart.max-file-size`, was invisible to clients and only enforced after up to that many bytes had been received. This PR reports the effective limit and enforces the configured one.

## Instructions for Reviewers

List of changes in this PR:

* `SubmissionUploadRestRepository`: `maxSize` is now the configured limit capped by the container's multipart limit, and absent when neither applies. Previously it was `0` when `upload.max` was unset, which no client could use.
* `UploadStep.upload`: a file larger than the step's configured limit is refused before anything is stored, with the section error `error.validation.filesize` on `/sections/<step id>`. The multipart limit itself is still enforced by the container while the request is parsed, as before.
* `UploadConfiguration.getMaxSize()`: no longer caches `upload.max` permanently, so a changed value applies without a restart.
* Tests: `SubmissionUploadsControllerIT.maxSizeIsTheConfiguredLimitCappedByTheMultipartLimit` and `WorkspaceItemRestRepositoryIT.uploadFileLargerThanTheConfiguredLimitTest`.

How to test:

1. `GET /api/config/submissionuploads/upload` as any user: `maxSize` equals `spring.servlet.multipart.max-file-size` in bytes (512 MB by default). Set `upload.max = 1048576` in `local.cfg` and restart: `maxSize` is `1048576`.
2. With that limit, upload a 2 MB file to a workspace item: the response carries `errors[].message = "error.validation.filesize"` and no bitstream is created. With DSpace/dspace-angular#6248 the UI refuses the file before uploading it.

Note: this makes the whole-file transfer visible earlier only in the UI. Rejecting before the bytes arrive at the server is what the staged uploads in #13106 are for.

## Checklist

- [x] My PR is **created against the `main` branch** of code (unless it is a backport or is fixing an issue specific to an older branch).
- [x] My PR is **small in size** (e.g. less than 1,000 lines of code, not including comments & integration tests). Exceptions may be made if previously agreed upon.
- [x] My PR **follows all coding best practices** based on the [Code Conventions Guide](../CODE_CONVENTIONS.md).
- [x] My PR **passes Checkstyle** validation based on the [Code Style Guide](../CODE_STYLE.md).
- [x] My PR **includes Javadoc** for _all new (or modified) public methods and classes_. It also includes Javadoc for large or complex private methods.
- [x] My PR **passes all tests and includes new/updated Unit or Integration Tests** based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [x] My PR **includes details on how to test it**. I've provided clear instructions to reviewers on how to successfully test this fix or feature.
- [x] If my PR includes new libraries/dependencies (in any `pom.xml`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation. (No new dependencies.)
- [x] If my PR modifies REST API endpoints, I've opened a separate [REST Contract](https://github.com/DSpace/RestContract/blob/main/README.md) PR related to this change.
- [x] If my PR includes new configurations, I've provided basic technical documentation in the PR itself. (No new configuration.)
- [x] If my PR fixes an issue ticket, I've [linked them together](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

https://claude.ai/code/session_01HtPYmqfFzg7fmZgovGWP5A
